### PR TITLE
Dragonfly: Fix filter wheel position description

### DIFF
--- a/DeviceAdapters/Dragonfly/FilterWheelProperty.cpp
+++ b/DeviceAdapters/Dragonfly/FilterWheelProperty.cpp
@@ -89,6 +89,7 @@ bool CFilterWheelProperty::RetrievePositionsFromFilterConfig()
           }
           else
           {
+            vDescription[vStringLength - 1] = 0;
             vPositionName += FilterWheelDevice_->ParseDescription( vDescription );
           }
           PositionNames_[vIndex] = vPositionName;

--- a/DeviceAdapters/Dragonfly/PositionComponentHelper.cpp
+++ b/DeviceAdapters/Dragonfly/PositionComponentHelper.cpp
@@ -32,6 +32,7 @@ bool CPositionComponentHelper::RetrievePositionsFromFilterSet( IFilterSet* Filte
         }
         else
         {
+          vDescription[vStringLength - 1] = 0;
           vPositionName += vDescription;
         }
         PositionNames[vIndex] = vPositionName;


### PR DESCRIPTION
If a filter wheel position string length is bigger or equal to the
buffer it is going to be stored in, it is missing a terminal 0.
This leads to scrambled text stored in the property value preventing
the use of this value.