### PR TITLE
Avoid forced set-branch when syncing to submodule

### DIFF
--- a/.github/workflows/sync-micro-manager-submodule.yml
+++ b/.github/workflows/sync-micro-manager-submodule.yml
@@ -30,7 +30,6 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git submodule init
-          git submodule set-branch -b ${{ github.ref_name }} -- mmCoreAndDevices
           git submodule update --remote -- mmCoreAndDevices
           git add mmCoreAndDevices
           if [ -z "$(git status --porcelain=v1 2>/dev/null)" ]; then


### PR DESCRIPTION
The line removed here led to an error in the case that the submodule is
already up to date, and the main repo had the submodule remote tracking
branch set to the default (i.e. branch not set in .gitmodules).

There should be no need to force-set the submodule branch; we should
just ensure that it is set correctly in any branch of the main repo.

None of this matters unless we use a long-lived branch with
semi-official status anyway (as we did with the 'vs2019' branches of
each repo).