### PR TITLE
Sutter lambda fix unix build

### DIFF
--- a/DeviceAdapters/SutterLambda/SutterLambda.cpp
+++ b/DeviceAdapters/SutterLambda/SutterLambda.cpp
@@ -1612,7 +1612,7 @@ bool ShutterOnTenDashTwo::Busy()
 {
 
    {
-      std::auto_ptr<MMThreadGuard> pg ( new MMThreadGuard(*(::gplocks_[port_])));
+      MMThreadGuard pg(*(::gplocks_[port_]));
       if(::g_Busy[port_])
          return true;
    }
@@ -2402,7 +2402,7 @@ bool ShutterOn721::Busy()
 {
 
    {
-      std::auto_ptr<MMThreadGuard> pg ( new MMThreadGuard(*(::gplocks_[port_])));
+      MMThreadGuard pg(*(::gplocks_[port_]));
       if(::g_Busy[port_])
          return true;
    }

--- a/DeviceAdapters/SutterLambda/SutterLambda.cpp
+++ b/DeviceAdapters/SutterLambda/SutterLambda.cpp
@@ -121,12 +121,6 @@ MODULE_API MM::Device* CreateDevice(const char* deviceName)
 {
    if (deviceName == 0)
       return 0;
-   if (strcmp(deviceName, g_ShutterLambda721Name) == 0)
-   {
-      // create Shutter
-      ShutterOn721* pShutter = new ShutterOn721(g_ShutterLambda721Name, 0);
-      return pShutter;
-   }
    if (strcmp(deviceName, g_WheelAName) == 0)
    {
       // create Wheel A
@@ -163,14 +157,12 @@ MODULE_API MM::Device* CreateDevice(const char* deviceName)
       Shutter* pShutter = new Shutter(g_ShutterBName, 1);
       return pShutter;
    }
-#ifdef DefineSutter721
    else if (strcmp(deviceName, g_ShutterLambda721Name) == 0)
    {
-      // create Shutter 721
-      ShutterOn721* pShutter = new ShutterOn721(g_ShutterLambda721Name, 3);
+      // create Shutter
+      ShutterOn721* pShutter = new ShutterOn721(g_ShutterLambda721Name, 0);
       return pShutter;
    }
-#endif
 #ifdef DefineShutterOnTenDashTwo
    else if (strcmp(deviceName, g_ShutterAName10dash2) == 0)
    {

--- a/DeviceAdapters/SutterLambda/SutterLambda.cpp
+++ b/DeviceAdapters/SutterLambda/SutterLambda.cpp
@@ -45,11 +45,9 @@ const char* g_WheelCName = "Wheel-C";
 const char* g_ShutterAName = "Shutter-A";
 const char* g_ShutterBName = "Shutter-B";
 
-#ifdef DefineShutterOnTenDashTwo
 const char* g_ShutterAName10dash2 = "Shutter-A 10-2";
 const char* g_ShutterBName10dash2 = "Shutter-B 10-2";
 const double g_busyTimeoutMs = 500;
-#endif
 
 const char* g_DG4WheelName = "Wheel-DG4";
 const char* g_DG4ShutterName = "Shutter-DG4";
@@ -109,10 +107,8 @@ MODULE_API void InitializeModuleData()
    RegisterDevice(g_WheelCName, MM::StateDevice, "Lambda 10 wheel C (10-3 only)");
    RegisterDevice(g_ShutterAName, MM::ShutterDevice, "Lambda 10 shutter A");
    RegisterDevice(g_ShutterBName, MM::ShutterDevice, "Lambda 10 shutter B");
-#ifdef DefineShutterOnTenDashTwo
    RegisterDevice(g_ShutterAName10dash2, MM::ShutterDevice, "Lambda 10-2 shutter A");
    RegisterDevice(g_ShutterBName10dash2, MM::ShutterDevice, "Lambda 10-2 shutter B");
-#endif
    RegisterDevice(g_DG4ShutterName, MM::ShutterDevice, "DG4 shutter");
    RegisterDevice(g_DG4WheelName, MM::StateDevice, "DG4 filter changer");
 }
@@ -163,7 +159,6 @@ MODULE_API MM::Device* CreateDevice(const char* deviceName)
       ShutterOn721* pShutter = new ShutterOn721(g_ShutterLambda721Name, 0);
       return pShutter;
    }
-#ifdef DefineShutterOnTenDashTwo
    else if (strcmp(deviceName, g_ShutterAName10dash2) == 0)
    {
       // create Shutter A
@@ -176,7 +171,6 @@ MODULE_API MM::Device* CreateDevice(const char* deviceName)
       ShutterOnTenDashTwo* pShutter = new ShutterOnTenDashTwo(g_ShutterBName10dash2, 1);
       return pShutter;
    }
-#endif
    else if (strcmp(deviceName, g_DG4ShutterName) == 0)
    {
       // create DG4 shutter
@@ -1360,7 +1354,6 @@ int Shutter::OnND(MM::PropertyBase* pProp, MM::ActionType eAct)
 ///////////////////////////////////////////////////////////////////////////////
 // Shutter implementation
 // ~~~~~~~~~~~~~~~~~~~~~~~
-#ifdef DefineShutterOnTenDashTwo
 ShutterOnTenDashTwo::ShutterOnTenDashTwo(const char* name, int id) :
 initialized_(false), 
 id_(id), 
@@ -1726,7 +1719,6 @@ int ShutterOnTenDashTwo::OnMode(MM::PropertyBase* pProp, MM::ActionType eAct)
    return DEVICE_OK;
 }
 
-#endif
 
 ShutterOn721::ShutterOn721(const char* name, int id) :
 initialized_(false), 

--- a/DeviceAdapters/SutterLambda/SutterLambda.h
+++ b/DeviceAdapters/SutterLambda/SutterLambda.h
@@ -160,7 +160,7 @@ private:
    Shutter& operator=(Shutter& /*rhs*/) {assert(false); return *this;}
 };
 
-#ifdef DefineShutterOnTenDashTwo 
+
 class ShutterOnTenDashTwo : public CShutterBase<ShutterOnTenDashTwo>
 {
 public:
@@ -198,7 +198,6 @@ private:
    ShutterOnTenDashTwo& operator=(ShutterOnTenDashTwo& /*rhs*/) {assert(false); return *this;}
 };
 
-#endif
 
 class ShutterOn721 : public CShutterBase<ShutterOn721>
 {

--- a/DeviceAdapters/SutterLambda/SutterLambda.vcxproj
+++ b/DeviceAdapters/SutterLambda/SutterLambda.vcxproj
@@ -55,7 +55,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;DefineShutterOnTenDashTwo;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>
@@ -75,7 +75,7 @@
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;DefineShutterOnTenDashTwo;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>
       </PrecompiledHeader>


### PR DESCRIPTION
Fix Unix build following #193.

@dscbiggs Could you take a look at my first commit ('Remove redundant/dead code') and make sure it is correct? I'm not sure what the role of the second parameter (`id`) to the `ShutterOn721` constructor is. There were lines setting `id` to `0` and `3`; I removed the one using `3` because it never would have been reached.

(Also, just to check, is it correct to pass `3` as the `id` to the `Wheel` constructor in the case of `g_WheelLambda721Name`?)