### PR TITLE
Fix Zeiss uninitialized memory issue

### DIFF
--- a/DeviceAdapters/ZeissCAN29/ZeissCAN29.cpp
+++ b/DeviceAdapters/ZeissCAN29/ZeissCAN29.cpp
@@ -1996,7 +1996,7 @@ int XYStage::OnTrajectoryVelocity(MM::PropertyBase* pProp, MM::ActionType eAct)
    } else if (eAct == MM::AfterSet) {
       double tmp;
       pProp->Get(tmp);
-      ZeissLong velocity = tmp * 1000.0;
+      auto velocity = ZeissLong(tmp * 1000.0);
       int ret = ZeissAxis::SetTrajectoryVelocity(*this, *GetCoreCallback(), g_StageXAxis, velocity);
       if (ret != DEVICE_OK)
          return ret;
@@ -2019,7 +2019,7 @@ int XYStage::OnTrajectoryAcceleration(MM::PropertyBase* pProp, MM::ActionType eA
    } else if (eAct == MM::AfterSet) {
       double tmp;
       pProp->Get(tmp);
-      ZeissLong accel = (tmp * 1000.0);
+      auto accel = ZeissLong(tmp * 1000.0);
       int ret = ZeissAxis::SetTrajectoryAcceleration(*this, *GetCoreCallback(), g_StageXAxis, accel);
       if (ret != DEVICE_OK)
          return ret;

--- a/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
+++ b/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
@@ -53,6 +53,7 @@
 #include "MMDevice.h"
 #include "DeviceBase.h"
 #include "DeviceThreads.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>
@@ -62,19 +63,19 @@
 // Typedefs for the following Zeiss datatypes:
 // TEXT (max 20 ascii characters, not null terminated)
 // BYTE - 1 byte
-typedef char ZeissByte;
+typedef int8_t ZeissByte;
 // UBYTE - 1 unsigned byte
-typedef unsigned char ZeissUByte;
+typedef uint8_t ZeissUByte;
 #define ZeissByteSize 1
 // SHORT - 2 Byte Motorola format
-typedef short ZeissShort;
+typedef int16_t ZeissShort;
 // USHORT - 2 Byte Motorola format, unsigned
-typedef unsigned short ZeissUShort;
+typedef uint16_t ZeissUShort;
 #define ZeissShortSize 2
 // LONG - 4 Byte Motorola format
-typedef int  ZeissLong;
+typedef int32_t  ZeissLong;
 // ULONG - 4 Byte Motorola format, unsigned
-typedef unsigned int  ZeissULong;
+typedef uint32_t  ZeissULong;
 #define ZeissLongSize 4
 // FLOAT - 4 Byte Float Motorola format
 typedef float  ZeissFloat;
@@ -540,7 +541,7 @@ class ZeissDevice
       virtual ~ZeissDevice();
 
       int GetPosition(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong& position);
-      int SetPosition(MM::Device& device, MM::Core& core, ZeissUByte commandGroup, ZeissUByte devId, int position);
+      int SetPosition(MM::Device& device, MM::Core& core, ZeissUByte commandGroup, ZeissUByte devId, ZeissLong position);
       int GetStatus(MM::Device& device, MM::Core& core, ZeissUByte commandGroup, ZeissUByte devId);
       int GetTargetPosition(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong& position);
       int GetMaxPosition(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong& position);
@@ -559,7 +560,7 @@ class ZeissChanger : public ZeissDevice
       ZeissChanger();
       ~ZeissChanger();
 
-      int SetPosition(MM::Device& device, MM::Core& core, ZeissUByte devId, int position);
+      int SetPosition(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong position);
       ZeissUByte devId_;
 
    private:
@@ -572,7 +573,7 @@ class ZeissServo : public ZeissDevice
       ZeissServo();
       ~ZeissServo();
 
-      int SetPosition(MM::Device& device, MM::Core& core, ZeissUByte devId, int position);
+      int SetPosition(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong position);
       ZeissUByte devId_;
 
    private:
@@ -586,13 +587,13 @@ class ZeissAxis : public ZeissDevice
       ZeissAxis();
       ~ZeissAxis();
 
-      int SetPosition(MM::Device& device, MM::Core& core, ZeissUByte devId, long position, ZeissByte moveMode);
-      int SetRelativePosition(MM::Device& device, MM::Core& core, ZeissUByte devId, long increment, ZeissByte moveMode);
+      int SetPosition(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong position, ZeissByte moveMode);
+      int SetRelativePosition(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong increment, ZeissByte moveMode);
       int FindHardwareStop(MM::Device& device, MM::Core& core, ZeissUByte devId, HardwareStops stop);
       int StopMove(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissByte moveMode);
       int HasTrajectoryVelocity(MM::Device& device, MM::Core& core, ZeissUByte devId, bool& hasTV);
-      int SetTrajectoryVelocity(MM::Device& device, MM::Core& core, ZeissUByte devId, long velocity);
-      int SetTrajectoryAcceleration(MM::Device& device, MM::Core& core, ZeissUByte devId, long acceleration);
+      int SetTrajectoryVelocity(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong velocity);
+      int SetTrajectoryAcceleration(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong acceleration);
       int GetTrajectoryVelocity(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong& velocity);
       int GetTrajectoryAcceleration(MM::Device& device, MM::Core& core, ZeissUByte devId, ZeissLong& acceleration);
 


### PR DESCRIPTION

I was having an issue on an x64 Linux computer
with incorrect absolute XY stage positions being read. After some investigation I tracked it down to it accessing uninitialized memory due to an invalid cast.

ZeissLong is only 4 bytes, but on (most?) 64-bit machines a long is
8 bytes. There were parts of the code that were casting a long
to a ZeissLong leading to undefined values for values that were
being read.

I tried to clean it up in a few positions, although the specific bug that I was facing stemmed from XYStage::GetPositionSteps: 

https://github.com/micro-manager/mmCoreAndDevices/compare/micro-manager:300caa5...wxs:c5a8242#diff-f2bd135a3e8514850d9899bb795dc4dbd273a9bb1ef492871da41077b33cd027R1891

I also changed some typedefs to make the integer sizes explicit, as this could be an issue on different architectures.

Side comment: `ZeissCan29.cpp` and `.h` seem to use Windows line endings, but everything else seems to use Unix line endings. I left the line endings the same to make it easier to read the diffs, but seems like this should be made consistent?