### PR TITLE
Add links to api docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # mmCoreAndDevices
 The c++ code at the core of the Micro-Manager project.
 
+## API Docs
+[Main Page](https://micro-manager.org/apidoc/MMCore/latest/index.html)
+
+If you are using a scripting language to control a microscope through the CMMCore object
+then you are likely looking for the [CMMCore API](https://micro-manager.org/apidoc/MMCore/latest/class_c_m_m_core.html)
+
 ### Building on Windows
 The windows project uses the following properties which may be overridden in the MSBuild command line using the `/property:name=value` switch:
 


### PR DESCRIPTION
I always go here first to find these, then remember I have to go pymmcore in order to find a link. Nice to also have them here.

I added the second link because the main page is currently empty of content (ill open an issue about that) and CMMCore is probably the thing most people will be looking for.