### PR TITLE
Add instructions + files for building on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ test-reports/
 *.pb.cc
 *.pb.h
 bin
+DeviceAdapters/depcomp
+DeviceAdapters/install-sh
+depcomp
+install-sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,28 @@
+AUTOMAKE_OPTIONS = foreign
+ACLOCAL_AMFLAGS = -I m4
+
+
+# if BUILD_MMCORE
+# MMCORE_DIR = MMCore
+# endif
+
+if BUILD_SECRETDEVICEADAPTERS
+SECRETDEVICEADAPTERS = SecretDeviceAdapters
+endif
+
+
+# CLEANFILES = $(launcher_SCRIPTS)
+
+
+# TODO: Building of DeviceAdapters could be made optional.
+SUBDIRS = \
+	MMDevice \
+	DeviceAdapters \
+	$(SECRETDEVICEADAPTERS)
+
+dox:
+	-rm -rf doxygen/out
+	$(MKDIR_P) doxygen/out/MMDevice
+	$(MKDIR_P) doxygen/out/MMCore
+	doxygen doxygen/MMDevice
+	doxygen doxygen/MMCore

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ The windows project uses the following properties which may be overridden in the
 	
 To see the default values of each property please view `MMCommon.props`
 
-### Building on Mac and  Linux
-*TODO*
+### Building on Mac and Linux
+
+For building just the `C++` in this repository (ignoring `MMCoreJ_wrap`) see the instructions in `building-cpp.md`
+
 
 ### Branches
 This repository consists of two primary branches: `main` and `privateMain`.  

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+
+echo "Bootstrapping autoconf/automake build system ..." 1>&2
+
+# Subdirectory must be present, even if empty, to prevent automake errors.
+mkdir -p SecretDeviceAdapters
+
+autoreconf --force --install --verbose
+
+if [ $? -eq 0 ] # Command succeeded.
+then
+	echo "Bootstrapping complete; now you can run ./configure" 1>&2
+else
+	echo "Bootstrapping failed"
+fi

--- a/building-cpp.md
+++ b/building-cpp.md
@@ -1,0 +1,75 @@
+# Building On Linux
+
+## 1. Install dependencies:
+
+- bzip2
+- bc
+- build-essential
+- cmake
+- curl
+- g++
+- gfortran
+- libboost-dev
+- libboost-thread-dev
+- libtool
+- autoconf
+- automake
+- pkg-config
+- software-properties-common
+- unzip
+- wget
+
+On Debian based OSes you can install these with `apt`
+```bash
+sudo apt update && sudo apt install -y \
+        bzip2 \
+        bc \
+        build-essential \
+        cmake \
+        curl \
+        g++ \
+        gfortran \
+        libboost-dev \
+        libboost-thread-dev \
+        libtool \
+        autoconf \
+        automake \
+        pkg-config \
+        software-properties-common \
+        unzip \
+        wget \
+```
+
+## 2. Build and Install
+
+```bash
+./autogen.sh
+./configure
+make
+sudo make install
+```
+
+The `sudo` is only necessary if you are installing to the default `/usr/local/micro-manager`
+
+## 3. Download MMConfig_Demo.cfg
+Many downstream libraries will expect the demo config file to be located along with the installed files. So here we download it directly from the micro-manager repo:
+
+```bash
+sudo curl https://github.com/micro-manager/micro-manager/blob/master/bindist/any-platform/MMConfig_demo.cfg --output /usr/local/micro-manager/MMConfig_demo.cfg
+```
+
+## 4. Test install
+Now downstream libraries e.g. [pymmcore-plus](https://github.com/tlambert03/pymmcore-plus) should work.
+
+
+```bash
+pip install pymmcore-plus
+```
+
+```python
+from pymmcore_plus import CMMCorePlus
+
+mmcore = CMMCorePlus()
+mmcore.loadSystemConfiguration("demo")
+print(mmcore.getLoadedDevices())
+```

--- a/building-cpp.md
+++ b/building-cpp.md
@@ -55,7 +55,7 @@ The `sudo` is only necessary if you are installing to the default `/usr/local/mi
 Many downstream libraries will expect the demo config file to be located along with the installed files. So here we download it directly from the micro-manager repo:
 
 ```bash
-sudo curl https://github.com/micro-manager/micro-manager/blob/master/bindist/any-platform/MMConfig_demo.cfg --output /usr/local/micro-manager/MMConfig_demo.cfg
+sudo curl https://raw.githubusercontent.com/micro-manager/micro-manager/master/bindist/any-platform/MMConfig_demo.cfg --output /usr/local/micro-manager/MMConfig_demo.cfg
 ```
 
 ## 4. Test install

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,124 @@
+
+m4_define([MM_CPP_DIR], [.])  # Define a macro substitution to be used in this file.
+AC_PREREQ([2.64])
+AC_INIT([Micro-Manager], [1.4], [info@micro-manager.org])
+AC_CONFIG_MACRO_DIR([m4])
+AC_CONFIG_SRCDIR(MM_CPP_DIR[/MMCore/MMCore.cpp])
+AC_CANONICAL_BUILD
+AC_CANONICAL_HOST
+AM_INIT_AUTOMAKE([foreign 1.11])
+LT_PREREQ([2.2.6])
+LT_INIT([disable-static])
+AC_PROG_MKDIR_P
+
+AC_PROG_CXX([clang++ llvm-g++ g++ c++])
+AC_PROG_CC([clang llvm-gcc gcc cc])
+
+
+# Testing (googletest, googlemock)
+# See testing/setuptesting.sh
+MM_GMOCK([$srcdir/testing/googletest], [\$(top_srcdir)/testing/googletest])
+AM_CONDITIONAL([BUILD_CPP_TESTS], [test "x$have_gmock" = xyes])
+
+
+# Boost
+# TODO Reflect results in configuration
+AX_BOOST_BASE([1.48.0])
+AX_BOOST_DATE_TIME
+AX_BOOST_FILESYSTEM
+AX_BOOST_SYSTEM
+AX_BOOST_THREAD
+
+
+# AppleHost dependencies
+case $host in
+   *apple-darwin*) MMCORE_APPLEHOST_LDFLAGS="-framework CoreFoundation -framework IOKit" ;;
+   *) MMCORE_APPLEHOST_LDFLAGS="" ;;
+esac
+AC_SUBST([MMCORE_APPLEHOST_LDFLAGS])
+
+
+# TODO Make conditional
+can_build_mmcore=yes
+
+
+##
+## MMCoreJ
+##
+
+# Define a shell variable based on the earlier m4_define
+[MM_CPP_DIR]=MM_CPP_DIR
+AC_ARG_VAR([MM_CPP_DIR], [The directory containing the c++ code])
+
+# SWIG
+AC_ARG_VAR([SWIG], [Simple Wrapper and Interface Generator])
+AC_CHECK_PROGS([SWIG], [swig])
+# TODO Provide SWIGFLAGS as precious variable
+
+
+
+
+##
+## Leftover stuff (needs cleanup)
+##
+
+AC_HEADER_STDC
+AC_HEADER_STDBOOL
+AC_C_CONST
+AC_C_INLINE
+AC_CHECK_FUNCS([memset])
+AC_CHECK_LIB(dl, dlopen)
+
+
+# Install Device Adapter API library and headers
+install_mmdevapi=false
+# TODO reinstate this flag in some better form
+#AC_ARG_ENABLE(inst-devapi,
+#    [  --enable-inst-devapi    Install the Device Adapter API library and headers ],
+#    [ install_mmdevapi=true ])
+AM_CONDITIONAL([INSTALL_MMDEVAPI], [test x$install_mmdevapi = xtrue])
+
+
+##
+## Subdirectory configuration
+##
+
+AC_MSG_CHECKING([for proprietary device adapter source])
+AS_IF([test -f "$srcdir/$MM_CPP_DIR/SecretDeviceAdapters/configure"],
+   [build_secretdeviceadapters=yes], [build_secretdeviceadapters=no])
+AM_CONDITIONAL([BUILD_SECRETDEVICEADAPTERS],
+   [test "x$build_secretdeviceadapters" = xyes])
+
+AC_CONFIG_SUBDIRS(MM_CPP_DIR[/DeviceAdapters])
+AS_IF([test "x$build_secretdeviceadapters" = xyes], [
+   AC_CONFIG_SUBDIRS(MM_CPP_DIR[/SecretDeviceAdapters])
+])
+
+
+##
+## Output generation
+##
+
+AC_CONFIG_FILES(m4_strip([
+   Makefile
+   ]MM_CPP_DIR[/MMDevice/Makefile
+   ]MM_CPP_DIR[/MMDevice/unittest/Makefile
+   ]MM_CPP_DIR[/MMCore/Makefile
+   ]MM_CPP_DIR[/MMCore/unittest/Makefile
+]))
+
+AC_OUTPUT
+
+echo ""
+echo "m4_text_box([Micro-Manager configuration])"
+echo ""
+
+echo "   Build device adapters:                  yes"
+echo "   Build closed-source device adapters:    $build_secretdeviceadapters"
+echo ""
+
+echo "   Installation prefix:                    $prefix"
+
+echo "Type 'make' to build."
+echo "Then type 'make install' to install."
+echo ""


### PR DESCRIPTION
This PR adds files to this repo that allow it be built without also downloading the micromanager repo. This is nice for linux users and people using pymmcore (and maybe eventually for pymmcore CI on linux).


I don't really know much about building cpp projects so I mostly just copied the micromanager files and messed with them until I go this working, so I probably did several things non-optimally.

That said if I follow the instructions I end up with a working installation that I can use with `pymmcore`.

Attn @oeway maybe interesting to you as I think this could have implications for https://github.com/micro-manager/pymmcore/issues/19