### PR TITLE
Retire Boost.Phoenix

### DIFF
--- a/MMCore/Semaphore.cpp
+++ b/MMCore/Semaphore.cpp
@@ -24,9 +24,6 @@
 #include "Semaphore.h"
 
 #include <boost/thread/locks.hpp>
-#ifndef _WINDOWS
-#include <boost/phoenix.hpp>
-#endif
 
 Semaphore::Semaphore()
     : count_(0)
@@ -41,12 +38,7 @@ Semaphore::Semaphore(size_t initCount)
 void Semaphore::Wait(size_t count)
 {
     boost::unique_lock<boost::mutex> lock(mx_);
-#ifndef _WINDOWS
-    namespace phx = boost::phoenix;
-    cv_.wait(lock, phx::ref(count_) >= phx::cref(count));
-#else
     cv_.wait(lock, [&]() { return count_ >= count; });
-#endif
     count_ -= count;
 }
 

--- a/MMCore/ThreadPool.cpp
+++ b/MMCore/ThreadPool.cpp
@@ -29,9 +29,6 @@
 #include <boost/foreach.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/thread/locks.hpp>
-#ifndef _WINDOWS
-#include <boost/phoenix.hpp>
-#endif
 
 #include <algorithm>
 #include <cassert>
@@ -97,12 +94,7 @@ void ThreadPool::ThreadFunc()
         Task* task = NULL;
         {
             boost::unique_lock<boost::mutex> lock(mx_);
-#ifndef _WINDOWS
-            namespace phx = boost::phoenix;
-            cv_.wait(lock,  phx::ref(abortFlag_) || !phx::empty(phx::ref(queue_)));
-#else
             cv_.wait(lock, [&]() { return abortFlag_ || !queue_.empty(); });
-#endif
             if (abortFlag_)
                 break;
             task = queue_.front();


### PR DESCRIPTION
The usage removed here was introduced in as a workaround for standard lambdas when we were still building with C++03. It is no longer necessary.