### PR TITLE
WieneckeSinske: Fix Unix build

### DIFF
--- a/DeviceAdapters/WieneckeSinske/Makefile.am
+++ b/DeviceAdapters/WieneckeSinske/Makefile.am
@@ -1,6 +1,22 @@
 
 AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS)
 deviceadapter_LTLIBRARIES = libmmgr_dal_WieneckeSinske.la
-libmmgr_dal_WieneckeSinske_la_SOURCES = WieneckeSinske.cpp WieneckeSinske.h CAN29.cpp CAN29.h
+libmmgr_dal_WieneckeSinske_la_SOURCES = \
+					CAN29.cpp \
+					CAN29.h \
+					CAN29Axis.cpp \
+					CAN29Axis.h \
+					WS.cpp \
+					WS.h \
+					WSAxis.cpp \
+					WSAxis.h \
+					WieneckeSinske.cpp \
+					WieneckeSinske.h \
+					XYStageDevice.cpp \
+					XYStageDevice.h \
+					ZPiezoCanDevice.cpp \
+					ZPiezoCanDevice.h \
+					ZPiezoWSDevice.cpp \
+					ZPiezoWSDevice.h
 libmmgr_dal_WieneckeSinske_la_LDFLAGS = $(MMDEVAPI_LDFLAGS)
 libmmgr_dal_WieneckeSinske_la_LIBADD = $(MMDEVAPI_LIBADD)


### PR DESCRIPTION
Missing source files in Makefile.am resulted in missing symbols.