### PR TITLE
create an onConfigSet callback

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -5062,6 +5062,11 @@ void CMMCore::setConfig(const char* groupName, const char* configName) throw (CM
       throw;
    }
 
+   if (externalCallback_) 
+   {
+      externalCallback_->onConfigSet(groupName, configName);
+   }
+
    LOG_DEBUG(coreLogger_) << "Config group " << groupName <<
       ": did apply preset " << configName;
 }

--- a/MMCore/MMEventCallback.h
+++ b/MMCore/MMEventCallback.h
@@ -52,6 +52,12 @@ public:
       std::cout << std:: endl; 
    }
 
+   virtual void onConfigSet(const char* groupName, const char* newConfigName)
+   {
+      std::cout << "onConfigSet() " << groupName << " " << newConfigName;
+      std::cout << std:: endl; 
+   }
+
    virtual void onSystemConfigurationLoaded()
    {
       std::cout << "onSystemConfigurationLoaded() ";


### PR DESCRIPTION
This will fire when `setConfig` is called successfully. It
is different from `onConfigGroupChanged` because the latter
is called after device properties are set that affect a config
group and has constraints such as not being activated if a config
group only contains one property.

Closes: #25 


Unfortunately I wasn't able to test this as I only know how to test using pymmcore and I was struggling to get it build correctly. But I think this should do the right thing, though perhaps it should be named `onSetConfig`?