### PR TITLE
Eliminate deprecated std::auto_ptr

### DIFF
--- a/DeviceAdapters/QCam/QICamera.cpp
+++ b/DeviceAdapters/QCam/QICamera.cpp
@@ -668,7 +668,7 @@ int QICamera::Initialize()
    }
 
    // init the driver
-   m_driverAccess = auto_ptr<QIDriver::Access>(new QIDriver::Access);
+   m_driverAccess = unique_ptr<QIDriver::Access>(new QIDriver::Access);
    if (!*m_driverAccess) {
       REPORT_QERR(m_driverAccess->Status());
       return DEVICE_NATIVE_MODULE_FAILED;

--- a/DeviceAdapters/QCam/QICamera.h
+++ b/DeviceAdapters/QCam/QICamera.h
@@ -294,7 +294,7 @@ private:
 #endif
     int SendSettingsToCamera(QCam_Settings* settings);
 
-    std::auto_ptr<QIDriver::Access> m_driverAccess;
+    std::unique_ptr<QIDriver::Access> m_driverAccess;
 
     bool				m_isInitialized;    // Has the camera been initialized (setup)?
     QCam_Handle			m_camera;           // handle to the camera. Used by all QCam_* functions

--- a/DeviceAdapters/SerialManager/SerialManager.cpp
+++ b/DeviceAdapters/SerialManager/SerialManager.cpp
@@ -130,7 +130,7 @@ void SerialPortLister::ListPorts(std::vector<std::string> &availablePorts)
 #ifdef WIN32
 
    availablePorts.clear();
-   std::auto_ptr<B100000> allDeviceNames (new B100000());
+   std::unique_ptr<B100000> allDeviceNames (new B100000());
 
    // on Windows the serial ports are devices that begin with "COM"
    int ret = QueryDosDevice( 0, allDeviceNames->buffer, MaxBuf);

--- a/DeviceAdapters/SutterLambda/SutterLambda.cpp
+++ b/DeviceAdapters/SutterLambda/SutterLambda.cpp
@@ -1572,7 +1572,7 @@ bool ShutterOnTenDashTwo::Busy()
 {
 
    {
-      std::auto_ptr<MMThreadGuard> pg ( new MMThreadGuard(*(::gplocks_[port_])));
+      std::unique_ptr<MMThreadGuard> pg ( new MMThreadGuard(*(::gplocks_[port_])));
       if(::g_Busy[port_])
          return true;
    }

--- a/DeviceAdapters/TwainCamera/TwainDevice.cpp
+++ b/DeviceAdapters/TwainCamera/TwainDevice.cpp
@@ -804,7 +804,7 @@ public:
 
 		twCap.Cap = cap;
 		twCap.ConType = TWON_ONEVALUE;
-		std::auto_ptr<TW_ONEVALUE> handle( new TW_ONEVALUE);
+		std::unique_ptr<TW_ONEVALUE> handle( new TW_ONEVALUE);
 		
 		twCap.hContainer = handle.get();
 		//twCap.hContainer = (void *) malloc(sizeof(TW_ONEVALUE));
@@ -1260,7 +1260,7 @@ public:
 
 	//  cap.Cap         = Cap;
 	//  cap.ConType     = TWON_ONEVALUE;
-	//  std::auto_ptr<TW_ONEVALUEFIX32> pcontainer (new TW_ONEVALUEFIX32);
+	//  std::unique_ptr<TW_ONEVALUEFIX32> pcontainer (new TW_ONEVALUEFIX32);
 	//  cap.hContainer  = pcontainer.get();
 
 	//  pcontainer->ItemType = TWTY_FIX32;

--- a/DeviceAdapters/UserDefinedSerial/ResponseDetector.cpp
+++ b/DeviceAdapters/UserDefinedSerial/ResponseDetector.cpp
@@ -28,10 +28,10 @@
 #include <vector>
 
 
-std::auto_ptr<ResponseDetector>
+std::unique_ptr<ResponseDetector>
 ResponseDetector::NewByName(const std::string& name)
 {
-   std::auto_ptr<ResponseDetector> newDetector;
+   std::unique_ptr<ResponseDetector> newDetector;
 
    newDetector = IgnoringResponseDetector::NewByName(name);
    if (newDetector.get())
@@ -49,14 +49,14 @@ ResponseDetector::NewByName(const std::string& name)
    if (newDetector.get())
       return newDetector;
 
-   return std::auto_ptr<ResponseDetector>();
+   return std::unique_ptr<ResponseDetector>();
 }
 
 
-std::auto_ptr<ResponseDetector>
+std::unique_ptr<ResponseDetector>
 IgnoringResponseDetector::NewByName(const std::string& name)
 {
-   std::auto_ptr<ResponseDetector> ret;
+   std::unique_ptr<ResponseDetector> ret;
    if (name == g_PropValue_ResponseIgnore)
       ret.reset(new IgnoringResponseDetector());
    return ret;
@@ -86,10 +86,10 @@ IgnoringResponseDetector::RecvAlternative(MM::Core*, MM::Device*,
 }
 
 
-std::auto_ptr<ResponseDetector>
+std::unique_ptr<ResponseDetector>
 TerminatorResponseDetector::NewByName(const std::string& name)
 {
-   std::auto_ptr<ResponseDetector> ret;
+   std::unique_ptr<ResponseDetector> ret;
    if (name == g_PropValue_ResponseCRLFTerminated)
       ret.reset(new TerminatorResponseDetector("\r\n", "CRLF"));
    else if (name == g_PropValue_ResponseCRTerminated)
@@ -240,10 +240,10 @@ BinaryResponseDetector::Recv(MM::Core* core, MM::Device* device,
 }
 
 
-std::auto_ptr<ResponseDetector>
+std::unique_ptr<ResponseDetector>
 FixedLengthResponseDetector::NewByName(const std::string& name)
 {
-   std::auto_ptr<ResponseDetector> ret;
+   std::unique_ptr<ResponseDetector> ret;
    const std::string prefix(g_PropValuePrefix_ResponseFixedByteCount);
    if (name.substr(0, prefix.size()) == prefix)
    {
@@ -322,10 +322,10 @@ FixedLengthResponseDetector::RecvAlternative(MM::Core* core,
 }
 
 
-std::auto_ptr<ResponseDetector>
+std::unique_ptr<ResponseDetector>
 VariableLengthResponseDetector::NewByName(const std::string& name)
 {
-   std::auto_ptr<ResponseDetector> ret;
+   std::unique_ptr<ResponseDetector> ret;
    if (name == g_PropValue_ResponseVariableByteCount)
       ret.reset(new VariableLengthResponseDetector());
    return ret;

--- a/DeviceAdapters/UserDefinedSerial/ResponseDetector.h
+++ b/DeviceAdapters/UserDefinedSerial/ResponseDetector.h
@@ -42,7 +42,7 @@ public:
     * NewByName() functions to create the appropriate instance. If name is not
     * a known name, returns null.
     */
-   static std::auto_ptr<ResponseDetector> NewByName(const std::string& name);
+   static std::unique_ptr<ResponseDetector> NewByName(const std::string& name);
 
    virtual ~ResponseDetector() {}
 
@@ -78,7 +78,7 @@ public:
 class IgnoringResponseDetector : public ResponseDetector
 {
 public:
-   static std::auto_ptr<ResponseDetector> NewByName(const std::string& name);
+   static std::unique_ptr<ResponseDetector> NewByName(const std::string& name);
 
    virtual std::string GetMethodName() const;
    virtual int RecvExpected(MM::Core* core, MM::Device* device,
@@ -101,7 +101,7 @@ class TerminatorResponseDetector : public ResponseDetector
    std::string terminatorName_;
 
 public:
-   static std::auto_ptr<ResponseDetector> NewByName(const std::string& name);
+   static std::unique_ptr<ResponseDetector> NewByName(const std::string& name);
 
    virtual std::string GetMethodName() const;
    virtual int RecvExpected(MM::Core* core, MM::Device* device,
@@ -138,7 +138,7 @@ class FixedLengthResponseDetector : public BinaryResponseDetector
    size_t byteCount_;
 
 public:
-   static std::auto_ptr<ResponseDetector> NewByName(const std::string& name);
+   static std::unique_ptr<ResponseDetector> NewByName(const std::string& name);
 
    virtual std::string GetMethodName() const;
    virtual int RecvExpected(MM::Core* core, MM::Device* device,
@@ -160,7 +160,7 @@ private:
 class VariableLengthResponseDetector : public BinaryResponseDetector
 {
 public:
-   static std::auto_ptr<ResponseDetector> NewByName(const std::string& name);
+   static std::unique_ptr<ResponseDetector> NewByName(const std::string& name);
 
    virtual std::string GetMethodName() const;
    virtual int RecvExpected(MM::Core* core, MM::Device* device,

--- a/DeviceAdapters/UserDefinedSerial/UserDefinedSerial.h
+++ b/DeviceAdapters/UserDefinedSerial/UserDefinedSerial.h
@@ -104,7 +104,7 @@ private:
 
    bool binaryMode_;
    std::string asciiTerminator_;
-   std::auto_ptr<ResponseDetector> responseDetector_;
+   std::unique_ptr<ResponseDetector> responseDetector_;
 
    std::vector<char> initializeCommand_;
    std::vector<char> initializeResponse_;

--- a/DeviceAdapters/UserDefinedSerial/UserDefinedSerialImpl.h
+++ b/DeviceAdapters/UserDefinedSerial/UserDefinedSerialImpl.h
@@ -272,11 +272,11 @@ OnResponseDetectionMethod(MM::PropertyBase* pProp, MM::ActionType eAct)
    {
       std::string s;
       pProp->Get(s);
-      std::auto_ptr<ResponseDetector> newDetector =
+      std::unique_ptr<ResponseDetector> newDetector =
          ResponseDetector::NewByName(s);
       if (!newDetector.get())
          return DEVICE_INVALID_PROPERTY_VALUE;
-      responseDetector_ = newDetector;
+      responseDetector_ = std::move(newDetector);
    }
    return DEVICE_OK;
 }

--- a/MMCore/Error.cpp
+++ b/MMCore/Error.cpp
@@ -28,15 +28,13 @@
 
 CMMError::CMMError(const std::string& msg, Code code) :
    message_(msg),
-   code_(code),
-   underlying_(0)
+   code_(code)
 {}
 
 
 CMMError::CMMError(const char* msg, Code code) :
    message_(msg ? msg : "(null message)"),
-   code_(code),
-   underlying_(0)
+   code_(code)
 {}
 
 
@@ -70,8 +68,7 @@ CMMError::CMMError(const char* msg, const CMMError& underlyingError) :
 
 CMMError::CMMError(const CMMError& other) :
    message_(other.message_),
-   code_(other.code_),
-   underlying_(0)
+   code_(other.code_)
 {
    if (other.getUnderlyingError())
       underlying_.reset(new CMMError(*(other.getUnderlyingError())));

--- a/MMCore/Error.h
+++ b/MMCore/Error.h
@@ -153,12 +153,12 @@ public:
    virtual const CMMError* getUnderlyingError() const;
 
 private:
-   // Prohibit assignment.
+   // Prohibit assignment. (BUG: Assignment should behave like copy ctor.)
    CMMError& operator=(const CMMError&);
 
    std::string message_;
    Code code_;
-   std::auto_ptr<CMMError> underlying_;
+   std::unique_ptr<CMMError> underlying_;
 };
 
 #endif //_ERROR_H_


### PR DESCRIPTION
Replace with std::unique_ptr, and add std::move() where necessary (one
location). Remove redundant initialization to 0 (nullptr) where it
causes ambiguity.