### PR TITLE
ASIStage: Add read-only property "AxisLetter" to CRISP

### DIFF
--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -79,6 +79,9 @@ int CRISP::Initialize()
 		return ret;
 	}
 
+	// Read-only "AxisLetter" property, axis_ is set using a pre-init property named "Axis".
+	CreateProperty("AxisLetter", axis_.c_str(), MM::String, true);
+	
 	CPropertyAction* pAct = new CPropertyAction(this, &CRISP::OnVersion);
 	CreateProperty("Version", "", MM::String, true, pAct);
 


### PR DESCRIPTION
Adds a read-only property that reads the member variable "axis_", which is set using  a pre-init property named "Axis". This means that you can use "AxisLetter" in both the ASIStage/ASITiger device adapters now.