### PR TITLE
add callbacks for device (un)loading

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -721,6 +721,11 @@ void CMMCore::loadDevice(const char* label, const char* moduleName, const char* 
 
    LOG_INFO(coreLogger_) << "Did load device " << deviceName <<
       " from " << moduleName << "; label = " << label;
+
+   if (externalCallback_ != 0) 
+   {
+      externalCallback_->onDeviceLoaded(label);
+   }
 }
 
 void CMMCore::assignDefaultRole(boost::shared_ptr<DeviceInstance> pDevice)
@@ -783,6 +788,11 @@ void CMMCore::unloadDevice(const char* label///< the name of the device to unloa
 {
    boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
+   if (externalCallback_ != 0) 
+   {
+      externalCallback_->onDeviceWillBeUnloaded(label);
+   }
+
    try {
       mm::DeviceModuleLockGuard guard(pDevice);
       LOG_DEBUG(coreLogger_) << "Will unload device " << label;
@@ -819,6 +829,10 @@ void CMMCore::unloadAllDevices() throw (CMMError)
       }
 
       LOG_DEBUG(coreLogger_) << "Will unload all devices";
+      if (externalCallback_ != 0) 
+      {
+         externalCallback_->onAllDevicesWillBeUnloaded();
+      }
       deviceManager_->UnloadAllDevices();
       LOG_INFO(coreLogger_) << "Did unload all devices";
 

--- a/MMCore/MMEventCallback.h
+++ b/MMCore/MMEventCallback.h
@@ -89,4 +89,18 @@ public:
       std::cout << "onSLMExposureChanged()" << name << " " << newExposure << "\n";
    }
 
+   virtual void onDeviceLoaded(const char* name)
+   {
+      std::cout << "onDeviceLoaded " << name;
+   }
+
+   virtual void onDeviceWillBeUnloaded(const char* name)
+   {
+      std::cout << "onDeviceWillBeUnloaded " << name;
+   }
+
+   virtual void onAllDevicesWillBeUnloaded()
+   {
+      std::cout << "onAllDevicesWillBeUnloaded ";
+   }
 };


### PR DESCRIPTION
Closes: https://github.com/micro-manager/mmCoreAndDevices/issues/149

~Couldn't test locally due to my struggles with pymmcore described here: https://github.com/micro-manager/pymmcore/issues/62~ tested locally, seems to be work as expected.

I have two main worries:

1. What happens if we send a `deviceWillBeUnloaded` callback and then device unload fails
2. Can devices ever be unloaded other than through core? LIke can they trigger their own unloading?