### PR TITLE
add light sheet rolling shutter options

### DIFF
--- a/camera_triggering_API.md
+++ b/camera_triggering_API.md
@@ -57,14 +57,17 @@ int SendBurstEndTrigger();
 
 
 
-//TODO light sheet/global shutter API calls
+// Rolling shutter/Lightsheet mode
+double GetRollingShutterLineOffset();
+void setRollingShutterLineOffset(double offset_us) throw (CMMError);
 
+int GetRollingShutterActiveLines();
+void setRollingShutterActiveLines(int numLines) throw (CMMError);
 ```
 
 
 ## New calls in MMCore
 A set of API calls in MMCore will provide access to this high-level API. Following MM convention, these will be essentially a 1to1 access of camera API methods, so they are omitted for now.
-
 
 
 ## Backwards compatibility


### PR DESCRIPTION
@jondaniels @bls337 Are these methods sufficient for light sheet mode? My understanding is that if you know the exposure, along with these two params, everything you need can be calculated.

I used "Line offset" because I think the "line time" that some camera manufacturers use is a bit confusing--I would think "line time" means the full line, rather than the delay between lines. But we could use different terminology if you think it's better.

Also, I use "rolling shutter" instead of "light sheet", because I think that is a more general way to describe these features, and it would be easier for a light sheet person to understand they need to manipulate "rolling shutter" than a non-light sheet person to understand they need to manipulate "light sheet" mode. And I have  bit of a bias towards on this because some of my colleagues have [used rolling shutter](https://www.semanticscholar.org/paper/Video-from-Stills%3A-Lensless-Imaging-with-Rolling-Antipa-Oare/7cee52f33e3aa27af79de98bfd65740e08f0e29a) to do interesting things that it wasn't intended for 