### PR TITLE
ASITiger: add the offset property to the filter wheel device

### DIFF
--- a/DeviceAdapters/ASITiger/ASIFWheel.h
+++ b/DeviceAdapters/ASITiger/ASIFWheel.h
@@ -56,6 +56,7 @@ public:
    int OnVelocity    (MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnSpeedSetting(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnLockMode    (MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnOffset      (MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
    unsigned int numPositions_;

--- a/DeviceAdapters/ASITiger/ASITiger.h
+++ b/DeviceAdapters/ASITiger/ASITiger.h
@@ -262,6 +262,7 @@ const char* const g_FWSpinStatePropertyName = "SpinOffOn";
 const char* const g_FWVelocityRunPropertyName = "VelocityRun";
 const char* const g_FWSpeedSettingPropertyName = "SpeedSetting";
 const char* const g_FWLockModePropertyName = "LockMode";
+const char* const g_FWOffsetPropertyName = "Offset";
 
 // scanner property names
 const char* const g_ScannerLowerLimXPropertyName = "MinDeflectionX(deg)";


### PR DESCRIPTION
This allows the user to set the filter wheel offset, which is followed by a home command so that the user can check the new offset.