### PR TITLE
ASITIger: use faster serial commands for CRISP

### DIFF
--- a/DeviceAdapters/ASITiger/ASICRISP.h
+++ b/DeviceAdapters/ASITiger/ASICRISP.h
@@ -64,22 +64,24 @@ public:
    int OnLoopGainMultiplier(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnNumAvg            (MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnSNR               (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnDitherError       (MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnDitherError	   (MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnLogAmpAGC         (MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnNumSkips          (MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnInFocusRange      (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnSum			   (MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnSum		       (MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnOffset			   (MM::PropertyBase* pProp, MM::ActionType eAct);
+   // For backwards compatibility with Tiger firmware < 3.40
+   int OnSumLegacy(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnDitherErrorLegacy(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
    string axisLetter_;
    string focusState_;
    long waitAfterLock_;
-   long sum_;
 
    int UpdateFocusState();
    int SetFocusState(string focusState);
    int ForceSetFocusState(string focusState);
 };
 
-#endif //_ASICRISP_H_
+#endif // end _ASICRISP_H_


### PR DESCRIPTION
When using Tiger firmware >= 3.40, CRISP will now use LK Y? and LK T? instead of EXTRA X? to query the "Dither Error" and "Sum" respectively.

This also gets rid of the weird dependency between "Dither Error" and "Sum" where you would need to call dither error first to the set the sum value, and then call the get sum method in older firmware. It may be slightly slower, but the values can be queried independently now.