### PR TITLE
Repair C++ unit tests (Unix build)

### DIFF
--- a/DeviceAdapters/HamiltonMVP/unittest/Makefile.am
+++ b/DeviceAdapters/HamiltonMVP/unittest/Makefile.am
@@ -3,5 +3,5 @@ check_PROGRAMS = \
 AM_DEFAULT_SOURCE_EXT = .cpp
 AM_CPPFLAGS = $(GMOCK_CPPFLAGS) -I..
 AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS)
-LDADD = ../../../testing/libgmock.la $(MMDEVAPI_LIBADD)
+LDADD = ../../../../testing/libgmock.la $(MMDEVAPI_LIBADD)
 TESTS = $(check_PROGRAMS)

--- a/DeviceAdapters/UserDefinedSerial/unittest/Makefile.am
+++ b/DeviceAdapters/UserDefinedSerial/unittest/Makefile.am
@@ -4,6 +4,6 @@ check_PROGRAMS = \
 AM_DEFAULT_SOURCE_EXT = .cpp
 AM_CPPFLAGS = $(GMOCK_CPPFLAGS) -I.. $(BOOST_CPPFLAGS)
 AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS)
-LDADD = ../../../testing/libgmock.la $(MMDEVAPI_LIBADD) \
+LDADD = ../../../../testing/libgmock.la $(MMDEVAPI_LIBADD) \
 	../StringEscapes.lo
 TESTS = $(check_PROGRAMS)

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -11,7 +11,7 @@ AC_PROG_CC([cc gcc clang])
 AC_PROG_CXX([c++ g++ clang++])
 AX_CXX_COMPILE_STDCXX([14], [noext])
 
-MM_GMOCK([$srcdir/../testing/googletest], [\$(top_srcdir)/../testing/googletest])
+MM_GMOCK([$srcdir/../../testing/googletest], [\$(top_srcdir)/../../testing/googletest])
 AM_CONDITIONAL([BUILD_CPP_TESTS], [test "x$have_gmock" = xyes])
 
 # TODO: Following should decide whether adapters depending on BOOST get build

--- a/MMCore/unittest/Makefile.am
+++ b/MMCore/unittest/Makefile.am
@@ -4,5 +4,5 @@ check_PROGRAMS = \
 	Logger-Tests
 AM_DEFAULT_SOURCE_EXT = .cpp
 AM_CPPFLAGS = $(GMOCK_CPPFLAGS) -I.. $(BOOST_CPPFLAGS)
-LDADD = ../../testing/libgmock.la ../libMMCore.la
+LDADD = ../../../testing/libgmock.la ../libMMCore.la
 TESTS = $(check_PROGRAMS)

--- a/MMDevice/unittest/Makefile.am
+++ b/MMDevice/unittest/Makefile.am
@@ -2,5 +2,5 @@ check_PROGRAMS = \
 	FloatPropertyTruncation-Tests
 AM_DEFAULT_SOURCE_EXT = .cpp
 AM_CPPFLAGS = $(GMOCK_CPPFLAGS) -I.. $(BOOST_CPPFLAGS)
-LDADD = ../../testing/libgmock.la ../libMMDevice.la
+LDADD = ../../../testing/libgmock.la ../libMMDevice.la
 TESTS = $(check_PROGRAMS)


### PR DESCRIPTION
Probably was neglected when mmCoreAndDevices was split out.

This does not fully fix `make check` at the toplevel of `micro-manager`, due to unmaintained Java tests, but does fix `make check` in all C++ subdirectories of `mmCoreAndDevices`.