### PR TITLE
Update Boost to 1.77.0 for VS2019

### DIFF
--- a/DeviceAdapters/SerialManager/AsioClient.h
+++ b/DeviceAdapters/SerialManager/AsioClient.h
@@ -181,7 +181,7 @@ public:
 
    void ChangeDTR (bool enable)
    {
-      boost::asio::serial_port::native_type handle = serialPortImplementation_.native();
+      SerialNativeHandle handle = serialPortImplementation_.native_handle();
       BOOL result = true;
       if (enable) 
       {

--- a/buildscripts/VisualStudio/MMCommon.props
+++ b/buildscripts/VisualStudio/MMCommon.props
@@ -6,13 +6,13 @@
     <MM_3RDPARTYPUBLIC>$(MM_SRCROOT)\..\..\3rdpartypublic</MM_3RDPARTYPUBLIC>
     <MM_3RDPARTYPRIVATE>$(MM_SRCROOT)\..\..\3rdparty</MM_3RDPARTYPRIVATE>
     <MM_MMDEVICE_INCLUDEDIR>$(MM_SRCROOT)\MMDevice</MM_MMDEVICE_INCLUDEDIR>
-    <MM_BOOST_INCLUDEDIR>$(MM_3RDPARTYPUBLIC)\boost-versions\boost_1_55_0</MM_BOOST_INCLUDEDIR>
-    <MM_BOOST_LIBDIR>$(MM_3RDPARTYPUBLIC)\boost-versions\boost_1_55_0-lib-$(Platform)</MM_BOOST_LIBDIR>
+    <MM_BOOST_INCLUDEDIR>$(MM_3RDPARTYPUBLIC)\boost-versions\boost_1_77_0</MM_BOOST_INCLUDEDIR>
+    <MM_BOOST_LIBDIR>$(MM_3RDPARTYPUBLIC)\boost-versions\boost_1_77_0-lib-$(Platform)</MM_BOOST_LIBDIR>
     <MM_SWIG>$(MM_3RDPARTYPUBLIC)\swig\swig.exe</MM_SWIG>
     <MM_PROTOBUF_INCLUDEDIR>$(MM_3RDPARTYPUBLIC)\google\protobuf-2.5.0_build\VS2010\include</MM_PROTOBUF_INCLUDEDIR>
     <MM_PROTOBUF_LIBDIR>$(MM_3RDPARTYPUBLIC)\google\protobuf-2.5.0_build\VS2010\lib\$(Configuration)\$(Platform)</MM_PROTOBUF_LIBDIR>
     <MM_PROTOC>$(MM_3RDPARTYPUBLIC)\google\protobuf-2.5.0_build\VS2010\bin\protoc.exe</MM_PROTOC>
-	<MM_BUILDDIR>$(SolutionDir)build</MM_BUILDDIR>
+    <MM_BUILDDIR>$(SolutionDir)build</MM_BUILDDIR>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir>$(MM_BUILDDIR)\$(Configuration)\$(Platform)\</OutDir>


### PR DESCRIPTION
It would have been nice to keep the same Boost version, but that is impractical due to the old version (1.55.0) not fully working with VS2019. So update to the latest (1.77.0) and fix incompatibilities.

The number of projects failing to build (x64-Release) went from 32 to 22 with these changes.

The fixes to SerialManager and DEClientLib should not affect Unix builds that still use Boost 1.55.0. But they have not been tested for correct functioning.

Note: At the time of this writing, Boost 1.77.0 is still being uploaded (committed) to 3rdpartypublic (svn is taking its time).