### PR TITLE
DemoCamera: easier and more reliable way to calculate emulated exposure time. 

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -1133,9 +1133,10 @@ int CDemoCamera::InsertImage()
  * Do actual capturing
  * Called from inside the thread  
  */
-int CDemoCamera::RunSequenceOnThread(MM::MMTime startTime)
+int CDemoCamera::RunSequenceOnThread()
 {
    int ret=DEVICE_ERR;
+   MM::MMTime startTime = GetCurrentMMTime();
    
    // Trigger
    if (triggerDevice_.length() > 0) {
@@ -1154,8 +1155,7 @@ int CDemoCamera::RunSequenceOnThread(MM::MMTime startTime)
    }
 
    // Simulate exposure duration
-   double finishTime = exposure * (imageCounter_ + 1);
-   while ((GetCurrentMMTime() - startTime).getMsec() < finishTime)
+   while ((GetCurrentMMTime() - startTime).getMsec() < exposure)
    {
       CDeviceUtils::SleepMs(1);
    }
@@ -1251,7 +1251,7 @@ int MySequenceThread::svc(void) throw()
    {
       do
       {  
-         ret = camera_->RunSequenceOnThread(startTime_);
+         ret = camera_->RunSequenceOnThread();
       } while (DEVICE_OK == ret && !IsStopped() && imageCounter_++ < numImages_-1);
       if (IsStopped())
          camera_->LogMessage("SeqAcquisition interrupted by the user\n");

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -154,7 +154,7 @@ public:
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();
    int InsertImage();
-   int RunSequenceOnThread(MM::MMTime startTime);
+   int RunSequenceOnThread();
    bool IsCapturing();
    void OnThreadExiting() throw(); 
    double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}


### PR DESCRIPTION
 Avoids errors when changing exposure time midway a sequence. Addresses hang reported in https://github.com/micro-manager/micro-manager/issues/1409.  