### PR TITLE
The Imaging Source cameras

### DIFF
--- a/DeviceAdapters/TISCam/TIScamera.cpp
+++ b/DeviceAdapters/TISCam/TIScamera.cpp
@@ -417,7 +417,7 @@ int CTIScamera::Initialize()
    pAct = new CPropertyAction (this, &CTIScamera::OnFlipVertical);
    if (pRotateFlipFilter == NULL)
    {
-      nRet = CreateProperty(g_FlipV, "n/a", MM::String, false, pAct);
+      nRet = CreateProperty(g_FlipV, "n/a", MM::String, true);
       if (nRet != DEVICE_OK) return nRet;
    }
    else
@@ -426,6 +426,23 @@ int CTIScamera::Initialize()
       if (nRet != DEVICE_OK) return nRet;
       AddAllowedValue(g_FlipV,g_On);
       AddAllowedValue(g_FlipV,g_Off);
+   }
+
+   if (pDeNoiseFilter == NULL)
+   {
+      nRet = CreateProperty(g_Keyword_DeNoise, "n/a", MM::String, true);
+      if (nRet != DEVICE_OK) return nRet;
+   }
+   else
+   {
+      pAct = new CPropertyAction(this, &CTIScamera::OnDeNoise);
+      nRet = CreateProperty(g_Keyword_DeNoise, "0", MM::Integer, false, pAct);
+      if (nRet != DEVICE_OK) return nRet;
+      AddAllowedValue(g_Keyword_DeNoise, "0");
+      AddAllowedValue(g_Keyword_DeNoise, "1");
+      AddAllowedValue(g_Keyword_DeNoise, "2");
+      AddAllowedValue(g_Keyword_DeNoise, "3");
+      AddAllowedValue(g_Keyword_DeNoise, "4");
    }
 
    pAct = new CPropertyAction (this, &CTIScamera::OnRotate);
@@ -615,13 +632,8 @@ int CTIScamera::SetupProperties()
    bool bResult = pGrabber->setSinkType(pSink);
    assert (bResult == true);
 
-
-
    //we use snap mode
    pSink->setSnapMode(true);
-
-
-
 
    //update property Serial Number
    LARGE_INTEGER iSerNum;
@@ -780,7 +792,6 @@ int CTIScamera::SetupProperties()
    // Retrieve the output type and dimension of the handler sink.
    // The dimension of the sink could be different from the VideoFormat, when
    // you use filters.
-
    bResult = pSink->isAttached();
    if (!bResult) RunTimeDebugMessage("pSink->isAttached() is FALSE");
 
@@ -853,34 +864,10 @@ int CTIScamera::SetupProperties()
    // DeNoise
    if( pDeNoiseFilter != NULL )
    {	
-      string buf;
-      pGrabber->stopLive();
-      pDeNoiseFilter->getParameter( "DeNoise Level", DeNoiseLevel_ );
-   }
-
-   if(!HasProperty(g_Keyword_DeNoise))
-   {
-      CPropertyAction *pAct = new CPropertyAction (this, &CTIScamera::OnDeNoise);
-      nRet = CreateProperty(g_Keyword_DeNoise, "n/a", MM::Integer, false, pAct);
-      assert(nRet == DEVICE_OK);
-   }
-   else
-   {
-      nRet = SetProperty(g_Keyword_DeNoise, "1");   
+      nRet = SetProperty(g_Keyword_DeNoise, "0");
       if (nRet != DEVICE_OK)
          return nRet;
    }
-
-   vector<string> DeNoiseValues;
-   DeNoiseValues.push_back("0");
-   DeNoiseValues.push_back("1");
-   DeNoiseValues.push_back("2");
-   DeNoiseValues.push_back("3");
-   DeNoiseValues.push_back("4");
-   LogMessage("Setting some DeNoise settings", true);
-   SetAllowedValues(g_Keyword_DeNoise, DeNoiseValues);
-
-
 
 
    initialized_ = true;

--- a/DeviceAdapters/TISCam/TIScamera.cpp
+++ b/DeviceAdapters/TISCam/TIScamera.cpp
@@ -472,12 +472,6 @@ int CTIScamera::Initialize()
    nRet = CreateProperty(g_Keyword_Gain, CDeviceUtils::ConvertToString(Gain_), MM::Integer, false, pAct);
    if (nRet != DEVICE_OK) return nRet;
 
-   pAct = new CPropertyAction (this, &CTIScamera::OnGainAuto);
-   nRet = CreateProperty(g_Keyword_Gain_Auto, "n/a", MM::String, false, pAct);
-   if (nRet != DEVICE_OK) return nRet;
-   AddAllowedValue(g_Keyword_Gain_Auto,g_On);
-   AddAllowedValue(g_Keyword_Gain_Auto,g_Off);
-
    pAct = new CPropertyAction (this, &CTIScamera::OnWhiteBalance);
    nRet = CreateProperty(g_Keyword_WhiteBalance, CDeviceUtils::ConvertToString(WhiteBalance_), MM::Integer, false, pAct);
    if (nRet != DEVICE_OK) return nRet;
@@ -677,7 +671,6 @@ int CTIScamera::SetupProperties()
       }
    }
 
-
    if (!m_pSimpleProperties->isAvailable(VCDID_Brightness))
       SetProperty(g_Keyword_Brightness, "n/a");
    else
@@ -714,6 +707,20 @@ int CTIScamera::SetupProperties()
       }
    }
 
+   if (!m_pSimpleProperties->isAutoAvailable(VCDID_Gain))
+   {
+      nRet = CreateProperty(g_Keyword_Gain_Auto, "n/a", MM::String, true);
+      if (nRet != DEVICE_OK) return nRet;
+   }
+   else
+   {
+      CPropertyAction* pAct = new CPropertyAction(this, &CTIScamera::OnGainAuto);
+      nRet = CreateProperty(g_Keyword_Gain_Auto, g_Off, MM::String, false, pAct);
+      if (nRet != DEVICE_OK) return nRet;
+      AddAllowedValue(g_Keyword_Gain_Auto, g_On);
+      AddAllowedValue(g_Keyword_Gain_Auto, g_Off);
+      SetProperty(g_Keyword_Gain_Auto, g_Off);
+   }
 
    if(!m_pSimpleProperties->isAvailable(VCDID_WhiteBalance))
       SetProperty(g_Keyword_WhiteBalance, "n/a");
@@ -738,11 +745,12 @@ int CTIScamera::SetupProperties()
             SetProperty(g_Keyword_WhiteBalance_Auto,g_Off);
          }
       }
-      else SetProperty(g_Keyword_WhiteBalance_Auto, "n/a");
+      else
+      {
+         SetProperty(g_Keyword_WhiteBalance_Auto, "n/a");
+      }
 
-
-
-	  // Initialize the slider for whitebalance blue
+	   // Initialize the slider for whitebalance blue
       if( !m_pSimpleProperties->isAvailable( VCDElement_WhiteBalanceBlue ) )
       {
          SetProperty(g_Keyword_WhiteBalanceBlue, "n/a");
@@ -757,7 +765,7 @@ int CTIScamera::SetupProperties()
       }
  
       // Initialize the slider for whitebalance green
-      if( !m_pSimpleProperties->isAvailable( VCDElement_WhiteBalanceGreen ) )
+      if ( !m_pSimpleProperties->isAvailable( VCDElement_WhiteBalanceGreen ) )
       {
          SetProperty(g_Keyword_WhiteBalanceGreen, "n/a");
       }
@@ -802,7 +810,7 @@ int CTIScamera::SetupProperties()
    //sink oriented data size
    lCCD_Width         = info.dim.cx;
    lCCD_Height        = info.dim.cy;
-   uiCCD_BitsPerPixel = info.getBitsPerPixel();
+   uiCCD_BitsPerPixel = (unsigned int) info.getBitsPerPixel();
 
    roiX_ = 0;
    roiY_ = 0;
@@ -868,7 +876,6 @@ int CTIScamera::SetupProperties()
       if (nRet != DEVICE_OK)
          return nRet;
    }
-
 
    initialized_ = true;
 
@@ -1098,7 +1105,7 @@ unsigned CTIScamera::GetBitDepth() const
   {
 	DShowLib::FrameTypeInfo fti;
 	pSink->getOutputFrameType(fti);
-	bitDepth = fti.getBitsPerPixel();
+	bitDepth = (unsigned int) fti.getBitsPerPixel();
 	const tColorformatEnum cf = fti.getColorformat();
 	if      (cf == eRGB32) bitDepth = bitDepth / 4;
 	else if (cf == eRGB24) bitDepth = bitDepth / 3;
@@ -1481,7 +1488,7 @@ int CTIScamera::ResizeImageBuffer()
    //sink oriented data size
    lCCD_Width         = info.dim.cx;
    lCCD_Height        = info.dim.cy;
-   uiCCD_BitsPerPixel = info.getBitsPerPixel();
+   uiCCD_BitsPerPixel = (unsigned int) info.getBitsPerPixel();
 
    int byteDepth = uiCCD_BitsPerPixel / 8;
 

--- a/DeviceAdapters/TISCam/TIScamera.h
+++ b/DeviceAdapters/TISCam/TIScamera.h
@@ -157,20 +157,19 @@ unsigned GetBitDepth() const;
 	int DisableTrigger();
 
 private:
+   static CTIScamera* instance_;
+   static unsigned refCount_;
 
-    static CTIScamera* instance_;
-    static unsigned refCount_;
-
-    bool initialized_;
+   bool initialized_;
 
 	long lCCD_Width, lCCD_Height;
 	unsigned int uiCCD_BitsPerPixel;
 	bool busy_;
 
-    double currentExpMS_; // value used by camera
+   double currentExpMS_; // value used by camera
 
 	bool sequenceRunning_;
-    bool sequencePaused_;
+   bool sequencePaused_;
 	double FPS_;
 	long Brightness_;
 	long Rotation_;
@@ -180,7 +179,6 @@ private:
 	long WhiteBalanceGreen_;
 	long Gain_;
 	long DeNoiseLevel_;
-
 
 	ImgBuffer img_;
 


### PR DESCRIPTION
More sensible handling of DeNoise and Autogain properties.  

However, there is some strange stuff going with camera selection.  Apparently, initialization partly
happens in the SetupProperties fundtion so that selection of other cameras is possible after the 
initialize function.  This currently does not work and causes MM to hang.   As long as nobody tries to 
use multiple TIS cameras at the same time (and not use those properties that cause MM to hange)
all should be good.