### PR TITLE
IDS_uEye additional features

### DIFF
--- a/DeviceAdapters/IDS_uEye/IDS_uEye.h
+++ b/DeviceAdapters/IDS_uEye/IDS_uEye.h
@@ -308,6 +308,7 @@ class CIDS_uEye : public CCameraBase<CIDS_uEye>
   int OnDropPixels(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnFractionOfPixelsToDropOrSaturate(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnGainMaster(MM::PropertyBase* pProp, MM::ActionType eAct);
+  int OnFlashMode(MM::PropertyBase* pProp, MM::ActionType eAct);
 
  private:
 

--- a/DeviceAdapters/IDS_uEye/IDS_uEye.h
+++ b/DeviceAdapters/IDS_uEye/IDS_uEye.h
@@ -319,6 +319,8 @@ class CIDS_uEye : public CCameraBase<CIDS_uEye>
   
   double dPhase_;
   ImgBuffer img_;
+  UEYEIMAGEINFO imgInfo_;
+
   bool busy_;
   bool stopOnOverflow_;
   bool initialized_;


### PR DESCRIPTION
Porting some additions we made to MM 1.4 IDS uEye device adapter to MM 2.0 code base.
https://github.com/biophotonics-bielefeld/ids-device-adapter

This PR is three commits, adding:

* User-settable camera ID, allows for running multiple IDS cameras in MM
* Option to control the 'flash output' (TTL-style exposure state output) of the cameras
* In-camera timestamp (and IO port state) gets added to metadata in sequence acquisitions

All of these *should* be backwards compatible with current configurations, as default values (camera id 1, flash off) match those used by the current adapter.
