### PR TITLE
Use protobuf 2.6.1 built with VS2019

### DIFF
--- a/buildscripts/VisualStudio/MMCommon.props
+++ b/buildscripts/VisualStudio/MMCommon.props
@@ -9,9 +9,9 @@
     <MM_BOOST_INCLUDEDIR>$(MM_3RDPARTYPUBLIC)\boost-versions\boost_1_77_0</MM_BOOST_INCLUDEDIR>
     <MM_BOOST_LIBDIR>$(MM_3RDPARTYPUBLIC)\boost-versions\boost_1_77_0-lib-$(Platform)</MM_BOOST_LIBDIR>
     <MM_SWIG>$(MM_3RDPARTYPUBLIC)\swig\swig.exe</MM_SWIG>
-    <MM_PROTOBUF_INCLUDEDIR>$(MM_3RDPARTYPUBLIC)\google\protobuf-2.5.0_build\VS2010\include</MM_PROTOBUF_INCLUDEDIR>
-    <MM_PROTOBUF_LIBDIR>$(MM_3RDPARTYPUBLIC)\google\protobuf-2.5.0_build\VS2010\lib\$(Configuration)\$(Platform)</MM_PROTOBUF_LIBDIR>
-    <MM_PROTOC>$(MM_3RDPARTYPUBLIC)\google\protobuf-2.5.0_build\VS2010\bin\protoc.exe</MM_PROTOC>
+    <MM_PROTOBUF_INCLUDEDIR>$(MM_3RDPARTYPUBLIC)\google\protobuf-2.6.1_build\VS2019\include</MM_PROTOBUF_INCLUDEDIR>
+    <MM_PROTOBUF_LIBDIR>$(MM_3RDPARTYPUBLIC)\google\protobuf-2.6.1_build\VS2019\lib-$(Configuration)</MM_PROTOBUF_LIBDIR>
+    <MM_PROTOC>$(MM_3RDPARTYPUBLIC)\google\protobuf-2.6.1_build\VS2019\bin\protoc.exe</MM_PROTOC>
     <MM_BUILDDIR>$(SolutionDir)build</MM_BUILDDIR>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
2.6.1 is the last 2.x version of protobuf. It may be perfectly fine to switch to 3.x; this is to be investigated in the future.

This allows the DirectElectron device adapter to build.