### PR TITLE
Add async property callback to DemoCamera

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -1327,18 +1327,12 @@ int CDemoCamera::OnAsyncFollower(MM::PropertyBase* pProp, MM::ActionType eAct)
 int CDemoCamera::OnAsyncLeader(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet){
-      MMThreadGuard g(asyncLeaderLock_);
       pProp->Set(asyncLeader_.c_str());
    }
    if (eAct == MM::AfterSet)
    {
-      std::string asyncLeaderTmp;
-      {
-         MMThreadGuard g(asyncLeaderLock_);
-         pProp->Get(asyncLeader_);
-         asyncLeaderTmp = asyncLeader_;
-      }
-      fut_ = std::async(std::launch::async, &CDemoCamera::SlowPropUpdate, this, asyncLeaderTmp);
+      pProp->Get(asyncLeader_);
+      fut_ = std::async(std::launch::async, &CDemoCamera::SlowPropUpdate, this, asyncLeader_);
    }
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -1328,7 +1328,7 @@ int CDemoCamera::OnAsyncLeader(MM::PropertyBase* pProp, MM::ActionType eAct)
    if (eAct == MM::AfterSet)
    {
       pProp->Get(asyncLeader);
-      _fut = std::async(std::launch::async, &CDemoCamera::SlowPropUpdate, this);
+      fut_ = std::async(std::launch::async, &CDemoCamera::SlowPropUpdate, this);
    }
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -1307,12 +1307,14 @@ void CDemoCamera::SlowPropUpdate()
       // in a thread
       long delay; GetProperty("AsyncPropertyDelayMS", delay);
       CDeviceUtils::SleepMs(delay);
+      MMThreadGuard g(asyncFollowerLock_);
       asyncFollower = asyncLeader;
       OnPropertyChanged("AsyncPropertyFollower", asyncFollower.c_str());
    }
 
 int CDemoCamera::OnAsyncFollower(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
+   MMThreadGuard g(asyncFollowerLock_);
    if (eAct == MM::BeforeGet){
       pProp->Set(asyncFollower.c_str());
    }
@@ -1322,6 +1324,7 @@ int CDemoCamera::OnAsyncFollower(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CDemoCamera::OnAsyncLeader(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
+   MMThreadGuard g(asyncLeaderLock_);
    if (eAct == MM::BeforeGet){
       pProp->Set(asyncLeader.c_str());
    }

--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -1307,11 +1307,13 @@ void CDemoCamera::SlowPropUpdate()
       // in a thread
       long delay; GetProperty("AsyncPropertyDelayMS", delay);
       CDeviceUtils::SleepMs(delay);
+      std::string followerValue;
       {
          MMThreadGuard g(asyncFollowerLock_);
          asyncFollower_ = asyncLeader_;
+         followerValue = asyncFollower_;
       }
-      OnPropertyChanged("AsyncPropertyFollower", asyncFollower_.c_str());
+      OnPropertyChanged("AsyncPropertyFollower", followerValue.c_str());
    }
 
 int CDemoCamera::OnAsyncFollower(MM::PropertyBase* pProp, MM::ActionType eAct)

--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -1309,16 +1309,16 @@ void CDemoCamera::SlowPropUpdate()
       CDeviceUtils::SleepMs(delay);
       {
          MMThreadGuard g(asyncFollowerLock_);
-         asyncFollower = asyncLeader;
+         asyncFollower_ = asyncLeader_;
       }
-      OnPropertyChanged("AsyncPropertyFollower", asyncFollower.c_str());
+      OnPropertyChanged("AsyncPropertyFollower", asyncFollower_.c_str());
    }
 
 int CDemoCamera::OnAsyncFollower(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet){
       MMThreadGuard g(asyncFollowerLock_);
-      pProp->Set(asyncFollower.c_str());
+      pProp->Set(asyncFollower_.c_str());
    }
    // no AfterSet as this is a readonly property
    return DEVICE_OK;
@@ -1328,13 +1328,13 @@ int CDemoCamera::OnAsyncLeader(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet){
       MMThreadGuard g(asyncLeaderLock_);
-      pProp->Set(asyncLeader.c_str());
+      pProp->Set(asyncLeader_.c_str());
    }
    if (eAct == MM::AfterSet)
    {
       {
          MMThreadGuard g(asyncLeaderLock_);
-         pProp->Get(asyncLeader);
+         pProp->Get(asyncLeader_);
       }
       fut_ = std::async(std::launch::async, &CDemoCamera::SlowPropUpdate, this);
    }

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -178,7 +178,7 @@ public:
    int OnTestProperty(MM::PropertyBase* pProp, MM::ActionType eAct, long);
    int OnAsyncFollower(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnAsyncLeader(MM::PropertyBase* pProp, MM::ActionType eAct);
-   void SlowPropUpdate();
+   void SlowPropUpdate(std::string leaderValue);
    int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnBitDepth(MM::PropertyBase* pProp, MM::ActionType eAct);

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -176,8 +176,9 @@ public:
    // ----------------
    int OnMaxExposure(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnTestProperty(MM::PropertyBase* pProp, MM::ActionType eAct, long);
-   int OnAsyncTestProperty(MM::PropertyBase* pProp, MM::ActionType eAct);
-   void slowPropUpdate(MM::PropertyBase* pProp);
+   int OnAsyncFollower(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnAsyncLeader(MM::PropertyBase* pProp, MM::ActionType eAct);
+   void SlowPropUpdate();
    int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnBitDepth(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -268,6 +269,8 @@ private:
    std::vector<unsigned> multiROIHeights_;
 
 	double testProperty_[10];
+   std::string asyncLeader;
+   std::string asyncFollower;
    MMThreadLock imgPixelsLock_;
    friend class MySequenceThread;
    int nComponents_;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -272,6 +272,8 @@ private:
    std::string asyncLeader;
    std::string asyncFollower;
    MMThreadLock imgPixelsLock_;
+   MMThreadLock asyncLeaderLock_;
+   MMThreadLock asyncFollowerLock_;
    friend class MySequenceThread;
    int nComponents_;
    MySequenceThread * thd_;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -272,7 +272,6 @@ private:
    std::string asyncLeader_;
    std::string asyncFollower_;
    MMThreadLock imgPixelsLock_;
-   MMThreadLock asyncLeaderLock_;
    MMThreadLock asyncFollowerLock_;
    friend class MySequenceThread;
    int nComponents_;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -269,8 +269,8 @@ private:
    std::vector<unsigned> multiROIHeights_;
 
 	double testProperty_[10];
-   std::string asyncLeader;
-   std::string asyncFollower;
+   std::string asyncLeader_;
+   std::string asyncFollower_;
    MMThreadLock imgPixelsLock_;
    MMThreadLock asyncLeaderLock_;
    MMThreadLock asyncFollowerLock_;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -37,6 +37,7 @@
 #include <map>
 #include <algorithm>
 #include <stdint.h>
+#include <future>
 
 //////////////////////////////////////////////////////////////////////////////
 // Error codes
@@ -174,7 +175,9 @@ public:
    // action interface
    // ----------------
    int OnMaxExposure(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnTestProperty(MM::PropertyBase* pProp, MM::ActionType eAct, long);
+   int OnTestProperty(MM::PropertyBase* pProp, MM::ActionType eAct, long);
+   int OnAsyncTestProperty(MM::PropertyBase* pProp, MM::ActionType eAct);
+   void slowPropUpdate(MM::PropertyBase* pProp);
    int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnBitDepth(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -269,6 +272,7 @@ private:
    friend class MySequenceThread;
    int nComponents_;
    MySequenceThread * thd_;
+   std::future<void> _fut;
    int mode_;
    ImgManipulator* imgManpl_;
    double pcf_;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -275,7 +275,7 @@ private:
    friend class MySequenceThread;
    int nComponents_;
    MySequenceThread * thd_;
-   std::future<void> _fut;
+   std::future<void> fut_;
    int mode_;
    ImgManipulator* imgManpl_;
    double pcf_;


### PR DESCRIPTION
Allows for more comprehensive testing of downstream libraries.
It seems that it was necessary to make a follower and leader property
as with only a single property there is a callback fired as soon
the action returns, so added a second "Follower" property that
is set to the leaders value after a (configurable) delay.