### PR TITLE
Add `onStagePositionChanged` callback to TE2000 adapter

### DIFF
--- a/DeviceAdapters/NikonTE2000/NikonTE2000.cpp
+++ b/DeviceAdapters/NikonTE2000/NikonTE2000.cpp
@@ -1946,7 +1946,11 @@ bool PFSOffset::Busy()
 
 int PFSOffset::SetPositionUm(double pos)
 {
-   return SetProperty(MM::g_Keyword_Position, CDeviceUtils::ConvertToString(pos));
+   int ret =  SetProperty(MM::g_Keyword_Position, CDeviceUtils::ConvertToString(pos));
+   if (ret== DEVICE_OK){
+      OnStagePositionChanged(pos);
+   }
+   return ret;
 }
 
 int PFSOffset::GetPositionUm(double& pos)


### PR DESCRIPTION
I did this based on the Demo camera though not entirely sure that this is the right place to put this. Should something also go into the `setStagePositionSteps`? If this is correct I'll add the same thing to the PFS offset