### PR TITLE
vs2019: Remove linker 'VERSION' flag from all projects

### DIFF
--- a/DeviceAdapters/MP285/MP285.vcxproj
+++ b/DeviceAdapters/MP285/MP285.vcxproj
@@ -63,7 +63,6 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>2.05.019</Version>
       <SubSystem>Windows</SubSystem>
       <EntryPointSymbol>
       </EntryPointSymbol>
@@ -83,7 +82,6 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>2.05.019</Version>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/DeviceAdapters/XCiteLed/XCiteLed.vcxproj
+++ b/DeviceAdapters/XCiteLed/XCiteLed.vcxproj
@@ -62,7 +62,8 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>1.02.032</Version>
+      <Version>
+      </Version>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -80,7 +81,8 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>1.02.032</Version>
+      <Version>
+      </Version>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/DeviceAdapters/XCiteLed/XCiteLed.vcxproj
+++ b/DeviceAdapters/XCiteLed/XCiteLed.vcxproj
@@ -62,8 +62,6 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>
-      </Version>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -81,8 +79,6 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>
-      </Version>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/DeviceAdapters/XCiteXT600/XCiteXT600.vcxproj
+++ b/DeviceAdapters/XCiteXT600/XCiteXT600.vcxproj
@@ -62,7 +62,8 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>1.02.032</Version>
+      <Version>
+      </Version>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -80,7 +81,8 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>1.02.032</Version>
+      <Version>
+      </Version>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/DeviceAdapters/XCiteXT600/XCiteXT600.vcxproj
+++ b/DeviceAdapters/XCiteXT600/XCiteXT600.vcxproj
@@ -62,8 +62,6 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>
-      </Version>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -81,8 +79,6 @@
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <Version>
-      </Version>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
Two of the XCite project files had a "Version" option in the linker configuration which results in a syntax error in VS2019.

The version hasn't been updated in more than a decade and I doubt anyone knows it is there any way. This PR removes the version and enables building these device adapters on VS2019.