### PR TITLE
ASITiger: increase Number of Averages for CRISP

### DIFF
--- a/DeviceAdapters/ASITiger/ASICRISP.cpp
+++ b/DeviceAdapters/ASITiger/ASICRISP.cpp
@@ -122,7 +122,7 @@ int CCRISP::Initialize()
 
    pAct = new CPropertyAction(this, &CCRISP::OnNumAvg);
    CreateProperty(g_CRISPNumberAveragesPropertyName, "1", MM::Integer, false, pAct);
-   SetPropertyLimits(g_CRISPNumberAveragesPropertyName, 0, 8);
+   SetPropertyLimits(g_CRISPNumberAveragesPropertyName, 0, 10);
    UpdateProperty(g_CRISPNumberAveragesPropertyName);
 
    pAct = new CPropertyAction(this, &CCRISP::OnSNR);


### PR DESCRIPTION
The property limit for "Number of Averages" on ASITiger and ASIStage is now the same.