### PR TITLE
Fix PicardStage timing out

### DIFF
--- a/DeviceAdapters/PicardStage/PicardStage.cpp
+++ b/DeviceAdapters/PicardStage/PicardStage.cpp
@@ -531,7 +531,7 @@ bool CPiTwister::IsContinuousFocusDrive() const
 // The Stage
 
 CPiStage::CPiStage()
-: serial_(DEFAULT_SERIAL_UNKNOWN), handle_(NULL)
+: serial_(DEFAULT_SERIAL_UNKNOWN), handle_(NULL), homing_(false)
 {
 	CreateProperty(g_Keyword_SerialNumber, FIXED_TO_STRING(DEFAULT_SERIAL_UNKNOWN), MM::Integer, false, new CPropertyAction (this, &CPiStage::OnSerialNumber), true);
 


### PR DESCRIPTION
Due the lack of default value for homing in the CPiStage, it is randomly considered as indefinitely busy when loading a configuration.
Adding the default value (false) should prevent random device timeouts at launch.