### PR TITLE
Fix Diskovery C++ errors

### DIFF
--- a/DeviceAdapters/Diskovery/Diskovery.cpp
+++ b/DeviceAdapters/Diskovery/Diskovery.cpp
@@ -534,10 +534,11 @@ int DiskoveryStateDev::Initialize()
       os << "Preset-" << (i + firstPos_);
       // set default label
       const char* label = os.str().c_str();
-      if (devType_ == WF) 
+      if (devType_ == WF)
       {
          label = hub_->GetModel()->GetButtonWFLabel(i + firstPos_);
-      } else if (devType_ == IRIS) 
+      }
+      else if (devType_ == IRIS)
       {
          label = hub_->GetModel()->GetButtonIrisLabel(i + firstPos_);
          uint16_t val;
@@ -546,26 +547,30 @@ int DiskoveryStateDev::Initialize()
          ss << strLabel.substr(0, strLabel.size() - 1);
          ss >> val;
          irisValues_.push_back(val);
-      } else if (devType_ == FILTERW) 
+      }
+      else if (devType_ == FILTERW)
       {
          label = hub_->GetModel()->GetButtonFilterWLabel(i + firstPos_);
-      } else if (devType_ == FILTERT) 
+      }
+      else if (devType_ == FILTERT)
       {
          label = hub_->GetModel()->GetButtonFilterTLabel(i + firstPos_);
-      } else if (devType_ == SD) {
+      }
+      else if (devType_ == SD) {
          if (i == 0)
             label = "Disk Out";
-         else if (i == 1) 
+         else if (i == 1)
             label = "Exchange";
          else
             label = hub_->GetModel()->GetDiskLabel(i - 2 + firstPos_);
-      } else if (devType_ == TIRF) {
+      }
+      else if (devType_ == TIRF) {
          if (i == 0)
             label = "Disabled";
-         else 
+         else
          {
             std::ostringstream os;
-            os << "OM " << i; 
+            os << "OM " << i;
             label = os.str().c_str();;
          }
       }

--- a/DeviceAdapters/Diskovery/Diskovery.cpp
+++ b/DeviceAdapters/Diskovery/Diskovery.cpp
@@ -533,7 +533,7 @@ int DiskoveryStateDev::Initialize()
       ostringstream os;
       os << "Preset-" << (i + firstPos_);
       // set default label
-      const char* label = os.str().c_str();
+      std::string label = os.str();
       if (devType_ == WF)
       {
          label = hub_->GetModel()->GetButtonWFLabel(i + firstPos_);
@@ -543,8 +543,7 @@ int DiskoveryStateDev::Initialize()
          label = hub_->GetModel()->GetButtonIrisLabel(i + firstPos_);
          uint16_t val;
          std::stringstream ss;
-         std::string strLabel(label);
-         ss << strLabel.substr(0, strLabel.size() - 1);
+         ss << label.substr(0, label.size() - 1);
          ss >> val;
          irisValues_.push_back(val);
       }
@@ -571,10 +570,10 @@ int DiskoveryStateDev::Initialize()
          {
             std::ostringstream os;
             os << "OM " << i;
-            label = os.str().c_str();;
+            label = os.str();;
          }
       }
-      SetPositionLabel(i, label);
+      SetPositionLabel(i, label.c_str());
    }
 
    // State

--- a/DeviceAdapters/Diskovery/DiskoveryModel.cpp
+++ b/DeviceAdapters/Diskovery/DiskoveryModel.cpp
@@ -36,8 +36,9 @@ void DiskoveryModel::SetMotorRunningSD(const bool p)
 {
    MMThreadGuard g(lock_);
    motorRunningSD_ = p;
-   std::string s = static_cast<std::ostringstream*>( &(std::ostringstream() << p) )->str();
-   core_.OnPropertyChanged(hubDevice_, motorRunningProp_, s.c_str());
+   std::ostringstream oss;
+   oss << p;
+   core_.OnPropertyChanged(hubDevice_, motorRunningProp_, oss.str().c_str());
 }
 
 // Preset SD


### PR DESCRIPTION
Taking the address of a temporary value does not work.
Previous code could have been working by coincidence, but does not compile in modern C++.