### PR TITLE
Fix linker error on GCC

### DIFF
--- a/MMCore/LogManager.cpp
+++ b/MMCore/LogManager.cpp
@@ -33,6 +33,8 @@ const char* StringForLogLevel(LogLevel level)
 
 } // anonymous namespace
 
+const logging::SinkMode LogManager::PrimarySinkMode = logging::SinkModeAsynchronous;
+
 LogManager::LogManager() :
    loggingCore_(boost::make_shared<LoggingCore>()),
    internalLogger_(loggingCore_->NewLogger("LogManager")),

--- a/MMCore/LogManager.h
+++ b/MMCore/LogManager.h
@@ -49,8 +49,7 @@ private:
    };
    std::map<LogFileHandle, LogFileInfo> secondaryLogFiles_;
 
-   static const logging::SinkMode PrimarySinkMode =
-      logging::SinkModeAsynchronous;
+   static const logging::SinkMode PrimarySinkMode;
 
 public:
    LogManager();


### PR DESCRIPTION
This PR fixes an error that prevent successful linking of MMCore on a GCC compiler. This is done by moving the definition of `LogManager::PrimarySinkMode` out of the header and into `LogManager.cpp`.

Up until C++17 where you can use `inline static` variable,  `static` member variables should not be defined inside a header. This is because even with `#pragma once` the definition will appear in any source file that includes the header, in this case `CMMCore.cpp` and `LogManager.cpp`, this then causes a problem when the object files are linked together.

I'm not sure why this issue doesn't appear on other compilers but it prevents successful compilation on GCC.