### PR TITLE
ThorlabsDCxxxx: Fix Unix build

### DIFF
--- a/DeviceAdapters/ThorlabsDCxxxx/Makefile.am
+++ b/DeviceAdapters/ThorlabsDCxxxx/Makefile.am
@@ -1,9 +1,8 @@
 
 AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS)
 deviceadapter_LTLIBRARIES = libmmgr_dal_ThorlabsDCxxxx.la
+
 libmmgr_dal_ThorlabsDCxxxx_la_SOURCES =  \
-			  DC2200.cpp \
-			  DC2200.h \
 			  DC2XXX.cpp \
 			  DC2XXX.h \
 			  DC3100.cpp \
@@ -14,5 +13,7 @@ libmmgr_dal_ThorlabsDCxxxx_la_SOURCES =  \
 			  DCxxxx_Plugin.h \
 			  DynError.cpp \
 			  DynError.h
+# Note that DC2200 requires a Windows-only SDK and should not be listed here.
+
 libmmgr_dal_ThorlabsDCxxxx_la_LDFLAGS = $(MMDEVAPI_LDFLAGS) 
 libmmgr_dal_ThorlabsDCxxxx_la_LIBADD = $(MMDEVAPI_LIBADD)


### PR DESCRIPTION
The Windows-only part of the code needs to be excluded from the build;
otherwise the device adapter contains missing symbols and does not load.