### PR TITLE
Fix FLI Camera for vs2019

### DIFF
--- a/DeviceAdapters/FLICamera/FLICamera.vcxproj
+++ b/DeviceAdapters/FLICamera/FLICamera.vcxproj
@@ -63,7 +63,7 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libfli64-static-debug.lib;wsock32.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libfli64-static-debug.lib;wsock32.lib;setupapi.lib;legacy_stdio_definitions.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\FLI\lib_2013_03_21;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>
@@ -83,7 +83,7 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libfli64-static.lib;wsock32.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libfli64-static.lib;wsock32.lib;setupapi.lib;legacy_stdio_definitions.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\FLI\lib_2013_03_21;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>


### PR DESCRIPTION
After updating to vc142 the FLICamera device adapter fails to build with this message: `LNK2019: unresolved external symbol __snprintf referenced in function`

One possible solution may be to look at updating to a new version of the FLI SDK.

This PR does not do that but instead keeps using the SDK currently in the 3Party repository. Instead the build is fixed just by adding `legacy_ stdio_definitions.lib` to the linker.