### PR TITLE
Add MicroFPGA

### DIFF
--- a/DeviceAdapters/MicroFPGA/Makefile.am
+++ b/DeviceAdapters/MicroFPGA/Makefile.am
@@ -1,0 +1,6 @@
+AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS)
+deviceadapter_LTLIBRARIES = libmmgr_dal_MicroFPGA.la
+libmmgr_dal_MicroFPGA_la_SOURCES = MicroFPGA.cpp MicroFPGA.h \
+   ../../MMDevice/MMDevice.h ../../MMDevice/DeviceBase.h
+libmmgr_dal_MicroFPGA_la_LIBADD = $(MMDEVAPI_LIBADD)
+libmmgr_dal_MicroFPGA_la_LDFLAGS = $(MMDEVAPI_LDFLAGS)

--- a/DeviceAdapters/MicroFPGA/MicroFPGA.cpp
+++ b/DeviceAdapters/MicroFPGA/MicroFPGA.cpp
@@ -15,7 +15,7 @@
 
 
 #include "MicroFPGA.h"
-#include "../../MMDevice/ModuleInterface.h"
+#include "ModuleInterface.h"
 
 #ifdef WIN32
 #include <windows.h>

--- a/DeviceAdapters/MicroFPGA/MicroFPGA.cpp
+++ b/DeviceAdapters/MicroFPGA/MicroFPGA.cpp
@@ -1,0 +1,1315 @@
+//////////////////////////////////////////////////////////////////////////////
+// FILE:          MicroFPGA.cpp
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     DeviceAdapters
+//-----------------------------------------------------------------------------
+// DESCRIPTION:   Adapter for MicroFPGA, a FPGA platform using FPGA boards from
+//                Alchitry. The adapter must be used with a special firmware, see:
+//                https://github.com/jdeschamps/MicroFPGA
+// COPYRIGHT:     EMBL
+// LICENSE:       LGPL
+//
+// AUTHOR:        Joran Deschamps, EMBL, 2020
+//				  
+//
+
+
+#include "MicroFPGA.h"
+#include "../../MMDevice/ModuleInterface.h"
+
+#ifdef WIN32
+#include <windows.h>
+#define snprintf _snprintf 
+#endif
+
+const char* g_DeviceNameMicroFPGAHub = "MicroFPGA-Hub";
+const char* g_DeviceNameLaserTrig = "LaserTrig";
+const char* g_DeviceNameAnalogInput = "AnalogInput";
+const char* g_DeviceNamePWM = "PWM";
+const char* g_DeviceNameTTL = "TTL";
+const char* g_DeviceNameServos = "Servos";
+
+//////////////////////////////////////////////////////////////////////////////
+/// Constants that should match the ones in the firmware
+const int g_version = 2;
+const int g_id_au = 79;
+const int g_id_cu = 29;
+
+const int g_maxlasers = 8;
+const int g_maxanaloginput = 8;
+const int g_maxttl = 5;
+const int g_maxpwm = 5;
+const int g_maxservos = 7;
+
+const int g_offsetaddressLaserMode = 0;
+const int g_offsetaddressLaserDuration = g_offsetaddressLaserMode+g_maxlasers;
+const int g_offsetaddressLaserSequence = g_offsetaddressLaserDuration+g_maxlasers;
+const int g_offsetaddressTTL = g_offsetaddressLaserSequence+g_maxlasers;
+const int g_offsetaddressServo = g_offsetaddressTTL+g_maxttl;
+const int g_offsetaddressPWM = g_offsetaddressServo+g_maxservos;
+const int g_offsetaddressAnalogInput = g_offsetaddressPWM+g_maxpwm;
+
+const int g_address_version = 100;
+const int g_address_id = 101;
+
+// static lock
+MMThreadLock MicroFPGAHub::lock_;
+
+///////////////////////////////////////////////////////////////////////////////
+// Exported MMDevice API
+///////////////////////////////////////////////////////////////////////////////
+MODULE_API void InitializeModuleData()
+{
+	RegisterDevice(g_DeviceNameMicroFPGAHub, MM::HubDevice, "Hub (required)");
+	RegisterDevice(g_DeviceNameLaserTrig, MM::GenericDevice, "Laser Trigger");
+	RegisterDevice(g_DeviceNameAnalogInput, MM::GenericDevice, "Analog Input");
+	RegisterDevice(g_DeviceNamePWM, MM::GenericDevice, "PWM Output");
+	RegisterDevice(g_DeviceNameTTL, MM::GenericDevice, "TTL Output");
+	RegisterDevice(g_DeviceNameServos, MM::GenericDevice, "Servos");
+}
+
+MODULE_API MM::Device* CreateDevice(const char* deviceName)
+{
+	if (deviceName == 0)
+		return 0;
+
+	if (strcmp(deviceName, g_DeviceNameMicroFPGAHub) == 0)
+	{
+		return new MicroFPGAHub;
+	}
+	else if (strcmp(deviceName, g_DeviceNameLaserTrig) == 0)
+	{
+		return new LaserTrig;
+	}
+	else if (strcmp(deviceName, g_DeviceNameAnalogInput) == 0)
+	{
+		return new AnalogInput;
+	}
+	else if (strcmp(deviceName, g_DeviceNamePWM) == 0)
+	{
+		return new PWM; 
+	}
+	else if (strcmp(deviceName, g_DeviceNameTTL) == 0)
+	{
+		return new TTL; 
+	}
+	else if (strcmp(deviceName, g_DeviceNameServos) == 0)
+	{
+		return new Servo;
+	}
+
+	return 0;
+}
+
+MODULE_API void DeleteDevice(MM::Device* pDevice)
+{
+	delete pDevice;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// MicroFPGA Hub implementation
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+MicroFPGAHub::MicroFPGAHub() :
+	initialized_ (false)
+{
+	portAvailable_ = false;
+
+	InitializeDefaultErrorMessages();
+	SetErrorText(ERR_PORT_OPEN_FAILED, "Failed opening MicroFPGA USB device.");
+	SetErrorText(ERR_BOARD_NOT_FOUND, "Did not find an MicroFPGA board with the correct firmware. Is the MicroFPGA board connected to this serial port?");
+	SetErrorText(ERR_NO_PORT_SET, "Hub Device not found. The MicroFPGA Hub device is needed to create this device.");
+	SetErrorText(ERR_VERSION_MISMATCH, "The firmware version on the MicroFPGA is not compatible with this adapter. Please use firmware version 2.");
+	SetErrorText(ERR_UNKNOWN_ID, "The board ID is unknwown.");
+	SetErrorText(ERR_COMMAND_UNKNOWN, "An unknown command was sent to the MicroFPGA.");
+
+	CPropertyAction* pAct = new CPropertyAction(this, &MicroFPGAHub::OnPort);
+	CreateProperty(MM::g_Keyword_Port, "Undefined", MM::String, false, pAct, true);
+}
+
+MicroFPGAHub::~MicroFPGAHub()
+{
+	Shutdown();
+}
+
+void MicroFPGAHub::GetName(char* name) const
+{
+	CDeviceUtils::CopyLimitedString(name, g_DeviceNameMicroFPGAHub);
+}
+
+bool MicroFPGAHub::Busy()
+{
+	return false;
+}
+
+MM::DeviceDetectionStatus MicroFPGAHub::DetectDevice(void)
+{
+	// Code adapted from Arduino.cpp, Micro-Manager, written by Nico Stuurman and Karl Hoover
+	if (initialized_)
+		return MM::CanCommunicate;
+
+	MM::DeviceDetectionStatus result = MM::Misconfigured;
+	char answerTO[MM::MaxStrLength];
+
+	try{
+		std::string portLowerCase = port_;
+		for( std::string::iterator its = portLowerCase.begin(); its != portLowerCase.end(); ++its)
+		{
+			*its = (char)tolower(*its);
+		}
+		if( 0< portLowerCase.length() &&  0 != portLowerCase.compare("undefined")  && 0 != portLowerCase.compare("unknown") )
+		{
+			result = MM::CanNotCommunicate;
+			// record the default answer time out
+			GetCoreCallback()->GetDeviceProperty(port_.c_str(), "AnswerTimeout", answerTO);
+
+			// device specific default communication parameters
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_Handshaking, "0");
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_BaudRate, "9600" );
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_StopBits, "1");
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), "AnswerTimeout", "500.0");
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), "DelayBetweenCharsMs", "0");
+			MM::Device* pS = GetCoreCallback()->GetDevice(this, port_.c_str());
+			pS->Initialize();
+
+			CDeviceUtils::SleepMs(100);
+			MMThreadGuard myLock(lock_);
+			PurgeComPort(port_.c_str());
+			long v = 0;
+			int ret = GetControllerVersion(v);
+
+			if( DEVICE_OK != ret ){
+				LogMessageCode(ret,true);
+			} else {
+				// to succeed must reach here....
+				result = MM::CanCommunicate;
+			}
+			pS->Shutdown();
+			// always restore the AnswerTimeout to the default
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), "AnswerTimeout", answerTO);
+
+		}
+	}
+	catch(...)
+	{
+		LogMessage("Exception in DetectDevice!",false);
+	}
+
+	return result;
+}
+
+
+int MicroFPGAHub::Initialize()
+{
+	// Name
+	int ret = CreateProperty(MM::g_Keyword_Name, g_DeviceNameMicroFPGAHub, MM::String, true);
+	if (DEVICE_OK != ret)
+		return ret;
+
+	MMThreadGuard myLock(lock_);
+
+	PurgeComPort(port_.c_str());
+
+	// Gets controller version
+	ret = GetControllerVersion(version_);
+	if( DEVICE_OK != ret)
+		return ret;
+
+	// Verifies that the version of the firmware and adapter match
+	if (g_version != version_){
+		return ERR_VERSION_MISMATCH;
+	}
+
+	//CPropertyAction* pAct = new CPropertyAction(this, &MicroFPGAHub::OnVersion);
+	std::ostringstream sversion;
+	sversion << version_;
+	CreateProperty("MicroFPGA version", sversion.str().c_str(), MM::Integer, true);
+
+	// Checks the ID
+	ret = GetID(id_);
+	if( DEVICE_OK != ret)
+		return ret;
+
+	if (g_id_au == id_){
+		CreateProperty("MicroFPGA ID", "Au", MM::String, true);
+	} else if(g_id_cu == id_){
+		CreateProperty("MicroFPGA ID", "Cu", MM::String, true);
+	}else {
+		return ERR_UNKNOWN_ID;
+	}
+
+	initialized_ = true;
+	return DEVICE_OK;
+}
+
+int MicroFPGAHub::DetectInstalledDevices()
+{
+	// Code adapted from Arduino.cpp, Micro-Manager, written by Nico Stuurman and Karl Hoover
+	if (MM::CanCommunicate == DetectDevice()) 
+	{
+		std::vector<std::string> peripherals; 
+		peripherals.clear();
+		peripherals.push_back(g_DeviceNameLaserTrig);
+		
+		// Only the Au has an ADC
+		if(id_ == g_id_au){
+			peripherals.push_back(g_DeviceNameAnalogInput);
+		}
+
+		peripherals.push_back(g_DeviceNamePWM);
+		peripherals.push_back(g_DeviceNameTTL);
+		peripherals.push_back(g_DeviceNameServos);
+		for (size_t i=0; i < peripherals.size(); i++) 
+		{
+			MM::Device* pDev = ::CreateDevice(peripherals[i].c_str());
+			if (pDev) 
+			{
+				AddInstalledDevice(pDev);
+			}
+		}
+	}
+
+	return DEVICE_OK;
+}
+
+int MicroFPGAHub::Shutdown()
+{
+	initialized_ = false;
+	return DEVICE_OK;
+}
+
+int MicroFPGAHub::GetControllerVersion(long& version)
+{
+	int ret = SendReadRequest(g_address_version);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	ret = ReadAnswer(version);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return ret;
+}
+
+int MicroFPGAHub::GetID(long& id)
+{
+	int ret = SendReadRequest(g_address_id);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	ret = ReadAnswer(id);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return ret;
+}
+
+int MicroFPGAHub::SendWriteRequest(long address, long value)
+{   
+	unsigned char command[9];
+	command[0] = (1 << 7);	// 1 = write
+	command[1] = static_cast<char>(address);	// put the least significant byte
+	command[2] = static_cast<char>((address >> 8));	// put the least but one significant byte 
+	command[3] = static_cast<char>((address >> 16));	
+	command[4] = static_cast<char>((address >> 24)); // address and value are 32 bits long
+	command[5] = static_cast<char>(value);	
+	command[6] = static_cast<char>((value >> 8));	
+	command[7] = static_cast<char>((value >> 16));	
+	command[8] = static_cast<char>((value >> 24));	
+
+	int ret = WriteToComPortH((const unsigned char*) command, 9);
+
+	return ret;
+}
+int MicroFPGAHub::SendReadRequest(long address){
+	unsigned char command[5];
+	command[0] = (0 << 7);	
+	command[1] = static_cast<char>(address);	
+	command[2] = static_cast<char>((address >> 8));	
+	command[3] = static_cast<char>((address >> 16));	
+	command[4] = static_cast<char>((address >> 24));
+
+	int ret = WriteToComPortH((const unsigned char*) command, 5);
+
+	return ret;
+}
+
+int MicroFPGAHub::ReadAnswer(long& ans){
+	unsigned char* answer = new unsigned char[4];
+	
+	// Code adapted from Arduino.cpp, Micro-Manager, written by Nico Stuurman and Karl Hoover
+	MM::MMTime startTime = GetCurrentMMTime();  
+	unsigned long bytesRead = 0;
+
+	while ((bytesRead < 4) && ( (GetCurrentMMTime() - startTime).getMsec() < 500)) {
+		unsigned long bR;
+		int ret = ReadFromComPortH(answer + bytesRead, 4 - bytesRead, bR);
+		if (ret != DEVICE_OK)
+			return ret;
+		bytesRead += bR;
+	}
+
+	// Format answer
+	int tmp = answer[3];
+	for(int i=1;i<4;i++){
+		tmp = tmp << 8;
+		tmp = tmp | answer[3-i];
+	}
+
+	ans = tmp;
+	
+	// If unknown command answer
+	if(ans == ERR_COMMAND_UNKNOWN){
+		return ERR_COMMAND_UNKNOWN;
+	}
+
+	return DEVICE_OK;
+}
+
+int MicroFPGAHub::OnPort(MM::PropertyBase* pProp, MM::ActionType pAct)
+{
+	if (pAct == MM::BeforeGet)
+	{
+		pProp->Set(port_.c_str());
+	}
+	else if (pAct == MM::AfterSet)
+	{
+		pProp->Get(port_);
+		portAvailable_ = true;
+	}
+	return DEVICE_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+LaserTrig::LaserTrig() :
+initialized_ (false),
+	busy_(false)
+{
+	InitializeDefaultErrorMessages();
+
+	// Custom error messages
+	SetErrorText(ERR_NO_PORT_SET, "Hub Device not found. The MicroFPGA Hub device is needed to create this device");
+	SetErrorText(ERR_COMMAND_UNKNOWN, "An unknown command was sent to the MicroFPGA.");
+
+	// Description
+	int ret = CreateProperty(MM::g_Keyword_Description, "MicroFPGA laser triggering system", MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Name
+	ret = CreateProperty(MM::g_Keyword_Name, g_DeviceNameLaserTrig, MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Number of lasers
+	CPropertyAction* pAct = new CPropertyAction(this, &LaserTrig::OnNumberOfLasers);
+	CreateProperty("Number of lasers", "4", MM::Integer, false, pAct, true);
+	SetPropertyLimits("Number of lasers", 1, g_maxlasers);
+}
+
+
+LaserTrig::~LaserTrig()
+{
+	Shutdown();
+}
+
+void LaserTrig::GetName(char* name) const
+{
+	CDeviceUtils::CopyLimitedString(name, g_DeviceNameLaserTrig);
+}
+
+
+int LaserTrig::Initialize()
+{
+	// Parent ID display	
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	char hubLabel[MM::MaxStrLength];
+	hub->GetLabel(hubLabel);
+	SetParentID(hubLabel);
+	CreateHubIDProperty();
+
+	// Allocate memory for lasers
+	mode_ = new long [GetNumberOfLasers()];
+	duration_ = new long [GetNumberOfLasers()];
+	sequence_ = new long [GetNumberOfLasers()];
+
+	CPropertyActionEx *pExAct;
+	int nRet;
+
+	for(unsigned int i=0;i<GetNumberOfLasers();i++){	
+		mode_[i] = 0;
+		duration_[i] = 0;
+		sequence_[i] = 0;
+
+		std::stringstream mode;
+		std::stringstream dura;
+		std::stringstream seq;
+		mode << "Mode" << i;
+		dura << "Duration" << i;
+		seq << "Sequence" << i;
+
+		pExAct = new CPropertyActionEx (this, &LaserTrig::OnDuration,i);
+		nRet = CreateProperty(dura.str().c_str(), "0", MM::Integer, false, pExAct);
+		if (nRet != DEVICE_OK)
+			return nRet;
+		SetPropertyLimits(dura.str().c_str(), 0, 65535);   
+
+		pExAct = new CPropertyActionEx (this, &LaserTrig::OnMode,i);
+		nRet = CreateProperty(mode.str().c_str(), "0", MM::Integer, false, pExAct);
+		if (nRet != DEVICE_OK)
+			return nRet;
+		SetPropertyLimits(mode.str().c_str(), 0, 4);
+
+		pExAct = new CPropertyActionEx (this, &LaserTrig::OnSequence,i);
+		nRet = CreateProperty(seq.str().c_str(), "65535", MM::Integer, false, pExAct);
+		if (nRet != DEVICE_OK)
+			return nRet;
+		SetPropertyLimits(seq.str().c_str(), 0, 65535);
+	}
+
+	nRet = UpdateStatus();
+	if (nRet != DEVICE_OK)
+		return nRet;
+
+	initialized_ = true;
+
+	return DEVICE_OK;
+}
+
+int LaserTrig::Shutdown()
+{
+	initialized_ = false;
+	return DEVICE_OK;
+}
+
+int LaserTrig::WriteToPort(long address, long value)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+
+	MMThreadGuard myLock(hub->GetLock());
+
+	hub->PurgeComPortH();
+
+	int ret = hub->SendWriteRequest(address, value);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+int LaserTrig::ReadFromPort(long& answer)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	int ret = hub->ReadAnswer(answer);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+
+///////////////////////////////////////
+/////////// Action handlers
+int LaserTrig::OnNumberOfLasers(MM::PropertyBase* pProp, MM::ActionType pAct)
+{
+	if (pAct == MM::BeforeGet){
+		pProp->Set(numlasers_);
+	} else if (pAct == MM::AfterSet){
+		pProp->Get(numlasers_);
+	}
+	return DEVICE_OK;
+}
+
+int LaserTrig::OnMode(MM::PropertyBase* pProp, MM::ActionType pAct, long laser)
+{
+	if (pAct == MM::BeforeGet)
+	{
+		MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+		if (!hub){
+			return ERR_NO_PORT_SET;
+		}
+
+		MMThreadGuard myLock(hub->GetLock());
+
+		int ret = hub->SendReadRequest(g_offsetaddressLaserMode+laser);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		long answer;
+		ret = ReadFromPort(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		pProp->Set(answer);
+		mode_[laser]=answer;
+	}
+	else if (pAct == MM::AfterSet)
+	{
+		long mode;
+		pProp->Get(mode);
+
+		int ret = WriteToPort(g_offsetaddressLaserMode+laser,mode);  
+		if (ret != DEVICE_OK)
+			return ret;
+
+		mode_[laser] = mode;
+	}
+
+	return DEVICE_OK;
+}
+
+int LaserTrig::OnDuration(MM::PropertyBase* pProp, MM::ActionType pAct, long laser)
+{
+	if (pAct == MM::BeforeGet)
+	{
+		MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+		if (!hub){
+			return ERR_NO_PORT_SET;
+		}
+
+		MMThreadGuard myLock(hub->GetLock());
+
+		int ret = hub->SendReadRequest(g_offsetaddressLaserDuration+laser);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		long answer;
+		ret = ReadFromPort(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		pProp->Set(answer);
+		duration_[laser]=answer;
+	}
+	else if (pAct == MM::AfterSet)
+	{
+		long pos;
+		pProp->Get(pos);
+
+		int ret = WriteToPort(g_offsetaddressLaserDuration+laser,pos); 
+		if (ret != DEVICE_OK)
+			return ret;
+
+		duration_[laser] = pos;
+	}
+
+	return DEVICE_OK;
+}
+
+int LaserTrig::OnSequence(MM::PropertyBase* pProp, MM::ActionType pAct, long laser)
+{
+	if (pAct == MM::BeforeGet)
+	{
+		MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+		if (!hub){
+			return ERR_NO_PORT_SET;
+		}
+
+		MMThreadGuard myLock(hub->GetLock());
+
+		int ret = hub->SendReadRequest(g_offsetaddressLaserSequence+laser);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		long answer;
+		ret = ReadFromPort(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		pProp->Set(answer);
+		sequence_[laser]=answer;
+	}
+	else if (pAct == MM::AfterSet)
+	{
+		long pos;
+		pProp->Get(pos);
+
+		int ret = WriteToPort(g_offsetaddressLaserSequence+laser,pos);
+		if (ret != DEVICE_OK)
+			return ret; 
+
+		sequence_[laser] = pos;
+	}
+
+	return DEVICE_OK;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+TTL::TTL() :
+initialized_ (false),
+	busy_(false)
+{
+	InitializeDefaultErrorMessages();
+
+	// Custom error messages
+	SetErrorText(ERR_NO_PORT_SET, "Hub Device not found. The MicroFPGA Hub device is needed to create this device");
+	SetErrorText(ERR_COMMAND_UNKNOWN, "An unknown command was sent to the MicroFPGA.");
+
+	// Description
+	int ret = CreateProperty(MM::g_Keyword_Description, "MicroFPGA TTL", MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Name
+	ret = CreateProperty(MM::g_Keyword_Name, g_DeviceNameTTL, MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Number of TTL channels
+	CPropertyAction* pAct = new CPropertyAction(this, &TTL::OnNumberOfChannels);
+	CreateProperty("Number of channels", "4", MM::Integer, false, pAct, true);
+	SetPropertyLimits("Number of channels", 1, g_maxttl);
+}
+
+TTL::~TTL()
+{
+	Shutdown();
+}
+
+void TTL::GetName(char* name) const
+{
+	CDeviceUtils::CopyLimitedString(name, g_DeviceNameTTL);
+}
+
+
+int TTL::Initialize()
+{
+	// Parent ID display	
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	char hubLabel[MM::MaxStrLength];
+	hub->GetLabel(hubLabel);
+	SetParentID(hubLabel);
+	CreateHubIDProperty();
+
+	// State
+	// -----
+
+	// Allocate memory for TTLs
+	state_ = new long [GetNumberOfChannels()];
+
+	CPropertyActionEx *pExAct;
+	int nRet;
+
+	for(unsigned int i=0;i<GetNumberOfChannels();i++){
+		state_[i]  = 0;
+
+		std::stringstream sstm;
+		sstm << "State" << i;
+
+		pExAct = new CPropertyActionEx (this, &TTL::OnState,i);
+		nRet = CreateProperty(sstm.str().c_str(), "0", MM::Integer, false, pExAct);
+		if (nRet != DEVICE_OK)
+			return nRet;
+		AddAllowedValue(sstm.str().c_str(), "0");
+		AddAllowedValue(sstm.str().c_str(), "1");
+	}
+
+	nRet = UpdateStatus();
+	if (nRet != DEVICE_OK)
+		return nRet;
+
+	initialized_ = true;
+
+	return DEVICE_OK;
+}
+
+int TTL::Shutdown()
+{
+	initialized_ = false;
+	return DEVICE_OK;
+}
+
+int TTL::WriteToPort(long address, long state)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+
+	MMThreadGuard myLock(hub->GetLock());
+
+	hub->PurgeComPortH();
+
+	int val = 0;
+	if(state == 1){
+		val = 1;
+	} 
+	int ret = hub->SendWriteRequest(address, val);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+int TTL::ReadFromPort(long& answer)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	int ret = hub->ReadAnswer(answer);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+///////////////////////////////////////
+/////////// Action handlers
+int TTL::OnNumberOfChannels(MM::PropertyBase* pProp, MM::ActionType pAct)
+{
+	if (pAct == MM::BeforeGet){
+		pProp->Set(numChannels_);
+	} else if (pAct == MM::AfterSet){
+		pProp->Get(numChannels_);
+	}
+	return DEVICE_OK;
+}
+
+int TTL::OnState(MM::PropertyBase* pProp, MM::ActionType pAct, long channel)
+{
+	if (pAct == MM::BeforeGet)
+	{
+		MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+		if (!hub){
+			return ERR_NO_PORT_SET;
+		}
+
+		MMThreadGuard myLock(hub->GetLock());
+
+		int ret = hub->SendReadRequest(g_offsetaddressTTL+channel);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		long answer;
+		ret = ReadFromPort(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		pProp->Set(answer);
+		state_[channel]=answer;
+	}
+	else if (pAct == MM::AfterSet)
+	{
+		long pos;
+		pProp->Get(pos);
+
+		int ret = WriteToPort(g_offsetaddressTTL+channel, pos); 
+		if (ret != DEVICE_OK)
+			return ret;
+
+		state_[channel] = pos;
+	}
+
+	return DEVICE_OK;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+Servo::Servo() :
+initialized_ (false),
+	busy_(false)
+{
+	InitializeDefaultErrorMessages();
+
+	// Custom error messages
+	SetErrorText(ERR_NO_PORT_SET, "Hub Device not found. The MicroFPGA Hub device is needed to create this device");
+	SetErrorText(ERR_COMMAND_UNKNOWN, "An unknown command was sent to the MicroFPGA.");
+
+	// Description
+	int ret = CreateProperty(MM::g_Keyword_Description, "MicroFPGA Servo controller", MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Name
+	ret = CreateProperty(MM::g_Keyword_Name, g_DeviceNameServos, MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Number of servos
+	CPropertyAction* pAct = new CPropertyAction(this, &Servo::OnNumberOfServos);
+	CreateProperty("Number of Servos", "4", MM::Integer, false, pAct, true);
+	SetPropertyLimits("Number of Servos", 1, g_maxservos);
+}
+
+Servo::~Servo()
+{
+	Shutdown();
+}
+
+void Servo::GetName(char* name) const
+{
+	CDeviceUtils::CopyLimitedString(name, g_DeviceNameServos);
+}
+
+
+int Servo::Initialize()
+{
+	// Parent ID display	
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	char hubLabel[MM::MaxStrLength];
+	hub->GetLabel(hubLabel);
+	SetParentID(hubLabel);
+	CreateHubIDProperty();
+
+	// State
+	// -----
+
+	// Allocate memory for servos
+	position_ = new long [GetNumberOfServos()];
+
+	CPropertyActionEx *pExAct;
+	int nRet;
+
+	for(unsigned int i=0;i<GetNumberOfServos();i++){	
+		position_[i] = 0;
+
+		std::stringstream sstm;
+		sstm << "Position" << i;
+
+		pExAct = new CPropertyActionEx (this, &Servo::OnPosition,i);
+		nRet = CreateProperty(sstm.str().c_str(), "0", MM::Integer, false, pExAct);
+		if (nRet != DEVICE_OK)
+			return nRet;
+		SetPropertyLimits(sstm.str().c_str(), 0, 65535);
+	}
+
+	nRet = UpdateStatus();
+	if (nRet != DEVICE_OK)
+		return nRet;
+
+	initialized_ = true;
+
+	return DEVICE_OK;
+}
+
+int Servo::Shutdown()
+{
+	initialized_ = false;
+	return DEVICE_OK;
+}
+
+int Servo::WriteToPort(long address, long value)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+
+	MMThreadGuard myLock(hub->GetLock());
+
+	hub->PurgeComPortH();
+
+
+	int ret = hub->SendWriteRequest(address, value);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+int Servo::ReadFromPort(long& answer)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	int ret = hub->ReadAnswer(answer);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+
+///////////////////////////////////////
+/////////// Action handlers
+int Servo::OnNumberOfServos(MM::PropertyBase* pProp, MM::ActionType pAct)
+{
+	if (pAct == MM::BeforeGet){
+		pProp->Set(numServos_);
+	} else if (pAct == MM::AfterSet){
+		pProp->Get(numServos_);
+	}
+	return DEVICE_OK;
+}
+
+int Servo::OnPosition(MM::PropertyBase* pProp, MM::ActionType pAct, long servo)
+{
+	if (pAct == MM::BeforeGet)
+	{
+		MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+		if (!hub){
+			return ERR_NO_PORT_SET;
+		}
+
+		MMThreadGuard myLock(hub->GetLock());
+
+		int ret = hub->SendReadRequest(g_offsetaddressServo+servo);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		long answer;
+		ret = ReadFromPort(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+
+
+		pProp->Set(answer);
+		position_[servo]=answer;
+	}
+	else if (pAct == MM::AfterSet)
+	{
+		long pos;
+		pProp->Get(pos);
+
+		int ret = WriteToPort(g_offsetaddressServo+servo,pos); 
+		if (ret != DEVICE_OK)
+			return ret;
+
+		position_[servo] = pos;
+	}
+
+	return DEVICE_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+PWM::PWM() :
+initialized_ (false),
+	busy_(false)
+{
+	InitializeDefaultErrorMessages();
+
+	// Custom error messages
+	SetErrorText(ERR_NO_PORT_SET, "Hub Device not found. The MicroFPGA Hub device is needed to create this device");
+	SetErrorText(ERR_COMMAND_UNKNOWN, "An unknown command was sent to the MicroFPGA.");
+
+	// Description
+	int ret = CreateProperty(MM::g_Keyword_Description, "MicroFPGA PWM controller", MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Name
+	ret = CreateProperty(MM::g_Keyword_Name, g_DeviceNamePWM, MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Number of PWM channels
+	CPropertyAction* pAct = new CPropertyAction(this, &PWM::OnNumberOfChannels);
+	CreateProperty("Number of PWM", "1", MM::Integer, false, pAct, true);
+	SetPropertyLimits("Number of PWM", 1, g_maxpwm);
+}
+
+PWM::~PWM()
+{
+	Shutdown();
+}
+
+void PWM::GetName(char* name) const
+{
+	CDeviceUtils::CopyLimitedString(name, g_DeviceNamePWM);
+}
+
+
+int PWM::Initialize()
+{
+	// Parent ID display	
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	char hubLabel[MM::MaxStrLength];
+	hub->GetLabel(hubLabel);
+	SetParentID(hubLabel);
+	CreateHubIDProperty();
+
+	// State
+	// -----
+
+	// Allocate memory for channels
+	state_ = new long [GetNumberOfChannels()];
+
+	CPropertyActionEx *pExAct;
+	int nRet;
+
+	for(unsigned int i=0;i<GetNumberOfChannels();i++){
+		state_[i] = 0;
+
+		std::stringstream sstm;
+		sstm << "Position" << i;
+
+		pExAct = new CPropertyActionEx (this, &PWM::OnState,i);
+		nRet = CreateProperty(sstm.str().c_str(), "0", MM::Integer, false, pExAct);
+		if (nRet != DEVICE_OK)
+			return nRet;
+		SetPropertyLimits(sstm.str().c_str(), 0, 255);
+	}
+
+	nRet = UpdateStatus();
+	if (nRet != DEVICE_OK)
+		return nRet;
+
+	initialized_ = true;
+
+	return DEVICE_OK;
+}
+
+int PWM::Shutdown()
+{
+	initialized_ = false;
+	return DEVICE_OK;
+}
+
+int PWM::WriteToPort(long address, long position)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+
+	MMThreadGuard myLock(hub->GetLock());
+
+	hub->PurgeComPortH();
+
+	int ret = hub->SendWriteRequest(address, position);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+int PWM::ReadFromPort(long& answer)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	int ret = hub->ReadAnswer(answer);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+///////////////////////////////////////
+/////////// Action handlers
+int PWM::OnNumberOfChannels(MM::PropertyBase* pProp, MM::ActionType pAct)
+{
+	if (pAct == MM::BeforeGet){
+		pProp->Set(numChannels_);
+	} else if (pAct == MM::AfterSet){
+		pProp->Get(numChannels_);
+	}
+	return DEVICE_OK;
+}
+
+int PWM::OnState(MM::PropertyBase* pProp, MM::ActionType pAct, long channel)
+{
+	if (pAct == MM::BeforeGet)
+	{
+		MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+		if (!hub){
+			return ERR_NO_PORT_SET;
+		}
+
+		MMThreadGuard myLock(hub->GetLock());
+
+		int ret = hub->SendReadRequest(g_offsetaddressPWM+channel);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		long answer;
+		ret = ReadFromPort(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		pProp->Set(answer);
+		state_[channel]=answer;
+	}
+	else if (pAct == MM::AfterSet)
+	{
+		long pos;
+		pProp->Get(pos);
+
+		if(pos<0 || pos>255){
+			pos = 0;
+		}
+
+		int ret = WriteToPort(g_offsetaddressPWM+channel,pos); 
+		if (ret != DEVICE_OK)
+			return ret;
+
+		state_[channel] = pos;
+	}
+
+	return DEVICE_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+AnalogInput::AnalogInput() :
+initialized_ (false)
+{
+	InitializeDefaultErrorMessages();
+
+	// Custom error messages
+	SetErrorText(ERR_NO_PORT_SET, "Hub Device not found. The MicroFPGA Hub device is needed to create this device");
+	SetErrorText(ERR_COMMAND_UNKNOWN, "An unknown command was sent to the MicroFPGA.");
+
+	// Description
+	int ret = CreateProperty(MM::g_Keyword_Description, "MicroFPGA AnalogInput", MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Name
+	ret = CreateProperty(MM::g_Keyword_Name, g_DeviceNameAnalogInput, MM::String, true);
+	assert(DEVICE_OK == ret);
+
+	// Number of Analog input channels
+	CPropertyAction* pAct = new CPropertyAction(this, &AnalogInput::OnNumberOfChannels);
+	CreateProperty("Number of channels", "3", MM::Integer, false, pAct, true);
+	SetPropertyLimits("Number of channels", 1, g_maxanaloginput);
+}
+
+AnalogInput::~AnalogInput()
+{
+	Shutdown();
+}
+
+void AnalogInput::GetName(char* name) const
+{
+	CDeviceUtils::CopyLimitedString(name, g_DeviceNameAnalogInput);
+}
+
+bool AnalogInput::Busy()
+{
+	return false;
+}
+
+int AnalogInput::Initialize()
+{
+	// Parent ID display	
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	char hubLabel[MM::MaxStrLength];
+	hub->GetLabel(hubLabel);
+	SetParentID(hubLabel);
+	CreateHubIDProperty();
+
+	// State
+	// -----
+
+	// Allocate memory for inputs
+	state_ = new long [GetNumberOfChannels()];
+
+	CPropertyActionEx *pExAct;
+	int nRet;
+
+	for(unsigned int i=0;i<GetNumberOfChannels();i++){
+		state_[i] = 0;
+
+		std::stringstream sstm;
+		sstm << "AnalogInput" << i;
+
+		pExAct = new CPropertyActionEx (this, &AnalogInput::OnAnalogInput,i);
+		nRet = CreateProperty(sstm.str().c_str(), "0", MM::Integer, true, pExAct);
+		if (nRet != DEVICE_OK)
+			return nRet;
+	}
+
+	nRet = UpdateStatus();
+	if (nRet != DEVICE_OK)
+		return nRet;
+
+	initialized_ = true;
+
+	return DEVICE_OK;
+}
+
+int AnalogInput::Shutdown()
+{
+	initialized_ = false;
+	return DEVICE_OK;
+}
+
+int AnalogInput::WriteToPort(long address)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+
+	MMThreadGuard myLock(hub->GetLock());
+
+	hub->PurgeComPortH();
+
+	int ret = hub->SendReadRequest(address);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+int AnalogInput::ReadFromPort(long& answer)
+{
+	MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+	if (!hub) {
+		return ERR_NO_PORT_SET;
+	}
+	int ret = hub->ReadAnswer(answer);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	return DEVICE_OK;
+}
+
+///////////////////////////////////////
+/////////// Action handlers
+int AnalogInput::OnNumberOfChannels(MM::PropertyBase* pProp, MM::ActionType pAct)
+{
+	if (pAct == MM::BeforeGet){
+		pProp->Set(numChannels_);
+	} else if (pAct == MM::AfterSet){
+		pProp->Get(numChannels_);
+	}
+	return DEVICE_OK;
+}
+
+int AnalogInput::OnAnalogInput(MM::PropertyBase* pProp, MM::ActionType pAct, long channel)
+{
+	if (pAct == MM::BeforeGet){
+		MicroFPGAHub* hub = static_cast<MicroFPGAHub*>(GetParentHub());
+		if (!hub){
+			return ERR_NO_PORT_SET;
+		}
+
+		MMThreadGuard myLock(hub->GetLock());
+
+		int ret = hub->SendReadRequest(g_offsetaddressAnalogInput+channel);
+		if (ret != DEVICE_OK)
+			return ret;
+
+		long answer;
+		ret = ReadFromPort(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+
+
+		pProp->Set(answer);
+		state_[channel]=answer;
+	}
+	return DEVICE_OK;
+}

--- a/DeviceAdapters/MicroFPGA/MicroFPGA.h
+++ b/DeviceAdapters/MicroFPGA/MicroFPGA.h
@@ -16,8 +16,8 @@
 #ifndef _Mojo_H_
 #define _Mojo_H_
 
-#include "../../MMDevice/MMDevice.h"
-#include "../../MMDevice/DeviceBase.h"
+#include "MMDevice.h"
+#include "DeviceBase.h"
 
 //////////////////////////////////////////////////////////////////////////////
 // Error codes

--- a/DeviceAdapters/MicroFPGA/MicroFPGA.h
+++ b/DeviceAdapters/MicroFPGA/MicroFPGA.h
@@ -1,0 +1,241 @@
+ //////////////////////////////////////////////////////////////////////////////
+// FILE:          MicroFPGA.h
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     DeviceAdapters
+//-----------------------------------------------------------------------------
+// DESCRIPTION:   Adapter for MicroFPGA, a FPGA platform using FPGA boards from
+//                Alchitry. The adapter must be used with a special firmware, see:
+//                https://github.com/jdeschamps/MicroFPGA
+// COPYRIGHT:     EMBL
+// LICENSE:       LGPL
+//
+// AUTHOR:        Joran Deschamps, EMBL, 2020
+//
+//
+
+#ifndef _Mojo_H_
+#define _Mojo_H_
+
+#include "../../MMDevice/MMDevice.h"
+#include "../../MMDevice/DeviceBase.h"
+
+//////////////////////////////////////////////////////////////////////////////
+// Error codes
+//
+#define ERR_BOARD_NOT_FOUND 101
+#define ERR_PORT_OPEN_FAILED 102
+#define ERR_NO_PORT_SET 103
+#define ERR_VERSION_MISMATCH 104
+#define ERR_UNKNOWN_ID 105
+#define ERR_COMMAND_UNKNOWN 11206655
+
+
+class MicroFPGAHub : public HubBase<MicroFPGAHub>  
+{
+public:
+   MicroFPGAHub();
+   ~MicroFPGAHub();
+
+   int Initialize();
+   int Shutdown();
+   void GetName(char* pszName) const;
+   bool Busy();
+
+   MM::DeviceDetectionStatus DetectDevice(void);
+   int DetectInstalledDevices();
+
+   // property handlers
+   int OnPort(MM::PropertyBase* pPropt, MM::ActionType eAct);
+
+   int PurgeComPortH() {return PurgeComPort(port_.c_str());}
+   int SendWriteRequest(long address, long value);
+   int SendReadRequest(long address);
+   int ReadAnswer(long& answer);
+   int WriteToComPortH(const unsigned char* command, unsigned len) {return WriteToComPort(port_.c_str(), command, len);}
+   int ReadFromComPortH(unsigned char* answer, unsigned maxLen, unsigned long& bytesRead) {
+      return ReadFromComPort(port_.c_str(), answer, maxLen, bytesRead);
+   }
+   static MMThreadLock& GetLock() {return lock_;}
+
+private:
+   int GetControllerVersion(long&);
+   int GetID(long&);
+   std::string port_;
+   bool initialized_;
+   bool portAvailable_;
+   long version_;
+   long id_;
+   static MMThreadLock lock_;
+};
+
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+class LaserTrig   : public CGenericBase<LaserTrig>  
+{
+public:
+   LaserTrig();
+   ~LaserTrig();
+  
+   // MMDevice API
+   // ------------
+   int Initialize();
+   int Shutdown();
+  
+   void GetName(char* pszName) const;
+   bool Busy() {return busy_;}
+   
+   unsigned long GetNumberOfLasers()const {return numlasers_;}
+
+   // action interface
+   // ----------------
+   int OnMode(MM::PropertyBase* pProp, MM::ActionType eAct, long laser);
+   int OnDuration(MM::PropertyBase* pProp, MM::ActionType eAct, long laser);
+   int OnSequence(MM::PropertyBase* pProp, MM::ActionType eAct, long laser);
+   int OnNumberOfLasers(MM::PropertyBase* pProp, MM::ActionType eAct);
+
+private:
+	
+   int WriteToPort(long address, long value);
+   int ReadFromPort(long& answer);
+
+   bool initialized_;
+   long numlasers_;
+   long *mode_;
+   long *duration_;
+   long *sequence_;
+   bool busy_;
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+
+class Servo : public CGenericBase<Servo>  
+{
+public:
+   Servo();
+   ~Servo();
+  
+   // MMDevice API
+   // ------------
+   int Initialize();
+   int Shutdown();
+  
+   void GetName(char* pszName) const;
+   bool Busy() {return busy_;}
+   
+   unsigned long GetNumberOfServos()const {return numServos_;}
+
+   // action interface
+   // ----------------
+   int OnNumberOfServos(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnPosition(MM::PropertyBase* pProp, MM::ActionType eAct, long servo);
+
+private:
+   int WriteToPort(long address, long value);
+   int ReadFromPort(long& answer);
+
+   long *position_;
+   bool initialized_;
+   long numServos_;
+   bool busy_;
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+
+class TTL : public CGenericBase<TTL>  
+{
+public:
+   TTL();
+   ~TTL();
+  
+   // MMDevice API
+   // ------------
+   int Initialize();
+   int Shutdown();
+  
+   void GetName(char* pszName) const;
+   bool Busy() {return busy_;}
+   
+   unsigned long GetNumberOfChannels()const {return numChannels_;}
+
+   // action interface
+   // ----------------
+   int OnState(MM::PropertyBase* pProp, MM::ActionType eAct, long channel);
+   int OnNumberOfChannels(MM::PropertyBase* pProp, MM::ActionType eAct);
+
+private:
+   int WriteToPort(long channel, long state);
+   int ReadFromPort(long& answer);
+
+   long numChannels_;
+   long *state_;
+   bool initialized_;
+   bool busy_;
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+
+class PWM : public CGenericBase<PWM>  
+{
+public:
+   PWM();
+   ~PWM();
+  
+   // MMDevice API
+   // ------------
+   int Initialize();
+   int Shutdown();
+  
+   void GetName(char* pszName) const;
+   bool Busy() {return busy_;}
+   
+   unsigned long GetNumberOfChannels()const {return numChannels_;}
+
+   // action interface
+   // ----------------
+   int OnState(MM::PropertyBase* pProp, MM::ActionType eAct, long servo);
+   int OnNumberOfChannels(MM::PropertyBase* pProp, MM::ActionType eAct);
+
+private:
+   int WriteToPort(long channel, long value);
+   int ReadFromPort(long& answer);
+   
+   bool initialized_;
+   long *state_;
+   long numChannels_;
+   bool busy_;
+};
+
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//////
+class AnalogInput : public CGenericBase<AnalogInput>  
+{
+public:
+   AnalogInput();
+   ~AnalogInput();
+
+   int Initialize();
+   int Shutdown();
+   void GetName(char* pszName) const;
+   bool Busy();
+
+   int OnAnalogInput(MM::PropertyBase* pProp, MM::ActionType eAct, long channel);
+   int OnNumberOfChannels(MM::PropertyBase* pProp, MM::ActionType eAct);
+   
+   unsigned long GetNumberOfChannels()const {return numChannels_;}
+
+private:
+   int WriteToPort(long address);
+   int ReadFromPort(long& answer);
+   
+   MMThreadLock lock_;
+   long numChannels_;
+   long *state_;
+   bool initialized_;
+};
+
+#endif

--- a/DeviceAdapters/MicroFPGA/MicroFPGA.vcxproj
+++ b/DeviceAdapters/MicroFPGA/MicroFPGA.vcxproj
@@ -1,0 +1,164 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2067D4A8-8C32-40D3-BA9F-6B388ECCD714}</ProjectGuid>
+    <RootNamespace>Arduino</RootNamespace>
+    <ProjectName>MicroFPGA</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="MicroFPGA.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="MicroFPGA.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\MMDevice\MMDevice-SharedRuntime.vcxproj">
+      <Project>{b8c95f39-54bf-40a9-807b-598df2821d55}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DeviceAdapters/MicroFPGA/license.txt
+++ b/DeviceAdapters/MicroFPGA/license.txt
@@ -1,0 +1,142 @@
+GNU Lesser General Public License
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Lesser General Public License, applies to some specially designated software packages--typically libraries--of the Free Software Foundation and other authors who decide to use it. You can use it too, but we suggest you first think carefully about whether this license or the ordinary General Public License is the better strategy to use in any particular case, based on the explanations below.
+
+When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.
+
+To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license, which gives you legal permission to copy, distribute and/or modify the library.
+
+To protect each distributor, we want to make it very clear that there is no warranty for the free library. Also, if the library is modified by someone else and passed on, the recipients should know that what they have is not the original version, so that the original author's reputation will not be affected by problems that might be introduced by others.
+
+Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. Therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the ordinary General Public License. We use this license for certain libraries in order to permit linking those libraries into non-free programs.
+
+When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other code with the library.
+
+We call this license the "Lesser" General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.
+
+For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the library. A more frequent case is that a free library does the same job as widely used non-free libraries. In this case, there is little to gain by limiting the free library to free software only, so we use the Lesser General Public License.
+
+In other cases, permission to use a particular library in non-free programs enables a greater number of people to use a large body of free software. For example, permission to use the GNU C Library in non-free programs enables many more people to use the whole GNU operating system, as well as its variant, the GNU/Linux operating system.
+
+Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user of a program that is linked with the Library has the freedom and the wherewithal to run that program using a modified version of the Library.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, whereas the latter must be combined with the library in order to run.
+
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Lesser General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+    These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+    Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+    In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License. 
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also combine or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+    a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+    b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS


### PR DESCRIPTION
Hi there,

Here is the device adapter for a FPGA board that the Ries lab (EMBL) and collaborators have been using for a few years on their microscopes. The platform is called [MicroFPGA](https://github.com/jdeschamps/MicroFPGA) and is based on an hobby FPGA board from Alchitry (Au or Cu, now produced by [SparkFun](https://www.sparkfun.com/categories/tags/alchitry)).

MicroFPGA generats various control signals used on microscopes such as a flexible laser triggering system, servomotors, TTL or PWM (used for instance together with a low-pass for analog output). Together with one of the FPGA board (Au), it can also read in analog signals.

We put some effort in making the [project repository](https://github.com/jdeschamps/MicroFPGA) as documented as possible so that it is easy for people to reproduce and install on their own microscope.