### PR TITLE
MoticCAmera: second attempt to fix binning

### DIFF
--- a/DeviceAdapters/Motic/MoticCamera.cpp
+++ b/DeviceAdapters/Motic/MoticCamera.cpp
@@ -101,7 +101,7 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 * perform most of the initialization in the Initialize() method.
 */
 CMoticCamera::CMoticCamera() :
-   m_iBinning(1),
+   m_iBinning(0),
    m_dGain(1.0),
    m_iBytesPerPixel(4),
    m_bInitialized(false),
@@ -1155,8 +1155,8 @@ void CMoticCamera::InitBinning()
   OutputDebugString("InitBinning");
 #endif
   m_vBinning.clear();
-  int c = MIDP_GetResolutionCount();
-  for(int i = 0; i < c; i++)
+  int resolutionCount = MIDP_GetResolutionCount();
+  for(int i = 0; i < resolutionCount; i++)
   {
     long x, y;
     MIDP_GetResolution(i, &x, &y);
@@ -1168,13 +1168,12 @@ void CMoticCamera::InitBinning()
       
   // binning
   CPropertyAction *pAct = new CPropertyAction (this, &CMoticCamera::OnBinning);
-  int ret = CreateProperty(MM::g_Keyword_Binning, _itoa(m_iBinning,bin, 10), MM::Integer, false, pAct);
-  //assert(ret == DEVICE_OK);
+  int ret = CreateProperty(MM::g_Keyword_Binning, _itoa(m_iBinning + 1, bin, 10), MM::Integer, false, pAct);
 
   vector<string> binningValues;
-  for(int i = 0; i < c; i++)
+  for(int i = 1; i<= resolutionCount; i++)
   {
-    binningValues.push_back(_itoa(i,bin, 10));
+    binningValues.push_back(_itoa(i, bin, 10));
   }  
 
   ret = SetAllowedValues(MM::g_Keyword_Binning, binningValues);


### PR DESCRIPTION
Motic uses a zero-based binning, whereas we are 1-based.  Previous attempt left out some conversions.  Hopefully this will fix it.