### PR TITLE
Fix SDK include paths 

### DIFF
--- a/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
+++ b/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
@@ -1531,7 +1531,7 @@ void CAndorSDK3Camera::RestartLiveAcquisition()
 
 AT_64 CAndorSDK3Camera::GetTimeStamp(unsigned char* pBuf)
 {
-#if defined(linux) && defined(_LP64)
+#if defined(__linux__) && defined(_LP64)
    typedef unsigned int    AT_U32;
 #else
    typedef unsigned long   AT_U32;

--- a/DeviceAdapters/MCL_MicroDrive/MCL_MicroDrive.vcxproj
+++ b/DeviceAdapters/MCL_MicroDrive/MCL_MicroDrive.vcxproj
@@ -82,6 +82,7 @@
       <PreprocessorDefinitions>MODULE_EXPORTS;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>MicroDrive.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -100,6 +101,7 @@
       <PreprocessorDefinitions>MODULE_EXPORTS;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>MicroDrive64.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -112,6 +114,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MODULE_EXPORTS;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>MicroDrive.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -131,6 +134,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MODULE_EXPORTS;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>MicroDrive64.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -158,11 +162,17 @@
     <ClInclude Include="mdutils.h" />
     <ClInclude Include="MicroDrive.h" />
     <ClInclude Include="MicroDriveXYStage.h" />
+    <ClInclude Include="..\MMDevice\DeviceBase.h" />
+    <ClInclude Include="..\MMDevice\DeviceUtils.h" />
+    <ClInclude Include="..\MMDevice\MMDevice.h" />
+    <ClInclude Include="..\MMDevice\MMDeviceConstants.h" />
+    <ClInclude Include="..\MMDevice\ModuleInterface.h" />
+    <ClInclude Include="..\MMDevice\Property.h" />
     <ClInclude Include="MicroDriveZStage.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\MMDevice\MMDevice-SharedRuntime.vcxproj">
-      <Project>{b8c95f39-54bf-40a9-807b-598df2821d55}</Project>
+    <ProjectReference Include="..\..\MMDevice\MMDevice-StaticRuntime.vcxproj">
+      <Project>{af3143a4-5529-4c78-a01a-9f2a8977ed64}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/DeviceAdapters/MCL_NanoDrive/MCL_NanoDrive.vcxproj
+++ b/DeviceAdapters/MCL_NanoDrive/MCL_NanoDrive.vcxproj
@@ -82,6 +82,7 @@
       <PreprocessorDefinitions>MODULE_EXPORTS;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Madlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -100,6 +101,7 @@
       <PreprocessorDefinitions>MODULE_EXPORTS;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Madlib64.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -112,7 +114,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MODULE_EXPORTS;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Madlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -132,7 +134,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MODULE_EXPORTS;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Madlib64.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -159,10 +161,17 @@
     <ClInclude Include="MCL_NanoDrive.h" />
     <ClInclude Include="MCL_NanoDrive_XYStage.h" />
     <ClInclude Include="MCL_NanoDrive_ZStage.h" />
+    <ClInclude Include="..\MMDevice\DeviceBase.h" />
+    <ClInclude Include="..\MMDevice\DeviceUtils.h" />
+    <ClInclude Include="..\MMDevice\ImgBuffer.h" />
+    <ClInclude Include="..\MMDevice\MMDevice.h" />
+    <ClInclude Include="..\MMDevice\MMDeviceConstants.h" />
+    <ClInclude Include="..\MMDevice\ModuleInterface.h" />
+    <ClInclude Include="..\MMDevice\Property.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\MMDevice\MMDevice-SharedRuntime.vcxproj">
-      <Project>{b8c95f39-54bf-40a9-807b-598df2821d55}</Project>
+    <ProjectReference Include="..\..\MMDevice\MMDevice-StaticRuntime.vcxproj">
+      <Project>{af3143a4-5529-4c78-a01a-9f2a8977ed64}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/DeviceAdapters/PVCAM/PVCAMIncludes.h
+++ b/DeviceAdapters/PVCAM/PVCAMIncludes.h
@@ -3,8 +3,8 @@
 
 #if defined(_WIN32)
     #pragma warning(push)
-    #include "../../../3rdpartypublic/Photometrics/PVCAM/SDK/Headers/master.h"
-    #include "../../../3rdpartypublic/Photometrics/PVCAM/SDK/Headers/pvcam.h"
+    #include "Photometrics/PVCAM/SDK/Headers/master.h"
+    #include "Photometrics/PVCAM/SDK/Headers/pvcam.h"
     #pragma warning(pop)
 #elif defined(__linux__)
     // PVCAM runtime and SDK must be installed in order to build and link the adapter.

--- a/DeviceAdapters/PrincetonInstruments/PVCAMInt.h
+++ b/DeviceAdapters/PrincetonInstruments/PVCAMInt.h
@@ -170,7 +170,7 @@ public:
    int ClearROI();
    int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}
 
-#ifndef linux
+#ifndef __linux__
    // high-speed interface
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();
@@ -216,7 +216,7 @@ public:
                                       uns32_ptr length);
 
 protected:
-#ifndef linux
+#ifndef __linux__
    int ThreadRun(void);
    void OnThreadExiting() throw();
 #endif

--- a/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
@@ -1901,7 +1901,7 @@ int Universal::ResizeImageBufferSingle()
 // Continuous acquisition
 //
 
-#ifndef linux
+#ifndef __linux__
 /*
 * Overrides a virtual function from the CCameraBase class
 * Do actual capture

--- a/DeviceAdapters/Sensicam/Sensicam.vcxproj.filters
+++ b/DeviceAdapters/Sensicam/Sensicam.vcxproj.filters
@@ -28,6 +28,6 @@
     <None Include="ReadMe.txt" />
   </ItemGroup>
   <ItemGroup>
-    <Library Include="..\..\..\3rdparty\Pco\Windows\Sdk_515\Senntcam.lib" />
+    <Library Include="$(MM_3RDPARTYPRIVATE)\Pco\Windows\Sdk_515\Senntcam.lib" />
   </ItemGroup>
 </Project>

--- a/DeviceAdapters/Spinnaker/SpinnakerCamera.h
+++ b/DeviceAdapters/Spinnaker/SpinnakerCamera.h
@@ -1,10 +1,10 @@
 #ifndef _SPINNAKER_CAMERA_H_
 #define _SPINNAKER_CAMERA_H_
 
-#include "Point Grey Research/Spinnaker/1.20.0.15/include/Spinnaker.h"
 #include "DeviceBase.h"
 #include "ImgBuffer.h"
 #include "DeviceThreads.h"
+#include "Spinnaker.h"
 
 #define SPKR Spinnaker
 #define GENAPI Spinnaker::GenApi

--- a/DeviceAdapters/Spinnaker/SpinnakerCamera.vcxproj
+++ b/DeviceAdapters/Spinnaker/SpinnakerCamera.vcxproj
@@ -79,26 +79,29 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <LibraryPath>"$(MM_3RDPARTYPRIVATE)\Point Grey Research\Spinnaker\1.20.0.15\lib\vs2010";$(LibraryPath)</LibraryPath>
+    <LibraryPath>"$(MM_3RDPARTYPRIVATE)\FLIR\Spinnaker\2.3.0.77\lib\vs2010";$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MM_3RDPARTYPRIVATE)\FLIR\Spinnaker\2.3.0.77\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <LibraryPath>"$(MM_3RDPARTYPRIVATE)\Point Grey Research\Spinnaker\1.20.0.15\lib64\vs2010";$(LibraryPath)</LibraryPath>
+    <LibraryPath>"$(MM_3RDPARTYPRIVATE)\FLIR\Spinnaker\2.3.0.77\lib64\vs2010";$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MM_3RDPARTYPRIVATE)\FLIR\Spinnaker\2.3.0.77\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <LibraryPath>"$(MM_3RDPARTYPRIVATE)\Point Grey Research\Spinnaker\1.20.0.15\lib\vs2010";$(LibraryPath)</LibraryPath>
+    <LibraryPath>"$(MM_3RDPARTYPRIVATE)\FLIR\Spinnaker\2.3.0.77\lib\vs2010";$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MM_3RDPARTYPRIVATE)\FLIR\Spinnaker\2.3.0.77\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <LibraryPath>"$(MM_3RDPARTYPRIVATE)\Point Grey Research\Spinnaker\1.20.0.15\lib64\vs2010";$(LibraryPath)</LibraryPath>
+    <LibraryPath>"$(MM_3RDPARTYPRIVATE)\FLIR\Spinnaker\2.3.0.77\lib64\vs2010";$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MM_3RDPARTYPRIVATE)\FLIR\Spinnaker\2.3.0.77\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;SPINNAKERCAMERA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -111,12 +114,11 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;SPINNAKERCAMERA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Spinnakerd_v100.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Spinnaker_v100.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -125,7 +127,6 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;SPINNAKERCAMERA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -142,7 +143,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;SPINNAKERCAMERA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
@nicost , I don't currently have the ability to test the build but this should fix the issue with the Spinnaker camera. The SDK include paths were accidentally reverted when migrating to this submodule.

Don't merge this yet as I am still checking all the other device adapters for similar mistakes. Since we changed all "3rdParty" include paths from `..\..\..\3rdParty` to `$(MM_3RDPARTYPRIVATE)`, Git recognizes them all as having changed which means they must be checked manually to see if the path is actually different.

So far I have noticed a few other potential issues which I'm not sure how to properly resolve:
1: The ABS device adapter code from before merging the submodule uses `#ifdef LINUX`, while the current code uses `#ifdef __linux__` I'm not sure which is correct.
2: The AndorSDK3 from before the merge uses `#if defined(__linux__)` while the current code uses `#if defined(linux)`
3: A change in the Basler device adapter has been committed to SVN in the time after we moved to using the submodule so the Git and SVN versions are now different. I really think we need to stop development on the SVN version.
