### PR TITLE
Utilities: Fixed Makefile to build all sources

### DIFF
--- a/DeviceAdapters/Utilities/Makefile.am
+++ b/DeviceAdapters/Utilities/Makefile.am
@@ -1,9 +1,26 @@
 
 AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS)
 deviceadapter_LTLIBRARIES = libmmgr_dal_Utilities.la
-libmmgr_dal_Utilities_la_SOURCES = Utilities.h Utilities.cpp
+libmmgr_dal_Utilities_la_SOURCES = \
+        AutoFocusStage.cpp \
+        ComboXYStage.cpp \
+        DAGalvo.cpp \
+        DAMonochromator.cpp \
+        DAShutter.cpp \
+        DATTLStateDevice.cpp \
+        DAXYStage.cpp \
+        DAZStage.cpp \
+        MultiCamera.cpp \
+        MultiDAStateDevice.cpp \
+        MultiShutter.cpp \
+        MultiStage.cpp \
+        SerialDTRShutter.cpp \
+        SingleAxisStage.cpp \
+        StateDeviceShutter.cpp \
+        Utilities.cpp \
+        Utilities.h
 libmmgr_dal_Utilities_la_LIBADD = $(MMDEVAPI_LIBADD)
 libmmgr_dal_Utilities_la_LDFLAGS = $(MMDEVAPI_LDFLAGS)
 
-EXTRA_DIST = DAZStage.vcproj license.txt
+EXTRA_DIST = Utilities.vcproj Utilities.vcproj.filters license.txt
 


### PR DESCRIPTION
Without this fix the adapter builds without errors but fails to load at runtime due to undefined symbols:

```Failed to load device "Multi Camera" from adapter module "Utilities" [ Failed to load device adapter "Utilities" [ Failed to load module "/home/tom/uM/build-mm2-ImageJ/ImageJ/libmmgr_dal_Utilities.so.0" [ /home/tom/uM/build-mm2-ImageJ/ImageJ/libmmgr_dal_Utilities.so.0: undefined symbol: _ZN18MultiDAStateDeviceC1Ev```

All undefined symbols were related to local sources not taken to build, filtered out with:
```objdump -a -x libmmgr_dal_Utilities.so.0 | grep -e "0000[^a-zA-Z]*\*UND\*"```




