### PR TITLE
TriggerscopeMM: Fix bug seen when using DAZStage with DAC output.

### DIFF
--- a/DeviceAdapters/TriggerScopeMM/TriggerScopeMMDAC.cpp
+++ b/DeviceAdapters/TriggerScopeMM/TriggerScopeMMDAC.cpp
@@ -222,12 +222,16 @@ int CTriggerScopeMMDAC::WriteSignal(double volts)
 
 int CTriggerScopeMMDAC::SetSignal(double volts)
 {
-   if (gateOpen_) {
+   volts_ = volts;
+   if (gateOpen_) 
+   {
       gatedVolts_ = volts;
-      return WriteSignal(volts);
    }
-   gatedVolts_ = 0;
-   return WriteSignal(0);
+   else 
+   {
+      gatedVolts_ = 0;
+   }
+   return WriteSignal(gatedVolts_);
 }
 
 


### PR DESCRIPTION
SetSignal function now stores the volt_ property that can be read
out by the OnVolt Property.