### PR TITLE
Merge main into vs2019

### DIFF
--- a/DeviceAdapters/Basler/BaslerPylon.vcxproj
+++ b/DeviceAdapters/Basler/BaslerPylon.vcxproj
@@ -56,7 +56,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\Basler\Windows\6.2.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\Basler\Windows\6.3.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <PrecompiledHeader>
@@ -65,7 +65,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\Basler\Windows\6.2.0\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\Basler\Windows\6.3.0\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
     </Link>
     <PostBuildEvent />
@@ -78,7 +78,7 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\Basler\Windows\6.2.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\Basler\Windows\6.3.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
@@ -87,7 +87,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\Basler\Windows\6.2.0\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\Basler\Windows\6.3.0\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/DeviceAdapters/RaptorEPIX/HoribaEPIX.vcxproj
+++ b/DeviceAdapters/RaptorEPIX/HoribaEPIX.vcxproj
@@ -60,12 +60,14 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -79,14 +81,16 @@
       <PreprocessorDefinitions>HORIBA_COMPILE;WIN32;WIN64;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
@@ -364,10 +364,8 @@ int serialWriteReadCmd(int unitopenmap, int unit, unsigned char* bufin, int insi
 	extern "C" {
 	#if defined (MMLINUX32) || defined(MMLINUX64)
 		#include "/usr/local/xclib/xcliball.h"
-	#elif defined(WIN64)
-		#include "..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\xcliball.h"
-	#else
-		#include "..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB32\xcliball.h"
+	#else // Assume build system configures include path
+		#include "xcliball.h"
 	#endif
 	}
 

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.vcxproj
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.vcxproj
@@ -60,12 +60,14 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -79,14 +81,16 @@
       <PreprocessorDefinitions>NOT_HORIBA_COMPILE;WIN32;WIN64;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\SecretDeviceAdapters\RaptorEPIX\XCLIB64\XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>XCLIBW64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\EPIX\XCLIB64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DeviceAdapters/RaptorEPIX/build.xml
+++ b/DeviceAdapters/RaptorEPIX/build.xml
@@ -1,11 +1,13 @@
 <project name="RaptorEPIX">
    <import file="../../../buildscripts/deviceadapter.xml"/>
 
-	<target name="install-Win32">
-		<copy todir="${mm.dll.installdir}" file="../../SecretDeviceAdapters/RaptorEPIX/XCLIB32/XCLIBWNT.dll"/>
-	</target>
+   <property name="epix.xclib" location="${mm.basedir}/../3rdparty/EPIX"/>
 
-	<target name="install-x64">
-		<copy todir="${mm.dll.installdir}" file="../../SecretDeviceAdapters/RaptorEPIX/XCLIB64/XCLIBW64.dll"/>
-	</target>
+   <target name="install-Win32">
+      <copy todir="${mm.dll.installdir}" file="${epix.xclib}/XCLIB32/XCLIBWNT.dll"/>
+   </target>
+
+   <target name="install-x64">
+      <copy todir="${mm.dll.installdir}" file="${epix.xclib}/XCLIB64/XCLIBW64.dll"/>
+   </target>
 </project>


### PR DESCRIPTION
This PR brings `vs2019` up to date with `main`.
Automatic merge had no conflicts and was correct.

The RaptorEPIX and HoribaEPIX build was broken on `main` and now fixed.

To preserve the merge, please do not squash this PR.