### PR TITLE
PointGrey for vs2019

### DIFF
--- a/DeviceAdapters/PointGrey/PointGrey.cpp
+++ b/DeviceAdapters/PointGrey/PointGrey.cpp
@@ -1917,7 +1917,7 @@ int PointGrey::CameraID(PGRGuid id, std::string* camIdString)
 
    std::string sep = "_";
    *camIdString = camInfo.modelName + sep;
-   *camIdString += std::to_string( (_ULonglong) camInfo.serialNumber);
+   *camIdString += std::to_string((unsigned long long) camInfo.serialNumber);
    error = cam.Disconnect();
 
    return DEVICE_OK;


### PR DESCRIPTION
The PointGrey adapter is fixed by replacing the no longer existent `_ULongLong` identifier with `unsigned long long`.

Remaining question: Why cast to `unsigned long long` in the first place? Why not just pass the `unsigned int` variable directly.