### PR TITLE
RaptorEPIX: Move location of dependencies

### DIFF
--- a/DeviceAdapters/RaptorEPIX/HoribaEPIX.vcxproj
+++ b/DeviceAdapters/RaptorEPIX/HoribaEPIX.vcxproj
@@ -60,12 +60,14 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -79,14 +81,16 @@
       <PreprocessorDefinitions>HORIBA_COMPILE;WIN32;WIN64;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
@@ -364,10 +364,8 @@ int serialWriteReadCmd(int unitopenmap, int unit, unsigned char* bufin, int insi
 	extern "C" {
 	#if defined (MMLINUX32) || defined(MMLINUX64)
 		#include "/usr/local/xclib/xcliball.h"
-	#elif defined(WIN64)
-		#include "..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\xcliball.h"
-	#else
-		#include "..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB32\xcliball.h"
+	#else // Assume build system configures include path
+		#include "xcliball.h"
 	#endif
 	}
 

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.vcxproj
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.vcxproj
@@ -60,12 +60,14 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -79,14 +81,16 @@
       <PreprocessorDefinitions>NOT_HORIBA_COMPILE;WIN32;WIN64;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DeviceAdapters/RaptorEPIX/build.xml
+++ b/DeviceAdapters/RaptorEPIX/build.xml
@@ -1,11 +1,13 @@
 <project name="RaptorEPIX">
    <import file="../../../buildscripts/deviceadapter.xml"/>
 
-	<target name="install-Win32">
-		<copy todir="${mm.dll.installdir}" file="../../SecretDeviceAdapters/RaptorEPIX/XCLIB32/XCLIBWNT.dll"/>
-	</target>
+   <property name="epix.xclib" location="${mm.basedir}/../3rdparty/EPIX"/>
 
-	<target name="install-x64">
-		<copy todir="${mm.dll.installdir}" file="../../SecretDeviceAdapters/RaptorEPIX/XCLIB64/XCLIBW64.dll"/>
-	</target>
+   <target name="install-Win32">
+      <copy todir="${mm.dll.installdir}" file="${epix.xclib}/XCLIB32/XCLIBWNT.dll"/>
+   </target>
+
+   <target name="install-x64">
+      <copy todir="${mm.dll.installdir}" file="${epix.xclib}/XCLIB64/XCLIBW64.dll"/>
+   </target>
 </project>


### PR DESCRIPTION
EPIX headers and libraries used to be in SecretDeviceAdapters, where
they have now been removed. Repoint to 3rdparty.