### PR TITLE
MMCore replace boost with std equivalents

### DIFF
--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -30,7 +30,7 @@
 
 #include "../MMDevice/DeviceUtils.h"
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 
 const long long bytesInMB = 1 << 20;
@@ -50,8 +50,8 @@ CircularBuffer::CircularBuffer(unsigned int memorySizeMB) :
    saveIndex_(0), 
    memorySizeMB_(memorySizeMB), 
    overflow_(false),
-   threadPool_(boost::make_shared<ThreadPool>()),
-   tasksMemCopy_(boost::make_shared<TaskSet_CopyMemory>(threadPool_))
+   threadPool_(std::make_shared<ThreadPool>()),
+   tasksMemCopy_(std::make_shared<TaskSet_CopyMemory>(threadPool_))
 {
    facet = new boost::posix_time::time_facet("%Y-%m-%d %H:%M:%s");
    tStream.imbue(std::locale(tStream.getloc(), facet));

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -32,8 +32,8 @@
 #include "../MMDevice/MMDevice.h"
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/smart_ptr/shared_ptr.hpp>
 
+#include <memory>
 #include <vector>
 
 #ifdef _MSC_VER
@@ -97,8 +97,8 @@ private:
    bool overflow_;
    std::vector<mm::FrameBuffer> frameArray_;
 
-   boost::shared_ptr<ThreadPool> threadPool_;
-   boost::shared_ptr<TaskSet_CopyMemory> tasksMemCopy_;
+   std::shared_ptr<ThreadPool> threadPool_;
+   std::shared_ptr<TaskSet_CopyMemory> tasksMemCopy_;
 
    boost::posix_time::time_facet * facet;
    std::ostringstream tStream;

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -56,7 +56,7 @@ int
 CoreCallback::LogMessage(const MM::Device* caller, const char* msg,
       bool debugOnly) const
 {
-   boost::shared_ptr<DeviceInstance> device;
+   std::shared_ptr<DeviceInstance> device;
    try
    {
       device = core_->deviceManager_->GetDevice(caller);
@@ -94,7 +94,7 @@ CoreCallback::GetDevice(const MM::Device* caller, const char* label)
 MM::PortType
 CoreCallback::GetSerialPortType(const char* portName) const
 {
-   boost::shared_ptr<SerialInstance> pSerial;
+   std::shared_ptr<SerialInstance> pSerial;
    try
    {
       pSerial = core_->deviceManager_->GetDeviceOfType<SerialInstance>(portName);
@@ -111,7 +111,7 @@ CoreCallback::GetSerialPortType(const char* portName) const
 MM::ImageProcessor*
 CoreCallback::GetImageProcessor(const MM::Device*)
 {
-   boost::shared_ptr<ImageProcessorInstance> imageProcessor =
+   std::shared_ptr<ImageProcessorInstance> imageProcessor =
       core_->currentImageProcessor_.lock();
    if (imageProcessor)
    {
@@ -153,7 +153,7 @@ CoreCallback::GetSignalIODevice(const MM::Device*, const char* label)
 MM::AutoFocus*
 CoreCallback::GetAutoFocus(const MM::Device*)
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       core_->currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -169,7 +169,7 @@ CoreCallback::GetParentHub(const MM::Device* caller) const
    if (caller == 0)
       return 0;
 
-   boost::shared_ptr<HubInstance> hubDevice;
+   std::shared_ptr<HubInstance> hubDevice;
    try
    {
       hubDevice = core_->deviceManager_->GetParentDevice(core_->deviceManager_->GetDevice(caller));
@@ -216,8 +216,8 @@ CoreCallback::AddCameraMetadata(const MM::Device* caller, const Metadata* pMd)
       newMD = *pMd;
    }
 
-   boost::shared_ptr<CameraInstance> camera =
-      boost::static_pointer_cast<CameraInstance>(
+   std::shared_ptr<CameraInstance> camera =
+      std::static_pointer_cast<CameraInstance>(
             core_->deviceManager_->GetDevice(caller));
 
    std::string label = camera->GetLabel();
@@ -364,7 +364,7 @@ int CoreCallback::InsertMultiChannel(const MM::Device* caller,
 
 int CoreCallback::AcqFinished(const MM::Device* caller, int /*statusCode*/)
 {
-   boost::shared_ptr<DeviceInstance> camera;
+   std::shared_ptr<DeviceInstance> camera;
    try
    {
       camera = core_->deviceManager_->GetDevice(caller);
@@ -376,12 +376,12 @@ int CoreCallback::AcqFinished(const MM::Device* caller, int /*statusCode*/)
       return DEVICE_ERR;
    }
 
-   boost::shared_ptr<DeviceInstance> currentCamera =
+   std::shared_ptr<DeviceInstance> currentCamera =
       core_->currentCameraDevice_.lock();
 
    if (core_->autoShutter_)
    {
-      boost::shared_ptr<ShutterInstance> shutter =
+      std::shared_ptr<ShutterInstance> shutter =
          core_->currentShutterDevice_.lock();
       if (shutter)
       {
@@ -429,7 +429,7 @@ int CoreCallback::PrepareForAcq(const MM::Device* /*caller*/)
 {
    if (core_->autoShutter_)
    {
-      boost::shared_ptr<ShutterInstance> shutter =
+      std::shared_ptr<ShutterInstance> shutter =
          core_->currentShutterDevice_.lock();
       if (shutter)
       {
@@ -685,7 +685,7 @@ int CoreCallback::SetSerialProperties(const char* portName,
  */
 int CoreCallback::WriteToSerial(const MM::Device* caller, const char* portName, const unsigned char* buf, unsigned long length)
 {
-   boost::shared_ptr<SerialInstance> pSerial;
+   std::shared_ptr<SerialInstance> pSerial;
    try
    {
       pSerial = core_->deviceManager_->GetDeviceOfType<SerialInstance>(portName);
@@ -711,7 +711,7 @@ int CoreCallback::WriteToSerial(const MM::Device* caller, const char* portName, 
   */
 int CoreCallback::ReadFromSerial(const MM::Device* caller, const char* portName, unsigned char* buf, unsigned long bufLength, unsigned long &bytesRead)
 {
-   boost::shared_ptr<SerialInstance> pSerial;
+   std::shared_ptr<SerialInstance> pSerial;
    try
    {
       pSerial = core_->deviceManager_->GetDeviceOfType<SerialInstance>(portName);
@@ -737,7 +737,7 @@ int CoreCallback::ReadFromSerial(const MM::Device* caller, const char* portName,
  */
 int CoreCallback::PurgeSerial(const MM::Device* caller, const char* portName)
 {
-   boost::shared_ptr<SerialInstance> pSerial;
+   std::shared_ptr<SerialInstance> pSerial;
    try
    {
       pSerial = core_->deviceManager_->GetDeviceOfType<SerialInstance>(portName);
@@ -819,7 +819,7 @@ int CoreCallback::GetImageDimensions(int& width, int& height, int& depth)
 
 int CoreCallback::GetFocusPosition(double& pos)
 {
-   boost::shared_ptr<StageInstance> focus = core_->currentFocusDevice_.lock();
+   std::shared_ptr<StageInstance> focus = core_->currentFocusDevice_.lock();
    if (focus)
    {
       return focus->GetPositionUm(pos);
@@ -830,7 +830,7 @@ int CoreCallback::GetFocusPosition(double& pos)
 
 int CoreCallback::SetFocusPosition(double pos)
 {
-   boost::shared_ptr<StageInstance> focus = core_->currentFocusDevice_.lock();
+   std::shared_ptr<StageInstance> focus = core_->currentFocusDevice_.lock();
    if (focus)
    {
       int ret = focus->SetPositionUm(pos);
@@ -845,7 +845,7 @@ int CoreCallback::SetFocusPosition(double pos)
 
 int CoreCallback::MoveFocus(double velocity)
 {
-   boost::shared_ptr<StageInstance> focus = core_->currentFocusDevice_.lock();
+   std::shared_ptr<StageInstance> focus = core_->currentFocusDevice_.lock();
    if (focus)
    {
       mm::DeviceModuleLockGuard g(focus);
@@ -860,7 +860,7 @@ int CoreCallback::MoveFocus(double velocity)
 
 int CoreCallback::GetXYPosition(double& x, double& y)
 {
-   boost::shared_ptr<XYStageInstance> xyStage =
+   std::shared_ptr<XYStageInstance> xyStage =
       core_->currentXYStageDevice_.lock();
    if (xyStage)
    {
@@ -873,7 +873,7 @@ int CoreCallback::GetXYPosition(double& x, double& y)
 
 int CoreCallback::SetXYPosition(double x, double y)
 {
-   boost::shared_ptr<XYStageInstance> xyStage =
+   std::shared_ptr<XYStageInstance> xyStage =
       core_->currentXYStageDevice_.lock();
    if (xyStage)
    {
@@ -888,7 +888,7 @@ int CoreCallback::SetXYPosition(double x, double y)
 
 int CoreCallback::MoveXYStage(double vx, double vy)
 {
-   boost::shared_ptr<XYStageInstance> xyStage =
+   std::shared_ptr<XYStageInstance> xyStage =
       core_->currentXYStageDevice_.lock();
    if (xyStage)
    {

--- a/MMCore/DeviceManager.cpp
+++ b/MMCore/DeviceManager.cpp
@@ -35,8 +35,8 @@ DeviceManager::~DeviceManager()
 }
 
 
-boost::shared_ptr<DeviceInstance>
-DeviceManager::LoadDevice(boost::shared_ptr<LoadedDeviceAdapter> module,
+std::shared_ptr<DeviceInstance>
+DeviceManager::LoadDevice(std::shared_ptr<LoadedDeviceAdapter> module,
       const std::string& deviceName, const std::string& label, CMMCore* core,
       mm::logging::Logger deviceLogger,
       mm::logging::Logger coreLogger)
@@ -50,7 +50,7 @@ DeviceManager::LoadDevice(boost::shared_ptr<LoadedDeviceAdapter> module,
       }
    }
 
-   boost::shared_ptr<DeviceInstance> device = module->LoadDevice(core,
+   std::shared_ptr<DeviceInstance> device = module->LoadDevice(core,
          deviceName, label, deviceLogger, coreLogger);
 
    std::string description;
@@ -79,7 +79,7 @@ DeviceManager::LoadDevice(boost::shared_ptr<LoadedDeviceAdapter> module,
 
 
 void
-DeviceManager::UnloadDevice(boost::shared_ptr<DeviceInstance> device)
+DeviceManager::UnloadDevice(std::shared_ptr<DeviceInstance> device)
 {
    if (device == 0)
       return;
@@ -107,8 +107,8 @@ DeviceManager::UnloadAllDevices()
    // device. Also, peripherals should explicitly be unloaded before hubs
    // instead of relying on the load order.
 
-   std::vector< boost::shared_ptr<DeviceInstance> > nonSerialDevices;
-   std::vector< boost::shared_ptr<DeviceInstance> > serialDevices;
+   std::vector< std::shared_ptr<DeviceInstance> > nonSerialDevices;
+   std::vector< std::shared_ptr<DeviceInstance> > serialDevices;
    for (DeviceIterator it = devices_.begin(), end = devices_.end(); it != end; ++it)
    {
       if (it->second->GetType() == MM::SerialDevice)
@@ -126,13 +126,13 @@ DeviceManager::UnloadAllDevices()
    // DeviceInstance.
    // TODO We need a mechanism to ensure automatic Shutdown (1:1 with
    // Initialize()).
-   for (std::vector< boost::shared_ptr<DeviceInstance> >::reverse_iterator
+   for (std::vector< std::shared_ptr<DeviceInstance> >::reverse_iterator
          it = nonSerialDevices.rbegin(), end = nonSerialDevices.rend();
          it != end; ++it)
    {
       (*it)->Shutdown();
    }
-   for (std::vector< boost::shared_ptr<DeviceInstance> >::reverse_iterator
+   for (std::vector< std::shared_ptr<DeviceInstance> >::reverse_iterator
          it = serialDevices.rbegin(), end = serialDevices.rend();
          it != end; ++it)
    {
@@ -163,13 +163,13 @@ namespace
    public:
       DevicePairMatcheslabel(const std::string& s) : s_(s) {}
       bool operator()(const std::pair< std::string,
-            boost::shared_ptr<DeviceInstance> >& p) const
+            std::shared_ptr<DeviceInstance> >& p) const
       { return p.first == s_; }
    };
 } // anonymous namespace
 
 
-boost::shared_ptr<DeviceInstance>
+std::shared_ptr<DeviceInstance>
 DeviceManager::GetDevice(const std::string& label) const
 {
    DeviceConstIterator found =
@@ -183,7 +183,7 @@ DeviceManager::GetDevice(const std::string& label) const
 }
 
 
-boost::shared_ptr<DeviceInstance>
+std::shared_ptr<DeviceInstance>
 DeviceManager::GetDevice(const char* label) const
 {
    if (!label)
@@ -194,10 +194,10 @@ DeviceManager::GetDevice(const char* label) const
 }
 
 
-boost::shared_ptr<DeviceInstance>
+std::shared_ptr<DeviceInstance>
 DeviceManager::GetDevice(const MM::Device* rawPtr) const
 {
-   typedef std::map< const MM::Device*, boost::weak_ptr<DeviceInstance> >::const_iterator Iterator;
+   typedef std::map< const MM::Device*, std::weak_ptr<DeviceInstance> >::const_iterator Iterator;
    Iterator it = deviceRawPtrIndex_.find(rawPtr);
    if (it == deviceRawPtrIndex_.end())
       throw CMMError("Invalid device pointer");
@@ -226,7 +226,7 @@ DeviceManager::GetLoadedPeripherals(const char* label) const
    std::vector<std::string> labels;
 
    // get hub
-   boost::shared_ptr<DeviceInstance> pDev;
+   std::shared_ptr<DeviceInstance> pDev;
    try
    {
       pDev = GetDevice(label);
@@ -251,8 +251,8 @@ DeviceManager::GetLoadedPeripherals(const char* label) const
 }
 
 
-boost::shared_ptr<HubInstance>
-DeviceManager::GetParentDevice(boost::shared_ptr<DeviceInstance> device) const
+std::shared_ptr<HubInstance>
+DeviceManager::GetParentDevice(std::shared_ptr<DeviceInstance> device) const
 {
    std::string parentLabel = device->GetParentID();
 
@@ -261,13 +261,13 @@ DeviceManager::GetParentDevice(boost::shared_ptr<DeviceInstance> device) const
       // no parent specified, but we will try to infer one anyway
       // TODO So what happens if there is more than one hub in a given device
       // adapter? Answer: bad things.
-      boost::shared_ptr<HubInstance> parentHub;
+      std::shared_ptr<HubInstance> parentHub;
       for (DeviceConstIterator it = devices_.begin(), end = devices_.end(); it != end; ++it)
       {
          if (it->second->GetType() == MM::HubDevice &&
                device->GetAdapterModule() == it->second->GetAdapterModule())
          {
-            parentHub = boost::static_pointer_cast<HubInstance>(it->second);
+            parentHub = std::static_pointer_cast<HubInstance>(it->second);
          }
       }
       // This returns the last matching hub; not sure why it was coded that
@@ -283,16 +283,16 @@ DeviceManager::GetParentDevice(boost::shared_ptr<DeviceInstance> device) const
                it->second->GetType() == MM::HubDevice &&
                it->second->GetAdapterModule() == device->GetAdapterModule())
          {
-            return boost::static_pointer_cast<HubInstance>(it->second);
+            return std::static_pointer_cast<HubInstance>(it->second);
          }
       }
       // TODO We should probably throw when the parent is missing.
-      return boost::shared_ptr<HubInstance>();
+      return std::shared_ptr<HubInstance>();
    }
 }
 
 
-DeviceModuleLockGuard::DeviceModuleLockGuard(boost::shared_ptr<DeviceInstance> device) :
+DeviceModuleLockGuard::DeviceModuleLockGuard(std::shared_ptr<DeviceInstance> device) :
    g_(device->GetAdapterModule()->GetLock())
 {}
 

--- a/MMCore/DeviceManager.h
+++ b/MMCore/DeviceManager.h
@@ -24,10 +24,8 @@
 #include "Error.h"
 #include "Logging/Logger.h"
 
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
-
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -44,15 +42,15 @@ class DeviceManager /* final */
    // Store devices in an ordered container. We could use a map or hash map to
    // retrieve by name, but the number of devices is so small that it is not
    // known to be worth it.
-   std::vector< std::pair<std::string, boost::shared_ptr<DeviceInstance> > > devices_;
-   typedef std::vector< std::pair<std::string, boost::shared_ptr<DeviceInstance> > >::const_iterator
+   std::vector< std::pair<std::string, std::shared_ptr<DeviceInstance> > > devices_;
+   typedef std::vector< std::pair<std::string, std::shared_ptr<DeviceInstance> > >::const_iterator
       DeviceConstIterator;
-   typedef std::vector< std::pair<std::string, boost::shared_ptr<DeviceInstance> > >::iterator
+   typedef std::vector< std::pair<std::string, std::shared_ptr<DeviceInstance> > >::iterator
       DeviceIterator;
 
    // Map raw device pointers to DeviceInstance objects, for those few places
    // where we need to retrieve device information from raw pointers.
-   std::map< const MM::Device*, boost::weak_ptr<DeviceInstance> > deviceRawPtrIndex_;
+   std::map< const MM::Device*, std::weak_ptr<DeviceInstance> > deviceRawPtrIndex_;
 
 public:
    ~DeviceManager();
@@ -60,8 +58,8 @@ public:
    /**
     * \brief Load the specified device and assign a device label.
     */
-   boost::shared_ptr<DeviceInstance>
-   LoadDevice(boost::shared_ptr<LoadedDeviceAdapter> module,
+   std::shared_ptr<DeviceInstance>
+   LoadDevice(std::shared_ptr<LoadedDeviceAdapter> module,
          const std::string& deviceName, const std::string& label, CMMCore* core,
          mm::logging::Logger deviceLogger,
          mm::logging::Logger coreLogger);
@@ -69,7 +67,7 @@ public:
    /**
     * \brief Unload a device.
     */
-   void UnloadDevice(boost::shared_ptr<DeviceInstance> device);
+   void UnloadDevice(std::shared_ptr<DeviceInstance> device);
 
    /**
     * \brief Unload all devices.
@@ -80,8 +78,8 @@ public:
     * \brief Get a device by label.
     */
    ///@{
-   boost::shared_ptr<DeviceInstance> GetDevice(const std::string& label) const;
-   boost::shared_ptr<DeviceInstance> GetDevice(const char* label) const;
+   std::shared_ptr<DeviceInstance> GetDevice(const std::string& label) const;
+   std::shared_ptr<DeviceInstance> GetDevice(const char* label) const;
    ///@}
 
    /**
@@ -89,28 +87,28 @@ public:
     */
    ///@{
    template <class TDeviceInstance>
-   boost::shared_ptr<TDeviceInstance>
-   GetDeviceOfType(boost::shared_ptr<DeviceInstance> device) const
+   std::shared_ptr<TDeviceInstance>
+   GetDeviceOfType(std::shared_ptr<DeviceInstance> device) const
    {
       if (device->GetType() != TDeviceInstance::RawDeviceClass::Type)
          throw CMMError("Device " + ToQuotedString(device->GetLabel()) +
                " is of the wrong type for the requested operation");
-      return boost::static_pointer_cast<TDeviceInstance>(device);
+      return std::static_pointer_cast<TDeviceInstance>(device);
    }
 
    template <class TDeviceInstance>
-   boost::shared_ptr<TDeviceInstance> GetDeviceOfType(const std::string& label) const
+   std::shared_ptr<TDeviceInstance> GetDeviceOfType(const std::string& label) const
    { return GetDeviceOfType<TDeviceInstance>(GetDevice(label)); }
 
    template <class TDeviceInstance>
-   boost::shared_ptr<TDeviceInstance> GetDeviceOfType(const char* label) const
+   std::shared_ptr<TDeviceInstance> GetDeviceOfType(const char* label) const
    { return GetDeviceOfType<TDeviceInstance>(GetDevice(label)); }
    ///@}
 
    /**
     * \brief Get a device from a raw pointer to its MMDevice object.
     */
-   boost::shared_ptr<DeviceInstance> GetDevice(const MM::Device* rawPtr) const;
+   std::shared_ptr<DeviceInstance> GetDevice(const MM::Device* rawPtr) const;
 
    /**
     * \brief Get the labels of all loaded devices of a given type.
@@ -129,7 +127,7 @@ public:
     * \param device
     * \return The hub device, or null if device has no parent.
     */
-   boost::shared_ptr<HubInstance> GetParentDevice(boost::shared_ptr<DeviceInstance> device) const;
+   std::shared_ptr<HubInstance> GetParentDevice(std::shared_ptr<DeviceInstance> device) const;
    // TODO GetParentDevice() should be a DeviceInstance method.
 };
 
@@ -139,7 +137,7 @@ class DeviceModuleLockGuard
 {
    MMThreadGuard g_;
 public:
-   explicit DeviceModuleLockGuard(boost::shared_ptr<DeviceInstance> device);
+   explicit DeviceModuleLockGuard(std::shared_ptr<DeviceInstance> device);
 };
 
 } // namespace mm

--- a/MMCore/Devices/AutoFocusInstance.h
+++ b/MMCore/Devices/AutoFocusInstance.h
@@ -26,7 +26,7 @@ class AutoFocusInstance : public DeviceInstanceBase<MM::AutoFocus>
 {
 public:
    AutoFocusInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/CameraInstance.h
+++ b/MMCore/Devices/CameraInstance.h
@@ -26,7 +26,7 @@ class CameraInstance : public DeviceInstanceBase<MM::Camera>
 {
 public:
    CameraInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/DeviceInstance.cpp
+++ b/MMCore/Devices/DeviceInstance.cpp
@@ -39,7 +39,7 @@ DeviceInstance::LogMessage(const char* msg, bool debugOnly)
 
 
 DeviceInstance::DeviceInstance(CMMCore* core,
-      boost::shared_ptr<LoadedDeviceAdapter> adapter,
+      std::shared_ptr<LoadedDeviceAdapter> adapter,
       const std::string& name,
       MM::Device* pDevice,
       DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/DeviceInstance.h
+++ b/MMCore/Devices/DeviceInstance.h
@@ -23,11 +23,12 @@
 #include "../Error.h"
 #include "../Logging/Logger.h"
 
+#include <boost/function.hpp>
+#include <boost/utility.hpp>
+
+#include <memory>
 #include <string>
 #include <vector>
-#include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/utility.hpp>
 
 class CMMCore;
 class HubInstance;
@@ -65,7 +66,7 @@ protected:
 
 private:
    CMMCore* core_; // Weak reference
-   boost::shared_ptr<LoadedDeviceAdapter> adapter_;
+   std::shared_ptr<LoadedDeviceAdapter> adapter_;
    const std::string label_;
    std::string description_;
    DeleteDeviceFunction deleteFunction_;
@@ -73,7 +74,7 @@ private:
    mm::logging::Logger coreLogger_;
 
 public:
-   boost::shared_ptr<LoadedDeviceAdapter> GetAdapterModule() const /* final */ { return adapter_; }
+   std::shared_ptr<LoadedDeviceAdapter> GetAdapterModule() const /* final */ { return adapter_; }
    std::string GetLabel() const /* final */ { return label_; }
    std::string GetDescription() const /* final */ { return description_; }
    void SetDescription(const std::string& description) /* final */ { description_ = description; }
@@ -89,7 +90,7 @@ protected:
    // The DeviceInstance object owns the raw device pointer (pDevice) as soon
    // as the constructor is called, even if the constructor throws.
    DeviceInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/DeviceInstance.h
+++ b/MMCore/Devices/DeviceInstance.h
@@ -23,9 +23,9 @@
 #include "../Error.h"
 #include "../Logging/Logger.h"
 
-#include <boost/function.hpp>
 #include <boost/utility.hpp>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -39,7 +39,7 @@ namespace MM
    class Device;
 }
 
-typedef boost::function<void (MM::Device*)> DeleteDeviceFunction;
+typedef std::function<void (MM::Device*)> DeleteDeviceFunction;
 
 
 /// Device instance wrapper class

--- a/MMCore/Devices/DeviceInstanceBase.h
+++ b/MMCore/Devices/DeviceInstanceBase.h
@@ -40,7 +40,7 @@ public:
 
 protected:
    DeviceInstanceBase(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/GalvoInstance.h
+++ b/MMCore/Devices/GalvoInstance.h
@@ -26,7 +26,7 @@ class GalvoInstance : public DeviceInstanceBase<MM::Galvo>
 {
 public:
    GalvoInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/GenericInstance.h
+++ b/MMCore/Devices/GenericInstance.h
@@ -26,7 +26,7 @@ class GenericInstance : public DeviceInstanceBase<MM::Generic>
 {
 public:
    GenericInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/HubInstance.h
+++ b/MMCore/Devices/HubInstance.h
@@ -29,7 +29,7 @@ class HubInstance : public DeviceInstanceBase<MM::Hub>
 
 public:
    HubInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/ImageProcessorInstance.h
+++ b/MMCore/Devices/ImageProcessorInstance.h
@@ -26,7 +26,7 @@ class ImageProcessorInstance : public DeviceInstanceBase<MM::ImageProcessor>
 {
 public:
    ImageProcessorInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/MagnifierInstance.h
+++ b/MMCore/Devices/MagnifierInstance.h
@@ -26,7 +26,7 @@ class MagnifierInstance : public DeviceInstanceBase<MM::Magnifier>
 {
 public:
    MagnifierInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/SLMInstance.h
+++ b/MMCore/Devices/SLMInstance.h
@@ -26,7 +26,7 @@ class SLMInstance : public DeviceInstanceBase<MM::SLM>
 {
 public:
    SLMInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/SerialInstance.h
+++ b/MMCore/Devices/SerialInstance.h
@@ -26,7 +26,7 @@ class SerialInstance : public DeviceInstanceBase<MM::Serial>
 {
 public:
    SerialInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/ShutterInstance.h
+++ b/MMCore/Devices/ShutterInstance.h
@@ -26,7 +26,7 @@ class ShutterInstance : public DeviceInstanceBase<MM::Shutter>
 {
 public:
    ShutterInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/SignalIOInstance.h
+++ b/MMCore/Devices/SignalIOInstance.h
@@ -26,7 +26,7 @@ class SignalIOInstance : public DeviceInstanceBase<MM::SignalIO>
 {
 public:
    SignalIOInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/StageInstance.h
+++ b/MMCore/Devices/StageInstance.h
@@ -29,7 +29,7 @@ class StageInstance : public DeviceInstanceBase<MM::Stage>
 
 public:
    StageInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/StateInstance.h
+++ b/MMCore/Devices/StateInstance.h
@@ -26,7 +26,7 @@ class StateInstance : public DeviceInstanceBase<MM::State>
 {
 public:
    StateInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/Devices/XYStageInstance.h
+++ b/MMCore/Devices/XYStageInstance.h
@@ -26,7 +26,7 @@ class XYStageInstance : public DeviceInstanceBase<MM::XYStage>
 {
 public:
    XYStageInstance(CMMCore* core,
-         boost::shared_ptr<LoadedDeviceAdapter> adapter,
+         std::shared_ptr<LoadedDeviceAdapter> adapter,
          const std::string& name,
          MM::Device* pDevice,
          DeleteDeviceFunction deleteFunction,

--- a/MMCore/LoadableModules/LoadedDeviceAdapter.cpp
+++ b/MMCore/LoadableModules/LoadedDeviceAdapter.cpp
@@ -25,8 +25,7 @@
 #include "../CoreUtils.h"
 #include "../Error.h"
 
-#include <boost/bind.hpp>
-
+#include <functional>
 #include <memory>
 
 
@@ -154,7 +153,7 @@ LoadedDeviceAdapter::LoadDevice(CMMCore* core, const std::string& name,
       expectedType = actualType;
 
    std::shared_ptr<LoadedDeviceAdapter> shared_this(shared_from_this());
-   DeleteDeviceFunction deleter = boost::bind(&LoadedDeviceAdapter::DeleteDevice, this, _1);
+   DeleteDeviceFunction deleter = std::bind(&LoadedDeviceAdapter::DeleteDevice, this, std::placeholders::_1);
 
    switch (expectedType)
    {

--- a/MMCore/LoadableModules/LoadedDeviceAdapter.cpp
+++ b/MMCore/LoadableModules/LoadedDeviceAdapter.cpp
@@ -26,7 +26,8 @@
 #include "../Error.h"
 
 #include <boost/bind.hpp>
-#include <boost/make_shared.hpp>
+
+#include <memory>
 
 
 LoadedDeviceAdapter::LoadedDeviceAdapter(const std::string& name, const std::string& filename) :
@@ -43,7 +44,7 @@ LoadedDeviceAdapter::LoadedDeviceAdapter(const std::string& name, const std::str
 {
    try
    {
-      module_ = boost::make_shared<LoadedModule>(filename);
+      module_ = std::make_shared<LoadedModule>(filename);
    }
    catch (const CMMError& e)
    {
@@ -125,7 +126,7 @@ LoadedDeviceAdapter::GetAdvertisedDeviceType(const std::string& deviceName) cons
 }
 
 
-boost::shared_ptr<DeviceInstance>
+std::shared_ptr<DeviceInstance>
 LoadedDeviceAdapter::LoadDevice(CMMCore* core, const std::string& name,
       const std::string& label,
       mm::logging::Logger deviceLogger,
@@ -152,39 +153,39 @@ LoadedDeviceAdapter::LoadDevice(CMMCore* core, const std::string& name,
    if (expectedType == MM::UnknownType)
       expectedType = actualType;
 
-   boost::shared_ptr<LoadedDeviceAdapter> shared_this(shared_from_this());
+   std::shared_ptr<LoadedDeviceAdapter> shared_this(shared_from_this());
    DeleteDeviceFunction deleter = boost::bind(&LoadedDeviceAdapter::DeleteDevice, this, _1);
 
    switch (expectedType)
    {
       case MM::CameraDevice:
-         return boost::make_shared<CameraInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<CameraInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::ShutterDevice:
-         return boost::make_shared<ShutterInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<ShutterInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::StageDevice:
-         return boost::make_shared<StageInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<StageInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::XYStageDevice:
-         return boost::make_shared<XYStageInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<XYStageInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::StateDevice:
-         return boost::make_shared<StateInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<StateInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::SerialDevice:
-         return boost::make_shared<SerialInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<SerialInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::GenericDevice:
-         return boost::make_shared<GenericInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<GenericInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::AutoFocusDevice:
-         return boost::make_shared<AutoFocusInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<AutoFocusInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::ImageProcessorDevice:
-         return boost::make_shared<ImageProcessorInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<ImageProcessorInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::SignalIODevice:
-         return boost::make_shared<SignalIOInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<SignalIOInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::MagnifierDevice:
-         return boost::make_shared<MagnifierInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<MagnifierInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::SLMDevice:
-         return boost::make_shared<SLMInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<SLMInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::GalvoDevice:
-         return boost::make_shared<GalvoInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<GalvoInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       case MM::HubDevice:
-         return boost::make_shared<HubInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
+         return std::make_shared<HubInstance>(core, shared_this, name, pDevice, deleter, label, deviceLogger, coreLogger);
       default:
          deleter(pDevice);
          throw CMMError("Device " + ToQuotedString(name) +

--- a/MMCore/LoadableModules/LoadedDeviceAdapter.h
+++ b/MMCore/LoadableModules/LoadedDeviceAdapter.h
@@ -27,9 +27,9 @@
 #include "../../MMDevice/ModuleInterface.h"
 #include "../Logging/Logger.h"
 
-#include <boost/enable_shared_from_this.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/utility.hpp>
+
+#include <memory>
 
 class CMMCore;
 
@@ -39,7 +39,7 @@ class DeviceInstance;
 
 class LoadedDeviceAdapter /* final */ :
 	boost::noncopyable,
-	public boost::enable_shared_from_this<LoadedDeviceAdapter>
+	public std::enable_shared_from_this<LoadedDeviceAdapter>
 {
 public:
    LoadedDeviceAdapter(const std::string& name, const std::string& filename);
@@ -58,7 +58,7 @@ public:
    std::string GetDeviceDescription(const std::string& deviceName) const;
    MM::DeviceType GetAdvertisedDeviceType(const std::string& deviceName) const;
 
-   boost::shared_ptr<DeviceInstance> LoadDevice(CMMCore* core,
+   std::shared_ptr<DeviceInstance> LoadDevice(CMMCore* core,
          const std::string& name, const std::string& label,
          mm::logging::Logger deviceLogger,
          mm::logging::Logger coreLogger);
@@ -105,7 +105,7 @@ private:
    void DeleteDevice(MM::Device* device);
 
    const std::string name_;
-   boost::shared_ptr<LoadedModule> module_;
+   std::shared_ptr<LoadedModule> module_;
 
    MMThreadLock lock_;
 

--- a/MMCore/LogManager.cpp
+++ b/MMCore/LogManager.cpp
@@ -3,9 +3,7 @@
 #include "CoreUtils.h"
 #include "Error.h"
 
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
-
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -36,7 +34,7 @@ const char* StringForLogLevel(LogLevel level)
 const logging::SinkMode LogManager::PrimarySinkMode = logging::SinkModeAsynchronous;
 
 LogManager::LogManager() :
-   loggingCore_(boost::make_shared<LoggingCore>()),
+   loggingCore_(std::make_shared<LoggingCore>()),
    internalLogger_(loggingCore_->NewLogger("LogManager")),
    primaryLogLevel_(LogLevelInfo),
    usingStdErr_(false),
@@ -57,9 +55,9 @@ LogManager::SetUseStdErr(bool flag)
    {
       if (!stdErrSink_)
       {
-         stdErrSink_ = boost::make_shared<StdErrLogSink>();
+         stdErrSink_ = std::make_shared<StdErrLogSink>();
          stdErrSink_->SetFilter(
-               boost::make_shared<LevelFilter>(primaryLogLevel_));
+               std::make_shared<LevelFilter>(primaryLogLevel_));
       }
       loggingCore_->AddSink(stdErrSink_, PrimarySinkMode);
 
@@ -103,10 +101,10 @@ LogManager::SetPrimaryLogFilename(const std::string& filename, bool truncate)
       return;
    }
 
-   boost::shared_ptr<LogSink> newSink;
+   std::shared_ptr<LogSink> newSink;
    try
    {
-      newSink = boost::make_shared<FileLogSink>(primaryFilename_, !truncate);
+      newSink = std::make_shared<FileLogSink>(primaryFilename_, !truncate);
    }
    catch (const CannotOpenFileException&)
    {
@@ -122,7 +120,7 @@ LogManager::SetPrimaryLogFilename(const std::string& filename, bool truncate)
       throw CMMError("Cannot open file " + ToQuotedString(filename));
    }
 
-   newSink->SetFilter(boost::make_shared<LevelFilter>(primaryLogLevel_));
+   newSink->SetFilter(std::make_shared<LevelFilter>(primaryLogLevel_));
 
    if (!primaryFileSink_)
    {
@@ -138,8 +136,8 @@ LogManager::SetPrimaryLogFilename(const std::string& filename, bool truncate)
       // rotation.
 
       LOG_INFO(internalLogger_) << "Switching primary log file";
-      std::vector< std::pair<boost::shared_ptr<LogSink>, SinkMode> > toRemove;
-      std::vector< std::pair<boost::shared_ptr<LogSink>, SinkMode> > toAdd;
+      std::vector< std::pair<std::shared_ptr<LogSink>, SinkMode> > toRemove;
+      std::vector< std::pair<std::shared_ptr<LogSink>, SinkMode> > toAdd;
       toRemove.push_back(
             std::make_pair(primaryFileSink_, PrimarySinkMode));
       toAdd.push_back(std::make_pair(newSink, PrimarySinkMode));
@@ -183,13 +181,13 @@ LogManager::SetPrimaryLogLevel(LogLevel level)
    LOG_INFO(internalLogger_) << "Switching primary log level from " <<
       StringForLogLevel(oldLevel) << " to " << StringForLogLevel(level);
 
-   boost::shared_ptr<EntryFilter> filter =
-      boost::make_shared<LevelFilter>(level);
+   std::shared_ptr<EntryFilter> filter =
+      std::make_shared<LevelFilter>(level);
 
    std::vector<
       std::pair<
-         std::pair<boost::shared_ptr<LogSink>, SinkMode>,
-         boost::shared_ptr<EntryFilter>
+         std::pair<std::shared_ptr<LogSink>, SinkMode>,
+         std::shared_ptr<EntryFilter>
       >
    > changes;
    if (stdErrSink_)
@@ -226,10 +224,10 @@ LogManager::AddSecondaryLogFile(LogLevel level,
 {
    boost::lock_guard<boost::mutex> lock(mutex_);
 
-   boost::shared_ptr<LogSink> sink;
+   std::shared_ptr<LogSink> sink;
    try
    {
-      sink = boost::make_shared<FileLogSink>(filename, !truncate);
+      sink = std::make_shared<FileLogSink>(filename, !truncate);
    }
    catch (const CannotOpenFileException&)
    {
@@ -238,7 +236,7 @@ LogManager::AddSecondaryLogFile(LogLevel level,
       throw CMMError("Cannot open file " + ToQuotedString(filename));
    }
 
-   sink->SetFilter(boost::make_shared<LevelFilter>(level));
+   sink->SetFilter(std::make_shared<LevelFilter>(level));
 
    LogFileHandle handle = nextSecondaryHandle_++;
    secondaryLogFiles_.insert(std::make_pair(handle,

--- a/MMCore/LogManager.cpp
+++ b/MMCore/LogManager.cpp
@@ -4,6 +4,7 @@
 #include "Error.h"
 
 #include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -45,7 +46,7 @@ LogManager::LogManager() :
 void
 LogManager::SetUseStdErr(bool flag)
 {
-   boost::lock_guard<boost::mutex> lock(mutex_);
+   std::lock_guard<std::mutex> lock(mutex_);
 
    if (flag == usingStdErr_)
       return;
@@ -75,7 +76,7 @@ LogManager::SetUseStdErr(bool flag)
 bool
 LogManager::IsUsingStdErr() const
 {
-   boost::lock_guard<boost::mutex> lock(mutex_);
+   std::lock_guard<std::mutex> lock(mutex_);
    return usingStdErr_;
 }
 
@@ -83,7 +84,7 @@ LogManager::IsUsingStdErr() const
 void
 LogManager::SetPrimaryLogFilename(const std::string& filename, bool truncate)
 {
-   boost::lock_guard<boost::mutex> lock(mutex_);
+   std::lock_guard<std::mutex> lock(mutex_);
 
    if (filename == primaryFilename_)
       return;
@@ -154,7 +155,7 @@ LogManager::SetPrimaryLogFilename(const std::string& filename, bool truncate)
 std::string
 LogManager::GetPrimaryLogFilename() const
 {
-   boost::lock_guard<boost::mutex> lock(mutex_);
+   std::lock_guard<std::mutex> lock(mutex_);
    return primaryFilename_;
 }
 
@@ -162,7 +163,7 @@ LogManager::GetPrimaryLogFilename() const
 bool
 LogManager::IsUsingPrimaryLogFile() const
 {
-   boost::lock_guard<boost::mutex> lock(mutex_);
+   std::lock_guard<std::mutex> lock(mutex_);
    return !primaryFilename_.empty();
 }
 
@@ -170,7 +171,7 @@ LogManager::IsUsingPrimaryLogFile() const
 void
 LogManager::SetPrimaryLogLevel(LogLevel level)
 {
-   boost::lock_guard<boost::mutex> lock(mutex_);
+   std::lock_guard<std::mutex> lock(mutex_);
 
    if (level == primaryLogLevel_)
       return;
@@ -213,7 +214,7 @@ LogManager::SetPrimaryLogLevel(LogLevel level)
 LogLevel
 LogManager::GetPrimaryLogLevel() const
 {
-   boost::lock_guard<boost::mutex> lock(mutex_);
+   std::lock_guard<std::mutex> lock(mutex_);
    return primaryLogLevel_;
 }
 
@@ -222,7 +223,7 @@ LogManager::LogFileHandle
 LogManager::AddSecondaryLogFile(LogLevel level,
       const std::string& filename, bool truncate, SinkMode mode)
 {
-   boost::lock_guard<boost::mutex> lock(mutex_);
+   std::lock_guard<std::mutex> lock(mutex_);
 
    std::shared_ptr<LogSink> sink;
    try
@@ -254,7 +255,7 @@ LogManager::AddSecondaryLogFile(LogLevel level,
 void
 LogManager::RemoveSecondaryLogFile(LogManager::LogFileHandle handle)
 {
-   boost::lock_guard<boost::mutex> lock(mutex_);
+   std::lock_guard<std::mutex> lock(mutex_);
 
    std::map<LogFileHandle, LogFileInfo>::iterator foundIt =
       secondaryLogFiles_.find(handle);

--- a/MMCore/LogManager.h
+++ b/MMCore/LogManager.h
@@ -19,7 +19,7 @@ public:
    typedef int LogFileHandle;
 
 private:
-   boost::shared_ptr<logging::LoggingCore> loggingCore_;
+   std::shared_ptr<logging::LoggingCore> loggingCore_;
    logging::Logger internalLogger_;
 
    mutable boost::mutex mutex_;
@@ -27,20 +27,20 @@ private:
    logging::LogLevel primaryLogLevel_;
 
    bool usingStdErr_;
-   boost::shared_ptr<logging::LogSink> stdErrSink_;
+   std::shared_ptr<logging::LogSink> stdErrSink_;
 
    std::string primaryFilename_;
-   boost::shared_ptr<logging::LogSink> primaryFileSink_;
+   std::shared_ptr<logging::LogSink> primaryFileSink_;
 
    LogFileHandle nextSecondaryHandle_;
    struct LogFileInfo
    {
       std::string filename_;
-      boost::shared_ptr<logging::LogSink> sink_;
+      std::shared_ptr<logging::LogSink> sink_;
       logging::SinkMode mode_;
 
       LogFileInfo(const std::string& filename,
-            boost::shared_ptr<logging::LogSink> sink,
+            std::shared_ptr<logging::LogSink> sink,
             logging::SinkMode mode) :
          filename_(filename),
          sink_(sink),

--- a/MMCore/LogManager.h
+++ b/MMCore/LogManager.h
@@ -2,9 +2,8 @@
 
 #include "Logging/Logging.h"
 
-#include <boost/thread/mutex.hpp>
-
 #include <map>
+#include <mutex>
 #include <string>
 
 namespace mm
@@ -22,7 +21,7 @@ private:
    std::shared_ptr<logging::LoggingCore> loggingCore_;
    logging::Logger internalLogger_;
 
-   mutable boost::mutex mutex_;
+   mutable std::mutex mutex_;
 
    logging::LogLevel primaryLogLevel_;
 

--- a/MMCore/Logging/GenericLogger.h
+++ b/MMCore/Logging/GenericLogger.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <boost/function.hpp>
 #include <boost/utility.hpp>
 
+#include <functional>
 #include <sstream>
 #include <string>
 
@@ -34,12 +34,12 @@ namespace internal
 template <typename TEntryData>
 class GenericLogger
 {
-   boost::function<void (TEntryData, const char*)> impl_;
+   std::function<void (TEntryData, const char*)> impl_;
 
 public:
    typedef TEntryData EntryDataType;
 
-   GenericLogger(boost::function<void (TEntryData, const char*)> f) :
+   GenericLogger(std::function<void (TEntryData, const char*)> f) :
       impl_(f)
    {}
 

--- a/MMCore/Logging/GenericLoggingCore.h
+++ b/MMCore/Logging/GenericLoggingCore.h
@@ -22,9 +22,8 @@
 #include "GenericPacketQueue.h"
 #include "GenericSink.h"
 
-#include <boost/bind.hpp>
-
 #include <algorithm>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -88,8 +87,8 @@ public:
       // Loggers hold a shared pointer to the LoggingCore, so that they are
       // guaranteed to be safe to call at any time.
       return internal::GenericLogger<EntryDataType>(
-            boost::bind(&GenericLoggingCore::SendEntryToShared,
-               this->shared_from_this(), metadata, _1, _2));
+            std::bind(&GenericLoggingCore::SendEntryToShared,
+               this->shared_from_this(), metadata, std::placeholders::_1, std::placeholders::_2));
    }
 
    /**
@@ -299,7 +298,7 @@ private:
    void StartAsyncReceiveLoop()
    {
       asyncQueue_.RunReceiveLoop(
-            boost::bind(&GenericLoggingCore::RunAsynchronousSinks, this, _1));
+            std::bind(&GenericLoggingCore::RunAsynchronousSinks, this, std::placeholders::_1));
    }
 
    void StopAsyncReceiveLoop()

--- a/MMCore/Logging/GenericPacketArray.h
+++ b/MMCore/Logging/GenericPacketArray.h
@@ -18,11 +18,10 @@
 
 #include "GenericLinePacket.h"
 
-#include <boost/container/vector.hpp>
-
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include <vector>
 
 namespace mm
 {
@@ -37,14 +36,13 @@ class GenericPacketArray
 {
 public:
    typedef GenericLinePacket<TMetadata> LinePacketType;
-   typedef typename boost::container::vector<LinePacketType>::iterator
+   typedef typename std::vector<LinePacketType>::iterator
       IteratorType;
-   typedef typename boost::container::vector<LinePacketType>::const_iterator
+   typedef typename std::vector<LinePacketType>::const_iterator
       ConstIteratorType;
 
 private:
-   // Use boost's vector, which supports C++11-style emplace_back().
-   boost::container::vector<LinePacketType> packets_;
+   std::vector<LinePacketType> packets_;
 
 public:
    template <typename TPacketIter>

--- a/MMCore/Logging/GenericPacketQueue.h
+++ b/MMCore/Logging/GenericPacketQueue.h
@@ -16,9 +16,7 @@
 
 #pragma once
 
-#include <boost/bind.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/function.hpp>
 
 #include <chrono>
 #include <condition_variable>
@@ -68,7 +66,7 @@ public:
       condVar_.notify_one();
    }
 
-   void RunReceiveLoop(boost::function<void (PacketArrayType&)>
+   void RunReceiveLoop(std::function<void (PacketArrayType&)>
          consume)
    {
       std::lock_guard<std::mutex> lock(threadMutex_);
@@ -84,7 +82,7 @@ public:
          loopThread_.join();
       }
 
-      std::thread t(boost::bind(&GenericPacketQueue::ReceiveLoop,
+      std::thread t(std::bind(&GenericPacketQueue::ReceiveLoop,
                this, consume));
       using std::swap;
       swap(loopThread_, t);
@@ -110,7 +108,7 @@ public:
    }
 
 private:
-   void ReceiveLoop(boost::function<void (PacketArrayType&)> consume)
+   void ReceiveLoop(std::function<void (PacketArrayType&)> consume)
    {
       using namespace std::chrono_literals;
 

--- a/MMCore/Logging/GenericSink.h
+++ b/MMCore/Logging/GenericSink.h
@@ -20,8 +20,6 @@
 #include "GenericLinePacket.h"
 #include "GenericPacketArray.h"
 
-#include <boost/container/vector.hpp>
-
 #include <memory>
 
 

--- a/MMCore/Logging/GenericSink.h
+++ b/MMCore/Logging/GenericSink.h
@@ -21,7 +21,8 @@
 #include "GenericPacketArray.h"
 
 #include <boost/container/vector.hpp>
-#include <boost/shared_ptr.hpp>
+
+#include <memory>
 
 
 namespace mm
@@ -36,10 +37,10 @@ template <class TMetadata>
 class GenericSink
 {
 private:
-   boost::shared_ptr< GenericEntryFilter<TMetadata> > filter_;
+   std::shared_ptr< GenericEntryFilter<TMetadata> > filter_;
 
 protected:
-   boost::shared_ptr< GenericEntryFilter<TMetadata> > GetFilter() const
+   std::shared_ptr< GenericEntryFilter<TMetadata> > GetFilter() const
    { return filter_; }
 
 public:
@@ -50,7 +51,7 @@ public:
 
    // Note: If setting the filter while the sink is in use, you must pause the
    // logger. See the LoggingCore member function AtomicSetSinkFilters().
-   void SetFilter(boost::shared_ptr< GenericEntryFilter<TMetadata> > filter)
+   void SetFilter(std::shared_ptr< GenericEntryFilter<TMetadata> > filter)
    { filter_ = filter; }
 };
 

--- a/MMCore/Logging/GenericStreamSink.h
+++ b/MMCore/Logging/GenericStreamSink.h
@@ -18,12 +18,12 @@
 
 #include "GenericSink.h"
 
-#include <boost/shared_ptr.hpp>
 #include <boost/utility.hpp>
 
 #include <exception>
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <memory>
 
 
 namespace mm
@@ -47,7 +47,7 @@ template <class TFormatter, class UMetadata, typename VPacketIter>
 void
 WritePacketsToStream(std::ostream& stream,
       VPacketIter first, VPacketIter last,
-      boost::shared_ptr< GenericEntryFilter<UMetadata> > filter)
+      std::shared_ptr< GenericEntryFilter<UMetadata> > filter)
 {
    TFormatter formatter;
 

--- a/MMCore/Logging/Metadata.cpp
+++ b/MMCore/Logging/Metadata.cpp
@@ -16,8 +16,7 @@
 
 #include "Metadata.h"
 
-#include <boost/thread.hpp>
-
+#include <mutex>
 #include <set>
 #include <string>
 
@@ -35,10 +34,10 @@ LoggerData::InternString(const std::string& s)
    // this set, iterators (and thus const char* to the contained strings)
    // are never invalidated and can be used as a light-weight handle. Thus,
    // we need to protect only insertion by a mutex.
-   static boost::mutex mutex;
+   static std::mutex mutex;
    static std::set<std::string> strings;
 
-   boost::lock_guard<boost::mutex> lock(mutex);
+   std::lock_guard<std::mutex> lock(mutex);
    return strings.insert(s).first->c_str();
 }
 

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -363,7 +363,7 @@ string CMMCore::getVersionInfo() const
 std::vector<std::string>
 CMMCore::getAvailableDevices(const char* moduleName) throw (CMMError)
 {
-   boost::shared_ptr<LoadedDeviceAdapter> module =
+   std::shared_ptr<LoadedDeviceAdapter> module =
       pluginManager_->GetDeviceAdapter(moduleName);
    return module->GetAvailableDeviceNames();
 }
@@ -376,7 +376,7 @@ CMMCore::getAvailableDeviceDescriptions(const char* moduleName) throw (CMMError)
 {
    // XXX It is a little silly that we return the list of descriptions, rather
    // than provide access to the description of each device.
-   boost::shared_ptr<LoadedDeviceAdapter> module =
+   std::shared_ptr<LoadedDeviceAdapter> module =
       pluginManager_->GetDeviceAdapter(moduleName);
    std::vector<std::string> names = module->GetAvailableDeviceNames();
    std::vector<std::string> descriptions;
@@ -397,7 +397,7 @@ CMMCore::getAvailableDeviceTypes(const char* moduleName) throw (CMMError)
 {
    // XXX It is a little silly that we return the list of types, rather than
    // provide access to the type of each device.
-   boost::shared_ptr<LoadedDeviceAdapter> module =
+   std::shared_ptr<LoadedDeviceAdapter> module =
       pluginManager_->GetDeviceAdapter(moduleName);
    std::vector<std::string> names = module->GetAvailableDeviceNames();
    std::vector<long> types;
@@ -436,7 +436,7 @@ Configuration CMMCore::getSystemState()
    vector<string> devices = deviceManager_->GetDeviceList();
    for (vector<string>::const_iterator i = devices.begin(), end = devices.end(); i != end; ++i)
    {
-      boost::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(*i);
+      std::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(*i);
       mm::DeviceModuleLockGuard guard(pDev);
       std::vector<std::string> propertyNames = pDev->GetPropertyNames();
       for (std::vector<std::string>::const_iterator it = propertyNames.begin(), end = propertyNames.end();
@@ -710,9 +710,9 @@ void CMMCore::loadDevice(const char* label, const char* moduleName, const char* 
 
    try
    {
-      boost::shared_ptr<LoadedDeviceAdapter> module =
+      std::shared_ptr<LoadedDeviceAdapter> module =
          pluginManager_->GetDeviceAdapter(moduleName);
-      boost::shared_ptr<DeviceInstance> pDevice =
+      std::shared_ptr<DeviceInstance> pDevice =
          deviceManager_->LoadDevice(module, deviceName, label, this,
                deviceLogger, coreLogger);
       pDevice->SetCallback(callback_);
@@ -728,7 +728,7 @@ void CMMCore::loadDevice(const char* label, const char* moduleName, const char* 
       " from " << moduleName << "; label = " << label;
 }
 
-void CMMCore::assignDefaultRole(boost::shared_ptr<DeviceInstance> pDevice)
+void CMMCore::assignDefaultRole(std::shared_ptr<DeviceInstance> pDevice)
 {
    // default special roles for particular devices
    // The roles which are assigned at the load time will make sense for a simple
@@ -740,37 +740,37 @@ void CMMCore::assignDefaultRole(boost::shared_ptr<DeviceInstance> pDevice)
    {
       case MM::CameraDevice:
          currentCameraDevice_ =
-            boost::static_pointer_cast<CameraInstance>(pDevice);
+            std::static_pointer_cast<CameraInstance>(pDevice);
          LOG_INFO(coreLogger_) << "Default camera set to " << label;
          break;
 
       case MM::ShutterDevice:
          currentShutterDevice_ =
-            boost::static_pointer_cast<ShutterInstance>(pDevice);
+            std::static_pointer_cast<ShutterInstance>(pDevice);
          LOG_INFO(coreLogger_) << "Default shutter set to " << label;
          break;
 
       case MM::XYStageDevice:
          currentXYStageDevice_ =
-            boost::static_pointer_cast<XYStageInstance>(pDevice);
+            std::static_pointer_cast<XYStageInstance>(pDevice);
          LOG_INFO(coreLogger_) << "Default xy stage set to " << label;
          break;
 
       case MM::AutoFocusDevice:
          currentAutofocusDevice_ =
-            boost::static_pointer_cast<AutoFocusInstance>(pDevice);
+            std::static_pointer_cast<AutoFocusInstance>(pDevice);
          LOG_INFO(coreLogger_) << "Default autofocus set to " << label;
          break;
 
       case MM::SLMDevice:
          currentSLMDevice_ =
-            boost::static_pointer_cast<SLMInstance>(pDevice);
+            std::static_pointer_cast<SLMInstance>(pDevice);
          LOG_INFO(coreLogger_) << "Default SLM set to " << label;
          break;
 
       case MM::GalvoDevice:
          currentGalvoDevice_ =
-            boost::static_pointer_cast<GalvoInstance>(pDevice);
+            std::static_pointer_cast<GalvoInstance>(pDevice);
          LOG_INFO(coreLogger_) << "Default galvo set to " << label;
          break;
 
@@ -786,7 +786,7 @@ void CMMCore::assignDefaultRole(boost::shared_ptr<DeviceInstance> pDevice)
 void CMMCore::unloadDevice(const char* label///< the name of the device to unload
                            ) throw (CMMError)
 {
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    try {
       mm::DeviceModuleLockGuard guard(pDevice);
@@ -890,7 +890,7 @@ void CMMCore::initializeAllDevices() throw (CMMError)
 
    for (size_t i=0; i<devices.size(); i++)
    {
-      boost::shared_ptr<DeviceInstance> pDevice;
+      std::shared_ptr<DeviceInstance> pDevice;
       try {
          pDevice = deviceManager_->GetDevice(devices[i]);
       }
@@ -951,7 +951,7 @@ void CMMCore::updateCoreProperty(const char* propName, MM::DeviceType devType) t
 void CMMCore::initializeDevice(const char* label ///< the device to initialize
                                ) throw (CMMError)
 {
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    mm::DeviceModuleLockGuard guard(pDevice);
 
@@ -986,7 +986,7 @@ MM::DeviceType CMMCore::getDeviceType(const char* label) throw (CMMError)
    if (IsCoreDeviceLabel(label))
       return MM::CoreDevice;
 
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    return pDevice->GetType();
 }
 
@@ -999,7 +999,7 @@ std::string CMMCore::getDeviceLibrary(const char* label) throw (CMMError)
    if (IsCoreDeviceLabel(label))
       return "";
 
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    mm::DeviceModuleLockGuard guard(pDevice);
    return pDevice->GetAdapterModule()->GetName();
@@ -1018,7 +1018,7 @@ void CMMCore::unloadLibrary(const char* moduleName) throw (CMMError)
       vector<string>::reverse_iterator it;
       for (it=devices.rbegin(); it != devices.rend(); it++)
       {
-         boost::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(*it);
+         std::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(*it);
          mm::DeviceModuleLockGuard guard(pDev);
 
          if (pDev->GetAdapterModule()->GetName() == moduleName)
@@ -1046,7 +1046,7 @@ std::string CMMCore::getDeviceName(const char* label) throw (CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return "Core";
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    mm::DeviceModuleLockGuard guard(pDevice);
    return pDevice->GetName();
@@ -1060,7 +1060,7 @@ std::string CMMCore::getParentLabel(const char* label) throw (CMMError)
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
       return "";
-   boost::shared_ptr<DeviceInstance> device = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> device = deviceManager_->GetDevice(label);
    mm::DeviceModuleLockGuard guard(device);
    return device->GetParentID();
 }
@@ -1073,7 +1073,7 @@ void CMMCore::setParentLabel(const char* label, const char* parentLabel) throw (
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
       return; // core can't have parent ID
-   boost::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(label);
    if (parentLabel && std::string(parentLabel).empty()) {
       // Empty label is acceptable, meaning no parent
    }
@@ -1096,7 +1096,7 @@ std::string CMMCore::getDeviceDescription(const char* label) throw (CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return "Core device";
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    mm::DeviceModuleLockGuard guard(pDevice);
    return pDevice->GetDescription();
@@ -1118,7 +1118,7 @@ double CMMCore::getDeviceDelayMs(const char* label) throw (CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return 0.0;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    mm::DeviceModuleLockGuard guard(pDevice);
    return pDevice->GetDelayMs();
@@ -1136,7 +1136,7 @@ void CMMCore::setDeviceDelayMs(const char* label, double delayMs) throw (CMMErro
 {
    if (IsCoreDeviceLabel(label))
       return; // ignore
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    mm::DeviceModuleLockGuard guard(pDevice);
    pDevice->SetDelayMs(delayMs);
@@ -1152,7 +1152,7 @@ bool CMMCore::usesDeviceDelay(const char* label) throw (CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return false;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    mm::DeviceModuleLockGuard guard(pDevice);
    return pDevice->UsesDelay();
@@ -1167,7 +1167,7 @@ bool CMMCore::deviceBusy(const char* label) throw (CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return false;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    mm::DeviceModuleLockGuard guard(pDevice);
    return pDevice->Busy();
@@ -1193,7 +1193,7 @@ void CMMCore::waitForDevice(const char* label) throw (CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return; // core property commands always block - no need to poll
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    waitForDevice(pDevice);
 }
@@ -1203,7 +1203,7 @@ void CMMCore::waitForDevice(const char* label) throw (CMMError)
  * Waits (blocks the calling thread) until the specified device becomes
  * @param device   the device label
  */
-void CMMCore::waitForDevice(boost::shared_ptr<DeviceInstance> pDev) throw (CMMError)
+void CMMCore::waitForDevice(std::shared_ptr<DeviceInstance> pDev) throw (CMMError)
 {
    LOG_DEBUG(coreLogger_) << "Waiting for device " << pDev->GetLabel() << "...";
 
@@ -1268,7 +1268,7 @@ bool CMMCore::deviceTypeBusy(MM::DeviceType devType) throw (CMMError)
    for (size_t i=0; i<devices.size(); i++)
    {
       try {
-         boost::shared_ptr<DeviceInstance> pDevice =
+         std::shared_ptr<DeviceInstance> pDevice =
             deviceManager_->GetDevice(devices[i]);
          mm::DeviceModuleLockGuard guard(pDevice);
          if (pDevice->Busy())
@@ -1321,11 +1321,11 @@ void CMMCore::waitForConfig(const char* group, const char* configName) throw (CM
  */
 void CMMCore::waitForImageSynchro() throw (CMMError)
 {
-   for (std::vector< boost::weak_ptr<DeviceInstance> >::iterator
+   for (std::vector< std::weak_ptr<DeviceInstance> >::iterator
          it = imageSynchroDevices_.begin(), end = imageSynchroDevices_.end();
          it != end; ++it)
    {
-      boost::shared_ptr<DeviceInstance> device = it->lock();
+      std::shared_ptr<DeviceInstance> device = it->lock();
       if (device)
       {
          waitForDevice(device);
@@ -1340,7 +1340,7 @@ void CMMCore::waitForImageSynchro() throw (CMMError)
  */
 void CMMCore::setPosition(const char* label, double position) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    LOG_DEBUG(coreLogger_) << "Will start absolute move of " << label <<
@@ -1372,7 +1372,7 @@ void CMMCore::setPosition(double position) throw (CMMError)
  */
 void CMMCore::setRelativePosition(const char* label, double d) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    LOG_DEBUG(coreLogger_) << "Will start relative move of " << label <<
@@ -1405,7 +1405,7 @@ void CMMCore::setRelativePosition(double d) throw (CMMError)
  */
 double CMMCore::getPosition(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -1437,7 +1437,7 @@ double CMMCore::getPosition() throw (CMMError)
  */
 void CMMCore::setXYPosition(const char* label, double x, double y) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pXYStage =
+   std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    LOG_DEBUG(coreLogger_) << "Will start absolute move of " << label <<
@@ -1472,7 +1472,7 @@ void CMMCore::setXYPosition(double x, double y) throw (CMMError)
  */
 void CMMCore::setRelativeXYPosition(const char* label, double dx, double dy) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pXYStage =
+   std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    LOG_DEBUG(coreLogger_) << "Will start relative move of " << label <<
@@ -1506,7 +1506,7 @@ void CMMCore::setRelativeXYPosition(double dx, double dy) throw (CMMError) {
  */
 void CMMCore::getXYPosition(const char* label, double& x, double& y) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pXYStage =
+   std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pXYStage);
@@ -1536,7 +1536,7 @@ void CMMCore::getXYPosition(double& x, double& y) throw (CMMError)
  */
 double CMMCore::getXPosition(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pXYStage =
+   std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pXYStage);
@@ -1569,7 +1569,7 @@ double CMMCore::getXPosition() throw (CMMError)
  */
 double CMMCore::getYPosition(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pXYStage =
+   std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pXYStage);
@@ -1604,11 +1604,11 @@ double CMMCore::getYPosition() throw (CMMError)
  */
 void CMMCore::stop(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<DeviceInstance> stage =
+   std::shared_ptr<DeviceInstance> stage =
       deviceManager_->GetDevice(label);
 
-   boost::shared_ptr<StageInstance> zStage =
-      boost::dynamic_pointer_cast<StageInstance>(stage);
+   std::shared_ptr<StageInstance> zStage =
+      std::dynamic_pointer_cast<StageInstance>(stage);
    if (zStage)
    {
       LOG_DEBUG(coreLogger_) << "Will stop stage " << label;
@@ -1625,8 +1625,8 @@ void CMMCore::stop(const char* label) throw (CMMError)
       return;
    }
 
-   boost::shared_ptr<XYStageInstance> xyStage =
-      boost::dynamic_pointer_cast<XYStageInstance>(stage);
+   std::shared_ptr<XYStageInstance> xyStage =
+      std::dynamic_pointer_cast<XYStageInstance>(stage);
    if (xyStage)
    {
       LOG_DEBUG(coreLogger_) << "Will stop xy stage " << label;
@@ -1658,11 +1658,11 @@ void CMMCore::stop(const char* label) throw (CMMError)
  */
 void CMMCore::home(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<DeviceInstance> stage =
+   std::shared_ptr<DeviceInstance> stage =
       deviceManager_->GetDevice(label);
 
-   boost::shared_ptr<StageInstance> zStage =
-      boost::dynamic_pointer_cast<StageInstance>(stage);
+   std::shared_ptr<StageInstance> zStage =
+      std::dynamic_pointer_cast<StageInstance>(stage);
    if (zStage)
    {
       LOG_DEBUG(coreLogger_) << "Will home stage " << label;
@@ -1679,8 +1679,8 @@ void CMMCore::home(const char* label) throw (CMMError)
       return;
    }
 
-   boost::shared_ptr<XYStageInstance> xyStage =
-      boost::dynamic_pointer_cast<XYStageInstance>(stage);
+   std::shared_ptr<XYStageInstance> xyStage =
+      std::dynamic_pointer_cast<XYStageInstance>(stage);
    if (xyStage)
    {
       LOG_DEBUG(coreLogger_) << "Will home xy stage " << label;
@@ -1711,7 +1711,7 @@ void CMMCore::home(const char* label) throw (CMMError)
  */
 void CMMCore::setOriginXY(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pXYStage =
+   std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pXYStage);
@@ -1745,7 +1745,7 @@ void CMMCore::setOriginXY() throw (CMMError)
  */
 void CMMCore::setOriginX(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pXYStage =
+   std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pXYStage);
@@ -1779,7 +1779,7 @@ void CMMCore::setOriginX() throw (CMMError)
  */
 void CMMCore::setOriginY(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pXYStage =
+   std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pXYStage);
@@ -1814,7 +1814,7 @@ void CMMCore::setOriginY() throw (CMMError)
  */
 void CMMCore::setOrigin(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -1851,7 +1851,7 @@ void CMMCore::setOrigin() throw (CMMError)
  */
 void CMMCore::setAdapterOrigin(const char* label, double newZUm) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -1894,7 +1894,7 @@ void CMMCore::setAdapterOrigin(double newZUm) throw (CMMError)
 void CMMCore::setAdapterOriginXY(const char* label,
       double newXUm, double newYUm) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pXYStage =
+   std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pXYStage);
@@ -1941,7 +1941,7 @@ void CMMCore::setAdapterOriginXY(double newXUm, double newYUm) throw (CMMError)
  */
 int CMMCore::getFocusDirection(const char* stageLabel) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> stage =
+   std::shared_ptr<StageInstance> stage =
       deviceManager_->GetDeviceOfType<StageInstance>(stageLabel);
 
    mm::DeviceModuleLockGuard guard(stage);
@@ -1976,7 +1976,7 @@ void CMMCore::setFocusDirection(const char* stageLabel, int sign)
 
    try
    {
-      boost::shared_ptr<StageInstance> stage =
+      std::shared_ptr<StageInstance> stage =
          deviceManager_->GetDeviceOfType<StageInstance>(stageLabel);
 
       mm::DeviceModuleLockGuard guard(stage);
@@ -1995,7 +1995,7 @@ void CMMCore::setFocusDirection(const char* stageLabel, int sign)
  */
 bool CMMCore::isExposureSequenceable(const char* cameraLabel) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCamera =
+   std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
 
    mm::DeviceModuleLockGuard guard(pCamera);
@@ -2016,7 +2016,7 @@ bool CMMCore::isExposureSequenceable(const char* cameraLabel) throw (CMMError)
  */
 void CMMCore::startExposureSequence(const char* cameraLabel) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCamera =
+   std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
 
    mm::DeviceModuleLockGuard guard(pCamera);
@@ -2033,7 +2033,7 @@ void CMMCore::startExposureSequence(const char* cameraLabel) throw (CMMError)
  */
 void CMMCore::stopExposureSequence(const char* cameraLabel) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCamera =
+   std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
 
    mm::DeviceModuleLockGuard guard(pCamera);
@@ -2050,7 +2050,7 @@ void CMMCore::stopExposureSequence(const char* cameraLabel) throw (CMMError)
  */
 long CMMCore::getExposureSequenceMaxLength(const char* cameraLabel) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCamera =
+   std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
 
    mm::DeviceModuleLockGuard guard(pCamera);
@@ -2070,7 +2070,7 @@ long CMMCore::getExposureSequenceMaxLength(const char* cameraLabel) throw (CMMEr
  */
 void CMMCore::loadExposureSequence(const char* cameraLabel, std::vector<double> exposureTime_ms) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCamera =
+   std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
 
    unsigned long maxLength = getExposureSequenceMaxLength(cameraLabel);
@@ -2108,7 +2108,7 @@ void CMMCore::loadExposureSequence(const char* cameraLabel, std::vector<double> 
  */
 bool CMMCore::isStageSequenceable(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2129,7 +2129,7 @@ bool CMMCore::isStageSequenceable(const char* label) throw (CMMError)
  */
 bool CMMCore::isStageLinearSequenceable(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2149,7 +2149,7 @@ bool CMMCore::isStageLinearSequenceable(const char* label) throw (CMMError)
  */
 void CMMCore::startStageSequence(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2166,7 +2166,7 @@ void CMMCore::startStageSequence(const char* label) throw (CMMError)
  */
 void CMMCore::stopStageSequence(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2184,7 +2184,7 @@ void CMMCore::stopStageSequence(const char* label) throw (CMMError)
  */
 long CMMCore::getStageSequenceMaxLength(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2204,7 +2204,7 @@ long CMMCore::getStageSequenceMaxLength(const char* label) throw (CMMError)
  */
 void CMMCore::loadStageSequence(const char* label, std::vector<double> positionSequence) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2241,7 +2241,7 @@ void CMMCore::setStageLinearSequence(const char* label, double dZ_um, int nSlice
    if (nSlices < 0)
       throw CMMError("Linear sequence cannot have negative length");
 
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2258,7 +2258,7 @@ void CMMCore::setStageLinearSequence(const char* label, double dZ_um, int nSlice
  */
 bool CMMCore::isXYStageSequenceable(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pStage =
+   std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2280,7 +2280,7 @@ bool CMMCore::isXYStageSequenceable(const char* label) throw (CMMError)
  */
 void CMMCore::startXYStageSequence(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pStage =
+   std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2297,7 +2297,7 @@ void CMMCore::startXYStageSequence(const char* label) throw (CMMError)
  */
 void CMMCore::stopXYStageSequence(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pStage =
+   std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2315,7 +2315,7 @@ void CMMCore::stopXYStageSequence(const char* label) throw (CMMError)
  */
 long CMMCore::getXYStageSequenceMaxLength(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pStage =
+   std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2339,7 +2339,7 @@ void CMMCore::loadXYStageSequence(const char* label,
                                   std::vector<double> xSequence,
                                   std::vector<double> ySequence) throw (CMMError)
 {
-   boost::shared_ptr<XYStageInstance> pStage =
+   std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -2370,7 +2370,7 @@ void CMMCore::loadXYStageSequence(const char* label,
  */
 void CMMCore::snapImage() throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       if(camera->IsCapturing())
@@ -2389,7 +2389,7 @@ void CMMCore::snapImage() throw (CMMError)
          waitForImageSynchro();
 
          // open the shutter
-         boost::shared_ptr<ShutterInstance> shutter =
+         std::shared_ptr<ShutterInstance> shutter =
             currentShutterDevice_.lock();
          if (autoShutter_ && shutter)
          {
@@ -2452,16 +2452,16 @@ namespace
 {
    class DeviceWeakPtrInvalidOrMatches
    {
-      boost::shared_ptr<DeviceInstance> theDevice_;
+      std::shared_ptr<DeviceInstance> theDevice_;
    public:
       explicit DeviceWeakPtrInvalidOrMatches(
-            boost::shared_ptr<DeviceInstance> theDevice) :
+            std::shared_ptr<DeviceInstance> theDevice) :
          theDevice_(theDevice)
       {}
 
-      bool operator()(const boost::weak_ptr<DeviceInstance>& ptr)
+      bool operator()(const std::weak_ptr<DeviceInstance>& ptr)
       {
-         boost::shared_ptr<DeviceInstance> aDevice = ptr.lock();
+         std::shared_ptr<DeviceInstance> aDevice = ptr.lock();
          return (!aDevice || aDevice == theDevice_);
       }
    };
@@ -2476,7 +2476,7 @@ namespace
  */
 void CMMCore::assignImageSynchro(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<DeviceInstance> device = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> device = deviceManager_->GetDevice(label);
 
    imageSynchroDevices_.erase(std::remove_if(imageSynchroDevices_.begin(),
             imageSynchroDevices_.end(), DeviceWeakPtrInvalidOrMatches(device)),
@@ -2494,7 +2494,7 @@ void CMMCore::assignImageSynchro(const char* label) throw (CMMError)
  */
 void CMMCore::removeImageSynchro(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<DeviceInstance> device = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> device = deviceManager_->GetDevice(label);
    imageSynchroDevices_.erase(std::remove_if(imageSynchroDevices_.begin(),
             imageSynchroDevices_.end(), DeviceWeakPtrInvalidOrMatches(device)),
          imageSynchroDevices_.end());
@@ -2542,7 +2542,7 @@ bool CMMCore::getAutoShutter()
 */
 void CMMCore::setShutterOpen(const char* shutterLabel, bool state) throw (CMMError)
 {
-   boost::shared_ptr<ShutterInstance> pShutter =
+   std::shared_ptr<ShutterInstance> pShutter =
       deviceManager_->GetDeviceOfType<ShutterInstance>(shutterLabel);
    if (pShutter)
    {
@@ -2581,7 +2581,7 @@ void CMMCore::setShutterOpen(bool state) throw (CMMError)
  */
 bool CMMCore::getShutterOpen(const char* shutterLabel) throw (CMMError)
 {
-   boost::shared_ptr<ShutterInstance> pShutter =
+   std::shared_ptr<ShutterInstance> pShutter =
       deviceManager_->GetDeviceOfType<ShutterInstance>(shutterLabel);
    bool state = true; // default open
    if (pShutter)
@@ -2630,7 +2630,7 @@ bool CMMCore::getShutterOpen() throw (CMMError)
  */
 void* CMMCore::getImage() throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
    else
@@ -2659,7 +2659,7 @@ void* CMMCore::getImage() throw (CMMError)
          mm::DeviceModuleLockGuard guard(camera);
          pBuf = const_cast<unsigned char*> (camera->GetImageBuffer());
 
-         boost::shared_ptr<ImageProcessorInstance> imageProcessor =
+         std::shared_ptr<ImageProcessorInstance> imageProcessor =
             currentImageProcessor_.lock();
          if (imageProcessor)
 	      {
@@ -2696,7 +2696,7 @@ void* CMMCore::getImage() throw (CMMError)
  */
 void* CMMCore::getImage(unsigned channelNr) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
    else
@@ -2706,7 +2706,7 @@ void* CMMCore::getImage(unsigned channelNr) throw (CMMError)
          mm::DeviceModuleLockGuard guard(camera);
          pBuf = const_cast<unsigned char*> (camera->GetImageBuffer(channelNr));
 
-         boost::shared_ptr<ImageProcessorInstance> imageProcessor =
+         std::shared_ptr<ImageProcessorInstance> imageProcessor =
             currentImageProcessor_.lock();
          if (imageProcessor)
 	      {
@@ -2736,7 +2736,7 @@ void* CMMCore::getImage(unsigned channelNr) throw (CMMError)
 */
 long CMMCore::getImageBufferSize()
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera) {
       mm::DeviceModuleLockGuard guard(camera);
       return camera->GetImageBufferSize();
@@ -2763,7 +2763,7 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
       postedErrors_.clear();
    }
 
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       if(camera->IsCapturing())
@@ -2811,7 +2811,7 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
  */
 void CMMCore::startSequenceAcquisition(const char* label, long numImages, double intervalMs, bool stopOnOverflow) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCam =
+   std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pCam);
@@ -2835,7 +2835,7 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
  */
 void CMMCore::prepareSequenceAcquisition(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCam =
+   std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pCam);
@@ -2859,7 +2859,7 @@ void CMMCore::prepareSequenceAcquisition(const char* label) throw (CMMError)
  */
 void CMMCore::initializeCircularBuffer() throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       mm::DeviceModuleLockGuard guard(camera);
@@ -2883,7 +2883,7 @@ void CMMCore::initializeCircularBuffer() throw (CMMError)
  */
 void CMMCore::stopSequenceAcquisition(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCam =
+   std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pCam);
@@ -2904,7 +2904,7 @@ void CMMCore::stopSequenceAcquisition(const char* label) throw (CMMError)
  */
 void CMMCore::startContinuousSequenceAcquisition(double intervalMs) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       mm::DeviceModuleLockGuard guard(camera);
@@ -2939,7 +2939,7 @@ void CMMCore::startContinuousSequenceAcquisition(double intervalMs) throw (CMMEr
  */
 void CMMCore::stopSequenceAcquisition() throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       mm::DeviceModuleLockGuard guard(camera);
@@ -2966,7 +2966,7 @@ void CMMCore::stopSequenceAcquisition() throw (CMMError)
  */
 bool CMMCore::isSequenceRunning() throw ()
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       mm::DeviceModuleLockGuard guard(camera);
@@ -2984,7 +2984,7 @@ bool CMMCore::isSequenceRunning() throw ()
  */
 bool CMMCore::isSequenceRunning(const char* label) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCam =
+   std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
 
    mm::DeviceModuleLockGuard guard(pCam);
@@ -3167,7 +3167,7 @@ void CMMCore::setCircularBufferMemoryFootprint(unsigned sizeMB ///< n megabytes
 	{
 
 		// attempt to initialize based on the current camera settings
-      boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+      std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
       if (camera)
 		{
          mm::DeviceModuleLockGuard guard(camera);
@@ -3252,7 +3252,7 @@ bool CMMCore::isBufferOverflowed() const
  */
 string CMMCore::getCameraDevice()
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       return camera->GetLabel();
@@ -3266,7 +3266,7 @@ string CMMCore::getCameraDevice()
  */
 string CMMCore::getShutterDevice()
 {
-   boost::shared_ptr<ShutterInstance> shutter = currentShutterDevice_.lock();
+   std::shared_ptr<ShutterInstance> shutter = currentShutterDevice_.lock();
    if (shutter)
    {
       return shutter->GetLabel();
@@ -3280,7 +3280,7 @@ string CMMCore::getShutterDevice()
  */
 string CMMCore::getFocusDevice()
 {
-   boost::shared_ptr<StageInstance> focus = currentFocusDevice_.lock();
+   std::shared_ptr<StageInstance> focus = currentFocusDevice_.lock();
    if (focus)
    {
       return focus->GetLabel();
@@ -3293,7 +3293,7 @@ string CMMCore::getFocusDevice()
  */
 string CMMCore::getXYStageDevice()
 {
-   boost::shared_ptr<XYStageInstance> xyStage = currentXYStageDevice_.lock();
+   std::shared_ptr<XYStageInstance> xyStage = currentXYStageDevice_.lock();
    if (xyStage)
    {
       return xyStage->GetLabel();
@@ -3306,7 +3306,7 @@ string CMMCore::getXYStageDevice()
  */
 string CMMCore::getAutoFocusDevice()
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -3344,7 +3344,7 @@ void CMMCore::setAutoFocusDevice(const char* autofocusLabel) throw (CMMError)
  */
 string CMMCore::getImageProcessorDevice()
 {
-   boost::shared_ptr<ImageProcessorInstance> imageProcessor =
+   std::shared_ptr<ImageProcessorInstance> imageProcessor =
       currentImageProcessor_.lock();
    if (imageProcessor)
    {
@@ -3359,7 +3359,7 @@ string CMMCore::getImageProcessorDevice()
  */
 string CMMCore::getSLMDevice()
 {
-   boost::shared_ptr<SLMInstance> slm = currentSLMDevice_.lock();
+   std::shared_ptr<SLMInstance> slm = currentSLMDevice_.lock();
    if (slm)
    {
       return slm->GetLabel();
@@ -3373,7 +3373,7 @@ string CMMCore::getSLMDevice()
  */
 string CMMCore::getGalvoDevice()
 {
-   boost::shared_ptr<GalvoInstance> galvos = currentGalvoDevice_.lock();
+   std::shared_ptr<GalvoInstance> galvos = currentGalvoDevice_.lock();
    if (galvos)
    {
       return galvos->GetLabel();
@@ -3510,7 +3510,7 @@ void CMMCore::setShutterDevice(const char* shutterLabel) throw (CMMError)
 
    // To avoid confusion close the current shutter:
    bool shutterWasOpen = false;
-   boost::shared_ptr<ShutterInstance> oldShutter =
+   std::shared_ptr<ShutterInstance> oldShutter =
       currentShutterDevice_.lock();
    if (oldShutter)
    {
@@ -3641,7 +3641,7 @@ vector<string> CMMCore::getDevicePropertyNames(const char* label) throw (CMMErro
 {
    if (IsCoreDeviceLabel(label))
       return properties_->GetNames();
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    {
       mm::DeviceModuleLockGuard guard(pDevice);
@@ -3691,7 +3691,7 @@ std::vector<std::string> CMMCore::getAllowedPropertyValues(const char* label, co
    if (IsCoreDeviceLabel(label))
       return properties_->GetAllowedValues(propName);
 
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    std::vector<std::string> valueList;
@@ -3720,7 +3720,7 @@ string CMMCore::getProperty(const char* label, const char* propName) throw (CMME
 {
    if (IsCoreDeviceLabel(label))
       return properties_->Get(propName);
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -3792,7 +3792,7 @@ void CMMCore::setProperty(const char* label, const char* propName,
    }
    else
    {
-      boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+      std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
       mm::DeviceModuleLockGuard guard(pDevice);
 
@@ -3866,7 +3866,7 @@ bool CMMCore::hasProperty(const char* label, const char* propName) throw (CMMErr
 {
    if (IsCoreDeviceLabel(label))
       return properties_->Has(propName);
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -3884,7 +3884,7 @@ bool CMMCore::isPropertyReadOnly(const char* label, const char* propName) throw 
 {
    if (IsCoreDeviceLabel(label))
       return properties_->IsReadOnly(propName);
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -3902,7 +3902,7 @@ bool CMMCore::isPropertyPreInit(const char* label, const char* propName) throw (
 {
    if (IsCoreDeviceLabel(label))
       return false;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -3916,7 +3916,7 @@ double CMMCore::getPropertyLowerLimit(const char* label, const char* propName) t
 {
    if (IsCoreDeviceLabel(label))
       return 0.0;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -3930,7 +3930,7 @@ double CMMCore::getPropertyUpperLimit(const char* label, const char* propName) t
 {
    if (IsCoreDeviceLabel(label))
       return 0.0;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -3946,7 +3946,7 @@ bool CMMCore::hasPropertyLimits(const char* label, const char* propName) throw (
 {
    if (IsCoreDeviceLabel(label))
       return false;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -3962,7 +3962,7 @@ bool CMMCore::isPropertySequenceable(const char* label, const char* propName) th
 {
    if (IsCoreDeviceLabel(label))
       return false;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -3979,7 +3979,7 @@ long CMMCore::getPropertySequenceMaxLength(const char* label, const char* propNa
 {
    if (IsCoreDeviceLabel(label))
       return 0;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -3998,7 +3998,7 @@ void CMMCore::startPropertySequence(const char* label, const char* propName) thr
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
       return;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -4016,7 +4016,7 @@ void CMMCore::stopPropertySequence(const char* label, const char* propName) thro
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
       return;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -4035,7 +4035,7 @@ void CMMCore::loadPropertySequence(const char* label, const char* propName, std:
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
       return;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -4061,7 +4061,7 @@ MM::PropertyType CMMCore::getPropertyType(const char* label, const char* propNam
    if (IsCoreDeviceLabel(label))
       // TODO: return the proper core type
       return MM::Undef;
-   boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
    CheckPropertyName(propName);
 
    mm::DeviceModuleLockGuard guard(pDevice);
@@ -4075,7 +4075,7 @@ MM::PropertyType CMMCore::getPropertyType(const char* label, const char* propNam
  */
 unsigned CMMCore::getImageWidth()
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       return 0;
@@ -4091,7 +4091,7 @@ unsigned CMMCore::getImageWidth()
  */
 unsigned CMMCore::getImageHeight()
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       return 0;
@@ -4108,7 +4108,7 @@ unsigned CMMCore::getImageHeight()
  */
 unsigned CMMCore::getBytesPerPixel()
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       return 0;
@@ -4127,7 +4127,7 @@ unsigned CMMCore::getBytesPerPixel()
  */
 unsigned CMMCore::getImageBitDepth()
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       return 0;
@@ -4143,7 +4143,7 @@ unsigned CMMCore::getImageBitDepth()
  */
 unsigned CMMCore::getNumberOfComponents()
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       return 0;
@@ -4157,7 +4157,7 @@ unsigned CMMCore::getNumberOfComponents()
  */
 unsigned CMMCore::getNumberOfCameraChannels()
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       return 0;
@@ -4172,7 +4172,7 @@ unsigned CMMCore::getNumberOfCameraChannels()
  */
 string CMMCore::getCameraChannelName(unsigned int channelNr)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       return std::string();
@@ -4188,7 +4188,7 @@ string CMMCore::getCameraChannelName(unsigned int channelNr)
  */
 void CMMCore::setExposure(double dExp) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
@@ -4211,7 +4211,7 @@ void CMMCore::setExposure(double dExp) throw (CMMError)
  */
 void CMMCore::setExposure(const char* label, double dExp) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCamera =
+   std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
 
    {
@@ -4241,7 +4241,7 @@ void CMMCore::setExposure(const char* label, double dExp) throw (CMMError)
  */
 double CMMCore::getExposure() throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       mm::DeviceModuleLockGuard guard(camera);
@@ -4259,7 +4259,7 @@ double CMMCore::getExposure() throw (CMMError)
 */
 double CMMCore::getExposure(const char* label) throw (CMMError)
 {
-  boost::shared_ptr<CameraInstance> pCamera =
+  std::shared_ptr<CameraInstance> pCamera =
         deviceManager_->GetDeviceOfType<CameraInstance>(label);
   if (pCamera)
   {
@@ -4289,7 +4289,7 @@ double CMMCore::getExposure(const char* label) throw (CMMError)
  */
 void CMMCore::setROI(int x, int y, int xSize, int ySize) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       mm::DeviceModuleLockGuard guard(camera);
@@ -4330,7 +4330,7 @@ void CMMCore::setROI(int x, int y, int xSize, int ySize) throw (CMMError)
 void CMMCore::getROI(int& x, int& y, int& xSize, int& ySize) throw (CMMError)
 {
    unsigned uX(0), uY(0), uXSize(0), uYSize(0);
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       mm::DeviceModuleLockGuard guard(camera);
@@ -4368,7 +4368,7 @@ void CMMCore::getROI(int& x, int& y, int& xSize, int& ySize) throw (CMMError)
 */
 void CMMCore::setROI(const char* label, int x, int y, int xSize, int ySize) throw (CMMError)
 {
-  boost::shared_ptr<CameraInstance> camera = deviceManager_->GetDeviceOfType<CameraInstance>(label);
+  std::shared_ptr<CameraInstance> camera = deviceManager_->GetDeviceOfType<CameraInstance>(label);
   if (camera)
   {
      mm::DeviceModuleLockGuard guard(camera);
@@ -4406,7 +4406,7 @@ void CMMCore::setROI(const char* label, int x, int y, int xSize, int ySize) thro
  */
 void CMMCore::getROI(const char* label, int& x, int& y, int& xSize, int& ySize) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> pCam =
+   std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
 
    unsigned uX(0), uY(0), uXSize(0), uYSize(0);
@@ -4429,7 +4429,7 @@ void CMMCore::getROI(const char* label, int& x, int& y, int& xSize, int& ySize) 
  */
 void CMMCore::clearROI() throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       // effectively clears the current ROI setting
@@ -4451,7 +4451,7 @@ void CMMCore::clearROI() throw (CMMError)
  */
 bool CMMCore::isMultiROISupported() throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
@@ -4465,7 +4465,7 @@ bool CMMCore::isMultiROISupported() throw (CMMError)
  */
 bool CMMCore::isMultiROIEnabled() throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
@@ -4494,7 +4494,7 @@ void CMMCore::setMultiROI(std::vector<unsigned> xs, std::vector<unsigned> ys,
    {
 	   throw CMMError("Inconsistent ROI parameter lengths");
    }
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
@@ -4536,7 +4536,7 @@ void CMMCore::getMultiROI(std::vector<unsigned>& xs, std::vector<unsigned>& ys,
       std::vector<unsigned>& widths,
       std::vector<unsigned>& heights) throw (CMMError)
 {
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
    {
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
@@ -4595,7 +4595,7 @@ void CMMCore::getMultiROI(std::vector<unsigned>& xs, std::vector<unsigned>& ys,
  */
 void CMMCore::setState(const char* deviceLabel, long state) throw (CMMError)
 {
-   boost::shared_ptr<StateInstance> pStateDev =
+   std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
    mm::DeviceModuleLockGuard guard(pStateDev);
 
@@ -4633,7 +4633,7 @@ void CMMCore::setState(const char* deviceLabel, long state) throw (CMMError)
  */
 long CMMCore::getState(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<StateInstance> pStateDev =
+   std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
    mm::DeviceModuleLockGuard guard(pStateDev);
 
@@ -4655,7 +4655,7 @@ long CMMCore::getNumberOfStates(const char* deviceLabel)
 {
    try
    {
-      boost::shared_ptr<StateInstance> pStateDev =
+      std::shared_ptr<StateInstance> pStateDev =
          deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
       mm::DeviceModuleLockGuard guard(pStateDev);
       return pStateDev->GetNumberOfPositions();
@@ -4674,7 +4674,7 @@ long CMMCore::getNumberOfStates(const char* deviceLabel)
  */
 void CMMCore::setStateLabel(const char* deviceLabel, const char* stateLabel) throw (CMMError)
 {
-   boost::shared_ptr<StateInstance> pStateDev =
+   std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
    CheckStateLabel(stateLabel);
 
@@ -4711,7 +4711,7 @@ void CMMCore::setStateLabel(const char* deviceLabel, const char* stateLabel) thr
  */
 string CMMCore::getStateLabel(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<StateInstance> pStateDev =
+   std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pStateDev);
@@ -4727,7 +4727,7 @@ string CMMCore::getStateLabel(const char* deviceLabel) throw (CMMError)
  */
 void CMMCore::defineStateLabel(const char* deviceLabel, long state, const char* label) throw (CMMError)
 {
-   boost::shared_ptr<StateInstance> pStateDev =
+   std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
    CheckStateLabel(label);
 
@@ -4788,7 +4788,7 @@ void CMMCore::defineStateLabel(const char* deviceLabel, long state, const char* 
  */
 vector<string> CMMCore::getStateLabels(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<StateInstance> pStateDev =
+   std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pStateDev);
@@ -4809,7 +4809,7 @@ vector<string> CMMCore::getStateLabels(const char* deviceLabel) throw (CMMError)
  */
 long CMMCore::getStateFromLabel(const char* deviceLabel, const char* stateLabel) throw (CMMError)
 {
-   boost::shared_ptr<StateInstance> pStateDev =
+   std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
    CheckStateLabel(stateLabel);
 
@@ -5468,7 +5468,7 @@ double CMMCore::getPixelSizeUm(bool cached)
 
       double pixSize = pCfg->getPixelSizeUm();
 
-      boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+      std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
       if (camera)
       {
          mm::DeviceModuleLockGuard guard(camera);
@@ -5522,7 +5522,7 @@ std::vector<double> CMMCore::getPixelSizeAffine(bool cached) throw (CMMError)
       PixelSizeConfiguration* pCfg = pixelSizeGroup_->Find(resolutionID.c_str());
       std::vector<double> af = pCfg->getPixelConfigAffineMatrix();
 
-      boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+      std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
       int binning = 1;
       if (camera)
       {
@@ -5599,7 +5599,7 @@ double CMMCore::getMagnificationFactor() const
    {
       try
       {
-         boost::shared_ptr<MagnifierInstance> magnifier =
+         std::shared_ptr<MagnifierInstance> magnifier =
             deviceManager_->GetDeviceOfType<MagnifierInstance>(magnifiers[i]);
 
          mm::DeviceModuleLockGuard guard(magnifier);
@@ -5712,7 +5712,7 @@ PropertyBlock CMMCore::getPropertyBlockData(const char* blockName)
  */
 PropertyBlock CMMCore::getStateLabelData(const char* deviceLabel, const char* stateLabel)
 {
-   boost::shared_ptr<StateInstance> pStateDev =
+   std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
    CheckStateLabel(stateLabel);
 
@@ -5746,7 +5746,7 @@ PropertyBlock CMMCore::getStateLabelData(const char* deviceLabel, const char* st
  */
 PropertyBlock CMMCore::getData(const char* deviceLabel)
 {
-   boost::shared_ptr<StateInstance> pStateDev =
+   std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
 
    // here we could have written simply:
@@ -5795,7 +5795,7 @@ void CMMCore::setSerialProperties(const char* portName,
  */
 void CMMCore::setSerialPortCommand(const char* portLabel, const char* command, const char* term) throw (CMMError)
 {
-   boost::shared_ptr<SerialInstance> pSerial =
+   std::shared_ptr<SerialInstance> pSerial =
       deviceManager_->GetDeviceOfType<SerialInstance>(portLabel);
    if (!command)
       command = ""; // XXX Or should we throw?
@@ -5815,7 +5815,7 @@ void CMMCore::setSerialPortCommand(const char* portLabel, const char* command, c
  */
 std::string CMMCore::getSerialPortAnswer(const char* portLabel, const char* term) throw (CMMError)
 {
-   boost::shared_ptr<SerialInstance> pSerial =
+   std::shared_ptr<SerialInstance> pSerial =
       deviceManager_->GetDeviceOfType<SerialInstance>(portLabel);
    if (!term || term[0] == '\0')
       throw CMMError("Null or empty terminator; cannot delimit received message");
@@ -5838,7 +5838,7 @@ std::string CMMCore::getSerialPortAnswer(const char* portLabel, const char* term
  */
 void CMMCore::writeToSerialPort(const char* portLabel, const std::vector<char> &data) throw (CMMError)
 {
-   boost::shared_ptr<SerialInstance> pSerial =
+   std::shared_ptr<SerialInstance> pSerial =
       deviceManager_->GetDeviceOfType<SerialInstance>(portLabel);
 
    int ret = pSerial->Write((unsigned char*)(&(data[0])), (unsigned long)data.size());
@@ -5854,7 +5854,7 @@ void CMMCore::writeToSerialPort(const char* portLabel, const std::vector<char> &
  */
 vector<char> CMMCore::readFromSerialPort(const char* portLabel) throw (CMMError)
 {
-   boost::shared_ptr<SerialInstance> pSerial =
+   std::shared_ptr<SerialInstance> pSerial =
       deviceManager_->GetDeviceOfType<SerialInstance>(portLabel);
 
    const int bufLen = 1024; // internal chunk size limit
@@ -5881,7 +5881,7 @@ vector<char> CMMCore::readFromSerialPort(const char* portLabel) throw (CMMError)
  */
 void CMMCore::setSLMImage(const char* deviceLabel, unsigned char* pixels) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
    if (!pixels)
       throw CMMError("Null image");
@@ -5899,7 +5899,7 @@ void CMMCore::setSLMImage(const char* deviceLabel, unsigned char* pixels) throw 
  */
 void CMMCore::setSLMImage(const char* deviceLabel, imgRGB32 pixels) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
    if (!pixels)
       throw CMMError("Null image");
@@ -5917,7 +5917,7 @@ void CMMCore::setSLMImage(const char* deviceLabel, imgRGB32 pixels) throw (CMMEr
  */
 void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char intensity) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -5934,7 +5934,7 @@ void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char intensity) t
  */
 void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char red, unsigned char green, unsigned char blue) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -5951,7 +5951,7 @@ void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char red, unsigne
  */
 void CMMCore::displaySLMImage(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -5969,7 +5969,7 @@ void CMMCore::displaySLMImage(const char* deviceLabel) throw (CMMError)
  */
 void CMMCore::setSLMExposure(const char* deviceLabel, double exposure_ms) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -5986,7 +5986,7 @@ void CMMCore::setSLMExposure(const char* deviceLabel, double exposure_ms) throw 
  */
 double CMMCore::getSLMExposure(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -6001,7 +6001,7 @@ double CMMCore::getSLMExposure(const char* deviceLabel) throw (CMMError)
  */
 unsigned CMMCore::getSLMWidth(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -6016,7 +6016,7 @@ unsigned CMMCore::getSLMWidth(const char* deviceLabel) throw (CMMError)
  */
 unsigned CMMCore::getSLMHeight(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -6031,7 +6031,7 @@ unsigned CMMCore::getSLMHeight(const char* deviceLabel) throw (CMMError)
  */
 unsigned CMMCore::getSLMNumberOfComponents(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -6045,7 +6045,7 @@ unsigned CMMCore::getSLMNumberOfComponents(const char* deviceLabel) throw (CMMEr
  */
 unsigned CMMCore::getSLMBytesPerPixel(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -6060,7 +6060,7 @@ unsigned CMMCore::getSLMBytesPerPixel(const char* deviceLabel) throw (CMMError)
  */
 long CMMCore::getSLMSequenceMaxLength(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -6078,7 +6078,7 @@ long CMMCore::getSLMSequenceMaxLength(const char* deviceLabel) throw (CMMError)
  */
 void CMMCore::startSLMSequence(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -6094,7 +6094,7 @@ void CMMCore::startSLMSequence(const char* deviceLabel) throw (CMMError)
  */
 void CMMCore::stopSLMSequence(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pSLM);
@@ -6111,7 +6111,7 @@ void CMMCore::stopSLMSequence(const char* deviceLabel) throw (CMMError)
  */
 void CMMCore::loadSLMSequence(const char* deviceLabel, std::vector<unsigned char *> imageSequence) throw (CMMError)
 {
-   boost::shared_ptr<SLMInstance> pSLM =
+   std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
 
 
@@ -6142,7 +6142,7 @@ void CMMCore::loadSLMSequence(const char* deviceLabel, std::vector<unsigned char
  */
 void CMMCore::pointGalvoAndFire(const char* deviceLabel, double x, double y, double pulseTime_us) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6158,7 +6158,7 @@ void CMMCore::pointGalvoAndFire(const char* deviceLabel, double x, double y, dou
 
 void CMMCore::setGalvoSpotInterval(const char* deviceLabel, double pulseTime_us) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6178,7 +6178,7 @@ void CMMCore::setGalvoSpotInterval(const char* deviceLabel, double pulseTime_us)
  */
 void CMMCore::setGalvoPosition(const char* deviceLabel, double x, double y) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6197,7 +6197,7 @@ void CMMCore::setGalvoPosition(const char* deviceLabel, double x, double y) thro
  */
 void CMMCore::getGalvoPosition(const char* deviceLabel, double &x, double &y) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6216,7 +6216,7 @@ void CMMCore::getGalvoPosition(const char* deviceLabel, double &x, double &y) th
  */
 void CMMCore::setGalvoIlluminationState(const char* deviceLabel, bool on) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6237,7 +6237,7 @@ void CMMCore::setGalvoIlluminationState(const char* deviceLabel, bool on) throw 
  */
 double CMMCore::getGalvoXRange(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6249,7 +6249,7 @@ double CMMCore::getGalvoXRange(const char* deviceLabel) throw (CMMError)
  */
 double CMMCore::getGalvoXMinimum(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6261,7 +6261,7 @@ double CMMCore::getGalvoXMinimum(const char* deviceLabel) throw (CMMError)
  */
 double CMMCore::getGalvoYRange(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6273,7 +6273,7 @@ double CMMCore::getGalvoYRange(const char* deviceLabel) throw (CMMError)
  */
 double CMMCore::getGalvoYMinimum(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6285,7 +6285,7 @@ double CMMCore::getGalvoYMinimum(const char* deviceLabel) throw (CMMError)
  */
 void CMMCore::addGalvoPolygonVertex(const char* deviceLabel, int polygonIndex, double x, double y) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6304,7 +6304,7 @@ void CMMCore::addGalvoPolygonVertex(const char* deviceLabel, int polygonIndex, d
  */
 void CMMCore::deleteGalvoPolygons(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6324,7 +6324,7 @@ void CMMCore::deleteGalvoPolygons(const char* deviceLabel) throw (CMMError)
  */
 void CMMCore::loadGalvoPolygons(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6343,7 +6343,7 @@ void CMMCore::loadGalvoPolygons(const char* deviceLabel) throw (CMMError)
  */
 void CMMCore::setGalvoPolygonRepetitions(const char* deviceLabel, int repetitions) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6363,7 +6363,7 @@ void CMMCore::setGalvoPolygonRepetitions(const char* deviceLabel, int repetition
  */
 void CMMCore::runGalvoPolygons(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6382,7 +6382,7 @@ void CMMCore::runGalvoPolygons(const char* deviceLabel) throw (CMMError)
  */
 void CMMCore::runGalvoSequence(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6401,7 +6401,7 @@ void CMMCore::runGalvoSequence(const char* deviceLabel) throw (CMMError)
  */
 string CMMCore::getGalvoChannel(const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<GalvoInstance> pGalvo =
+   std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
 
    mm::DeviceModuleLockGuard guard(pGalvo);
@@ -6548,7 +6548,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
    vector<string>::const_iterator it;
    for (it=devices.begin(); it != devices.end(); it++)
    {
-      boost::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(*it);
+      std::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(*it);
       mm::DeviceModuleLockGuard guard(pDev);
       os << MM::g_CFGCommand_Device << "," << *it << "," << pDev->GetAdapterModule()->GetName() << "," << pDev->GetName() << endl;
    }
@@ -6577,7 +6577,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
          continue;
 
       // check if the property must be set before initialization
-      boost::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(s.getDeviceLabel());
+      std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(s.getDeviceLabel());
       if (pDevice)
       {
          mm::DeviceModuleLockGuard guard(pDevice);
@@ -6594,7 +6594,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
    os << "# Hub references" << endl;
    for (it=devices.begin(); it != devices.end(); it++)
    {
-      boost::shared_ptr<DeviceInstance> device = deviceManager_->GetDevice(*it);
+      std::shared_ptr<DeviceInstance> device = deviceManager_->GetDevice(*it);
       mm::DeviceModuleLockGuard guard(device);
       std::string parentID = device->GetParentID();
       if (!parentID.empty())
@@ -6611,7 +6611,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
    os << "# Delays" << endl;
    for (it=devices.begin(); it != devices.end(); it++)
    {
-      boost::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(*it);
+      std::shared_ptr<DeviceInstance> pDev = deviceManager_->GetDevice(*it);
       mm::DeviceModuleLockGuard guard(pDev);
       if (pDev->GetDelayMs() > 0.0)
          os << MM::g_CFGCommand_Delay << "," << *it << "," << pDev->GetDelayMs() << endl;
@@ -6624,7 +6624,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
    for (std::vector<std::string>::const_iterator it = stageLabels.begin(),
          end = stageLabels.end(); it != end; ++it)
    {
-      boost::shared_ptr<StageInstance> stage =
+      std::shared_ptr<StageInstance> stage =
          deviceManager_->GetDeviceOfType<StageInstance>(*it);
       mm::DeviceModuleLockGuard guard(stage);
       int direction = getFocusDirection(it->c_str());
@@ -6637,7 +6637,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
    vector<string> deviceLabels = deviceManager_->GetDeviceList(MM::StateDevice);
    for (size_t i=0; i<deviceLabels.size(); i++)
    {
-      boost::shared_ptr<StateInstance> pSD =
+      std::shared_ptr<StateInstance> pSD =
          deviceManager_->GetDeviceOfType<StateInstance>(deviceLabels[i]);
       mm::DeviceModuleLockGuard guard(pSD);
       unsigned numPos = pSD->GetNumberOfPositions();
@@ -6685,17 +6685,17 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
 
    // save device roles
    os << "# Roles" << endl;
-   boost::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
+   std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
       os << MM::g_CFGCommand_Property << ',' << MM::g_Keyword_CoreDevice << ',' << MM::g_Keyword_CoreCamera << ',' << camera->GetLabel() << endl;
    }
-   boost::shared_ptr<ShutterInstance> shutter = currentShutterDevice_.lock();
+   std::shared_ptr<ShutterInstance> shutter = currentShutterDevice_.lock();
    if (shutter)
    {
       os << MM::g_CFGCommand_Property << ',' << MM::g_Keyword_CoreDevice << ',' << MM::g_Keyword_CoreShutter << ',' << shutter->GetLabel() << endl;
    }
-   boost::shared_ptr<StageInstance> focus = currentFocusDevice_.lock();
+   std::shared_ptr<StageInstance> focus = currentFocusDevice_.lock();
    if (focus)
    {
       os << MM::g_CFGCommand_Property << ',' << MM::g_Keyword_CoreDevice << ',' << MM::g_Keyword_CoreFocus << ',' << focus->GetLabel() << endl;
@@ -7015,7 +7015,7 @@ void CMMCore::registerCallback(MMEventCallback* cb)
  */
 double CMMCore::getLastFocusScore()
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -7038,7 +7038,7 @@ double CMMCore::getLastFocusScore()
  */
 double CMMCore::getCurrentFocusScore()
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -7059,7 +7059,7 @@ double CMMCore::getCurrentFocusScore()
  */
 void CMMCore::enableContinuousFocus(bool enable) throw (CMMError)
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -7089,7 +7089,7 @@ void CMMCore::enableContinuousFocus(bool enable) throw (CMMError)
  */
 bool CMMCore::isContinuousFocusEnabled() throw (CMMError)
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -7112,7 +7112,7 @@ bool CMMCore::isContinuousFocusEnabled() throw (CMMError)
 */
 bool CMMCore::isContinuousFocusLocked() throw (CMMError)
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
 	{
@@ -7130,7 +7130,7 @@ bool CMMCore::isContinuousFocusLocked() throw (CMMError)
  */
 bool CMMCore::isContinuousFocusDrive(const char* stageLabel) throw (CMMError)
 {
-   boost::shared_ptr<StageInstance> pStage =
+   std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(stageLabel);
 
    mm::DeviceModuleLockGuard guard(pStage);
@@ -7143,7 +7143,7 @@ bool CMMCore::isContinuousFocusDrive(const char* stageLabel) throw (CMMError)
  */
 void CMMCore::fullFocus() throw (CMMError)
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -7166,7 +7166,7 @@ void CMMCore::fullFocus() throw (CMMError)
  */
 void CMMCore::incrementalFocus() throw (CMMError)
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -7190,7 +7190,7 @@ void CMMCore::incrementalFocus() throw (CMMError)
  */
 void CMMCore::setAutoFocusOffset(double offset) throw (CMMError)
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -7213,7 +7213,7 @@ void CMMCore::setAutoFocusOffset(double offset) throw (CMMError)
  */
 double CMMCore::getAutoFocusOffset() throw (CMMError)
 {
-   boost::shared_ptr<AutoFocusInstance> autofocus =
+   std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
@@ -7467,7 +7467,7 @@ void CMMCore::applyConfiguration(const Configuration& config) throw (CMMError)
       else
       {
          // normal processing
-         boost::shared_ptr<DeviceInstance> pDevice =
+         std::shared_ptr<DeviceInstance> pDevice =
             deviceManager_->GetDevice(setting.getDeviceLabel());
          mm::DeviceModuleLockGuard guard(pDevice);
          try
@@ -7514,7 +7514,7 @@ int CMMCore::applyProperties(vector<PropertySetting>& props, string& lastError)
    for (size_t i=0; i<props.size(); i++)
    {
       // normal processing
-      boost::shared_ptr<DeviceInstance> pDevice =
+      std::shared_ptr<DeviceInstance> pDevice =
          deviceManager_->GetDevice(props[i].getDeviceLabel());
       mm::DeviceModuleLockGuard guard(pDevice);
       try
@@ -7542,7 +7542,7 @@ int CMMCore::applyProperties(vector<PropertySetting>& props, string& lastError)
 
 
 
-string CMMCore::getDeviceErrorText(int deviceCode, boost::shared_ptr<DeviceInstance> device)
+string CMMCore::getDeviceErrorText(int deviceCode, std::shared_ptr<DeviceInstance> device)
 {
    if (!device)
    {
@@ -7575,7 +7575,7 @@ void CMMCore::logError(const char* device, const char* msg)
    LOG_ERROR(coreLogger_) << "Error occurred in device " << device << ": " << msg;
 }
 
-string CMMCore::getDeviceName(boost::shared_ptr<DeviceInstance> pDev)
+string CMMCore::getDeviceName(std::shared_ptr<DeviceInstance> pDev)
 {
    mm::DeviceModuleLockGuard guard(pDev);
    return pDev->GetName();
@@ -7610,7 +7610,7 @@ bool CMMCore::supportsDeviceDetection(char* label)
 {
    try
    {
-      boost::shared_ptr<DeviceInstance> pDevice =
+      std::shared_ptr<DeviceInstance> pDevice =
          deviceManager_->GetDevice(label);
       mm::DeviceModuleLockGuard guard(pDevice);
       return pDevice->SupportsDeviceDetection();
@@ -7649,7 +7649,7 @@ MM::DeviceDetectionStatus CMMCore::detectDevice(char* label)
 
    try
    {
-      boost::shared_ptr<DeviceInstance> pDevice =
+      std::shared_ptr<DeviceInstance> pDevice =
          deviceManager_->GetDevice(label);
 
       mm::DeviceModuleLockGuard guard(pDevice);
@@ -7745,7 +7745,7 @@ MM::DeviceDetectionStatus CMMCore::detectDevice(char* label)
  */
 std::vector<std::string> CMMCore::getInstalledDevices(const char* hubDeviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<HubInstance> pHub =
+   std::shared_ptr<HubInstance> pHub =
       deviceManager_->GetDeviceOfType<HubInstance>(hubDeviceLabel);
 
    mm::DeviceModuleLockGuard guard(pHub);
@@ -7760,7 +7760,7 @@ std::vector<std::string> CMMCore::getLoadedPeripheralDevices(const char* hubLabe
 
 std::string CMMCore::getInstalledDeviceDescription(const char* hubLabel, const char* deviceLabel) throw (CMMError)
 {
-   boost::shared_ptr<HubInstance> pHub =
+   std::shared_ptr<HubInstance> pHub =
       deviceManager_->GetDeviceOfType<HubInstance>(hubLabel);
    CheckDeviceLabel(deviceLabel);
 

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -62,12 +62,10 @@
 #include "ErrorCodes.h"
 #include "Logging/Logger.h"
 
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
-
 #include <cstring>
 #include <deque>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -646,20 +644,20 @@ private:
 private:
    // LogManager should be the first data member, so that it is available for
    // as long as possible during construction and (especially) destruction.
-   boost::shared_ptr<mm::LogManager> logManager_;
+   std::shared_ptr<mm::LogManager> logManager_;
    mm::logging::Logger appLogger_;
    mm::logging::Logger coreLogger_;
 
    bool everSnapped_;
 
-   boost::weak_ptr<CameraInstance> currentCameraDevice_;
-   boost::weak_ptr<ShutterInstance> currentShutterDevice_;
-   boost::weak_ptr<StageInstance> currentFocusDevice_;
-   boost::weak_ptr<XYStageInstance> currentXYStageDevice_;
-   boost::weak_ptr<AutoFocusInstance> currentAutofocusDevice_;
-   boost::weak_ptr<SLMInstance> currentSLMDevice_;
-   boost::weak_ptr<GalvoInstance> currentGalvoDevice_;
-   boost::weak_ptr<ImageProcessorInstance> currentImageProcessor_;
+   std::weak_ptr<CameraInstance> currentCameraDevice_;
+   std::weak_ptr<ShutterInstance> currentShutterDevice_;
+   std::weak_ptr<StageInstance> currentFocusDevice_;
+   std::weak_ptr<XYStageInstance> currentXYStageDevice_;
+   std::weak_ptr<AutoFocusInstance> currentAutofocusDevice_;
+   std::weak_ptr<SLMInstance> currentSLMDevice_;
+   std::weak_ptr<GalvoInstance> currentGalvoDevice_;
+   std::weak_ptr<ImageProcessorInstance> currentImageProcessor_;
 
    std::string channelGroup_;
    long pollingIntervalMs_;
@@ -673,9 +671,9 @@ private:
    PixelSizeConfigGroup* pixelSizeGroup_;
    CircularBuffer* cbuf_;
 
-   std::vector< boost::weak_ptr<DeviceInstance> > imageSynchroDevices_;
-   boost::shared_ptr<CPluginManager> pluginManager_;
-   boost::shared_ptr<mm::DeviceManager> deviceManager_;
+   std::vector< std::weak_ptr<DeviceInstance> > imageSynchroDevices_;
+   std::shared_ptr<CPluginManager> pluginManager_;
+   std::shared_ptr<mm::DeviceManager> deviceManager_;
    std::map<int, std::string> errorText_;
    CPropBlockMap propBlocks_;
 
@@ -703,13 +701,13 @@ private:
 
    void applyConfiguration(const Configuration& config) throw (CMMError);
    int applyProperties(std::vector<PropertySetting>& props, std::string& lastError);
-   void waitForDevice(boost::shared_ptr<DeviceInstance> pDev) throw (CMMError);
+   void waitForDevice(std::shared_ptr<DeviceInstance> pDev) throw (CMMError);
    Configuration getConfigGroupState(const char* group, bool fromCache) throw (CMMError);
-   std::string getDeviceErrorText(int deviceCode, boost::shared_ptr<DeviceInstance> pDevice);
-   std::string getDeviceName(boost::shared_ptr<DeviceInstance> pDev);
+   std::string getDeviceErrorText(int deviceCode, std::shared_ptr<DeviceInstance> pDevice);
+   std::string getDeviceName(std::shared_ptr<DeviceInstance> pDev);
    void logError(const char* device, const char* msg);
    void updateAllowedChannelGroups();
-   void assignDefaultRole(boost::shared_ptr<DeviceInstance> pDev);
+   void assignDefaultRole(std::shared_ptr<DeviceInstance> pDev);
    void updateCoreProperty(const char* propName, MM::DeviceType devType) throw (CMMError);
    void loadSystemConfigurationImpl(const char* fileName) throw (CMMError);
 };

--- a/MMCore/PluginManager.cpp
+++ b/MMCore/PluginManager.cpp
@@ -38,10 +38,10 @@
 #include "PluginManager.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/make_shared.hpp>
 
 #include <cstring>
 #include <fstream>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -130,7 +130,7 @@ CPluginManager::FindInSearchPath(std::string filename)
  *
  * @param moduleName Simple module name without path, prefix, or suffix.
  */
-boost::shared_ptr<LoadedDeviceAdapter>
+std::shared_ptr<LoadedDeviceAdapter>
 CPluginManager::GetDeviceAdapter(const std::string& moduleName)
 {
    if (moduleName.empty())
@@ -138,7 +138,7 @@ CPluginManager::GetDeviceAdapter(const std::string& moduleName)
       throw CMMError("Empty device adapter module name");
    }
 
-   std::map< std::string, boost::shared_ptr<LoadedDeviceAdapter> >::iterator it =
+   std::map< std::string, std::shared_ptr<LoadedDeviceAdapter> >::iterator it =
       moduleMap_.find(moduleName);
    if (it != moduleMap_.end())
    {
@@ -150,13 +150,13 @@ CPluginManager::GetDeviceAdapter(const std::string& moduleName)
    filename += LIB_NAME_SUFFIX;
    filename = FindInSearchPath(filename);
 
-   boost::shared_ptr<LoadedDeviceAdapter> module =
-      boost::make_shared<LoadedDeviceAdapter>(moduleName, filename);
+   std::shared_ptr<LoadedDeviceAdapter> module =
+      std::make_shared<LoadedDeviceAdapter>(moduleName, filename);
    moduleMap_[moduleName] = module;
    return module;
 }
 
-boost::shared_ptr<LoadedDeviceAdapter>
+std::shared_ptr<LoadedDeviceAdapter>
 CPluginManager::GetDeviceAdapter(const char* moduleName)
 {
    if (!moduleName)
@@ -172,7 +172,7 @@ CPluginManager::GetDeviceAdapter(const char* moduleName)
 void
 CPluginManager::UnloadPluginLibrary(const char* moduleName)
 {
-   std::map< std::string, boost::shared_ptr<LoadedDeviceAdapter> >::iterator it =
+   std::map< std::string, std::shared_ptr<LoadedDeviceAdapter> >::iterator it =
       moduleMap_.find(moduleName);
    if (it == moduleMap_.end())
       throw CMMError("No device adapter named " + ToQuotedString(moduleName));

--- a/MMCore/PluginManager.cpp
+++ b/MMCore/PluginManager.cpp
@@ -211,7 +211,7 @@ CPluginManager::AddLegacyFallbackSearchPath(const std::string& path)
 }
 
 
-// TODO Use Boost.Filesystem instead of this.
+// TODO Use std::filesystem instead of this.
 // This stop-gap implementation makes the assumption that the argument is in
 // the format that could be returned from MMCorePrivate::GetPathOfThisModule()
 // (e.g. no trailing slashes; real filename present).

--- a/MMCore/PluginManager.h
+++ b/MMCore/PluginManager.h
@@ -26,10 +26,8 @@
 
 #include "../MMDevice/DeviceThreads.h"
 
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
-
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -59,9 +57,9 @@ public:
    /**
     * Return a device adapter module, loading it if necessary
     */
-   boost::shared_ptr<LoadedDeviceAdapter>
+   std::shared_ptr<LoadedDeviceAdapter>
    GetDeviceAdapter(const std::string& moduleName);
-   boost::shared_ptr<LoadedDeviceAdapter>
+   std::shared_ptr<LoadedDeviceAdapter>
    GetDeviceAdapter(const char* moduleName);
 
 private:
@@ -73,7 +71,7 @@ private:
    std::vector<std::string> preferredSearchPaths_;
    static std::vector<std::string> fallbackSearchPaths_;
 
-   std::map< std::string, boost::shared_ptr<LoadedDeviceAdapter> > moduleMap_;
+   std::map< std::string, std::shared_ptr<LoadedDeviceAdapter> > moduleMap_;
 };
 
 #endif //_PLUGIN_MANAGER_H_

--- a/MMCore/Semaphore.cpp
+++ b/MMCore/Semaphore.cpp
@@ -23,7 +23,7 @@
 
 #include "Semaphore.h"
 
-#include <boost/thread/locks.hpp>
+#include <mutex>
 
 Semaphore::Semaphore()
     : count_(0)
@@ -37,7 +37,7 @@ Semaphore::Semaphore(size_t initCount)
 
 void Semaphore::Wait(size_t count)
 {
-    boost::unique_lock<boost::mutex> lock(mx_);
+    std::unique_lock<std::mutex> lock(mx_);
     cv_.wait(lock, [&]() { return count_ >= count; });
     count_ -= count;
 }
@@ -45,7 +45,7 @@ void Semaphore::Wait(size_t count)
 void Semaphore::Release(size_t count)
 {
     {
-        boost::lock_guard<boost::mutex> lock(mx_);
+        std::lock_guard<std::mutex> lock(mx_);
         count_ += count;
     }
     cv_.notify_all();

--- a/MMCore/Semaphore.h
+++ b/MMCore/Semaphore.h
@@ -23,10 +23,9 @@
 
 #pragma once
 
-#include <boost/thread/condition_variable.hpp>
-#include <boost/thread/mutex.hpp>
-
+#include <condition_variable>
 #include <cstddef>
+#include <mutex>
 
 class Semaphore/* final*/
 {
@@ -39,6 +38,6 @@ public:
 
 private:
     size_t count_;
-    boost::mutex mx_;
-    boost::condition_variable cv_;
+    std::mutex mx_;
+    std::condition_variable cv_;
 };

--- a/MMCore/Task.cpp
+++ b/MMCore/Task.cpp
@@ -27,7 +27,7 @@
 
 #include <cassert>
 
-Task::Task(boost::shared_ptr<Semaphore> semaphore, size_t taskIndex, size_t totalTaskCount)
+Task::Task(std::shared_ptr<Semaphore> semaphore, size_t taskIndex, size_t totalTaskCount)
     : semaphore_(semaphore),
     taskIndex_(taskIndex),
     totalTaskCount_(totalTaskCount),

--- a/MMCore/Task.h
+++ b/MMCore/Task.h
@@ -23,16 +23,15 @@
 
 #pragma once
 
-#include <boost/smart_ptr/shared_ptr.hpp>
-
 #include <cstddef>
+#include <memory>
 
 class Semaphore;
 
 class Task
 {
 public:
-    explicit Task(boost::shared_ptr<Semaphore> semaphore, size_t taskIndex, size_t totalTaskCount);
+    explicit Task(std::shared_ptr<Semaphore> semaphore, size_t taskIndex, size_t totalTaskCount);
     virtual ~Task();
 
     Task(const Task&)/* = delete*/;
@@ -42,7 +41,7 @@ public:
     void Done();
 
 private:
-    const boost::shared_ptr<Semaphore> semaphore_;
+    const std::shared_ptr<Semaphore> semaphore_;
 
 protected:
     const size_t taskIndex_;

--- a/MMCore/TaskSet.cpp
+++ b/MMCore/TaskSet.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/foreach.hpp>
 
+#include <cassert>
 #include <memory>
 
 TaskSet::TaskSet(std::shared_ptr<ThreadPool> pool)

--- a/MMCore/TaskSet.cpp
+++ b/MMCore/TaskSet.cpp
@@ -24,11 +24,12 @@
 #include "TaskSet.h"
 
 #include <boost/foreach.hpp>
-#include <boost/make_shared.hpp>
 
-TaskSet::TaskSet(boost::shared_ptr<ThreadPool> pool)
+#include <memory>
+
+TaskSet::TaskSet(std::shared_ptr<ThreadPool> pool)
     : pool_(pool),
-    semaphore_(boost::make_shared<Semaphore>()),
+    semaphore_(std::make_shared<Semaphore>()),
     tasks_(),
     usedTaskCount_(0)
 {

--- a/MMCore/TaskSet.h
+++ b/MMCore/TaskSet.h
@@ -27,15 +27,15 @@
 #include "Task.h"
 #include "ThreadPool.h"
 
-#include <boost/smart_ptr/shared_ptr.hpp>
 #include <boost/utility/enable_if.hpp>
 
+#include <memory>
 #include <vector>
 
 class TaskSet
 {
 public:
-    explicit TaskSet(boost::shared_ptr<ThreadPool> pool);
+    explicit TaskSet(std::shared_ptr<ThreadPool> pool);
     virtual ~TaskSet();
 
     TaskSet(const TaskSet&)/* = delete*/;
@@ -66,8 +66,8 @@ protected:
     }
 
 protected:
-    const boost::shared_ptr<ThreadPool> pool_;
-    const boost::shared_ptr<Semaphore> semaphore_;
+    const std::shared_ptr<ThreadPool> pool_;
+    const std::shared_ptr<Semaphore> semaphore_;
     std::vector<Task*> tasks_;
     size_t usedTaskCount_;
 };

--- a/MMCore/TaskSet_CopyMemory.cpp
+++ b/MMCore/TaskSet_CopyMemory.cpp
@@ -28,7 +28,7 @@
 #include <algorithm>
 #include <cassert>
 
-TaskSet_CopyMemory::ATask::ATask(boost::shared_ptr<Semaphore> semDone, size_t taskIndex, size_t totalTaskCount)
+TaskSet_CopyMemory::ATask::ATask(std::shared_ptr<Semaphore> semDone, size_t taskIndex, size_t totalTaskCount)
     : Task(semDone, taskIndex, totalTaskCount),
     dst_(NULL),
     src_(NULL),
@@ -60,7 +60,7 @@ void TaskSet_CopyMemory::ATask::Execute()
     memcpy(dst, src, chunkBytes);
 }
 
-TaskSet_CopyMemory::TaskSet_CopyMemory(boost::shared_ptr<ThreadPool> pool)
+TaskSet_CopyMemory::TaskSet_CopyMemory(std::shared_ptr<ThreadPool> pool)
     : TaskSet(pool)
 {
     CreateTasks<ATask>();

--- a/MMCore/TaskSet_CopyMemory.h
+++ b/MMCore/TaskSet_CopyMemory.h
@@ -31,7 +31,7 @@ private:
     class ATask : public Task
     {
     public:
-        explicit ATask(boost::shared_ptr<Semaphore> semDone, size_t taskIndex, size_t totalTaskCount);
+        explicit ATask(std::shared_ptr<Semaphore> semDone, size_t taskIndex, size_t totalTaskCount);
 
         void SetUp(void* dst, const void* src, size_t bytes, size_t usedTaskCount);
 
@@ -44,7 +44,7 @@ private:
     };
 
 public:
-    explicit TaskSet_CopyMemory(boost::shared_ptr<ThreadPool> pool);
+    explicit TaskSet_CopyMemory(std::shared_ptr<ThreadPool> pool);
 
     void SetUp(void* dst, const void* src, size_t bytes);
 

--- a/MMCore/ThreadPool.cpp
+++ b/MMCore/ThreadPool.cpp
@@ -27,29 +27,30 @@
 #include "Task.h"
 
 #include <boost/foreach.hpp>
-#include <boost/thread/locks.hpp>
 
 #include <algorithm>
 #include <cassert>
 #include <memory>
+#include <mutex>
+#include <thread>
 
 ThreadPool::ThreadPool()
     : abortFlag_(false)
 {
-    const size_t hwThreadCount = std::max<size_t>(1, boost::thread::hardware_concurrency());
+    const size_t hwThreadCount = std::max<size_t>(1, std::thread::hardware_concurrency());
     for (size_t n = 0; n < hwThreadCount; ++n)
-        threads_.push_back(std::make_shared<boost::thread>(&ThreadPool::ThreadFunc, this));
+        threads_.push_back(std::make_shared<std::thread>(&ThreadPool::ThreadFunc, this));
 }
 
 ThreadPool::~ThreadPool()
 {
     {
-        boost::lock_guard<boost::mutex> lock(mx_);
+        std::lock_guard<std::mutex> lock(mx_);
         abortFlag_ = true;
     }
     cv_.notify_all();
 
-    BOOST_FOREACH(const std::shared_ptr<boost::thread>& thread, threads_)
+    BOOST_FOREACH(const std::shared_ptr<std::thread>& thread, threads_)
         thread->join();
 }
 
@@ -62,7 +63,7 @@ void ThreadPool::Execute(Task* task)
 {
     assert(task != NULL);
     {
-        boost::lock_guard<boost::mutex> lock(mx_);
+        std::lock_guard<std::mutex> lock(mx_);
         if (abortFlag_)
             return;
         queue_.push_back(task);
@@ -75,7 +76,7 @@ void ThreadPool::Execute(const std::vector<Task*>& tasks)
     assert(!tasks.empty());
 
     {
-        boost::lock_guard<boost::mutex> lock(mx_);
+        std::lock_guard<std::mutex> lock(mx_);
         if (abortFlag_)
             return;
         BOOST_FOREACH(Task* task, tasks)
@@ -93,7 +94,7 @@ void ThreadPool::ThreadFunc()
     {
         Task* task = NULL;
         {
-            boost::unique_lock<boost::mutex> lock(mx_);
+            std::unique_lock<std::mutex> lock(mx_);
             cv_.wait(lock, [&]() { return abortFlag_ || !queue_.empty(); });
             if (abortFlag_)
                 break;

--- a/MMCore/ThreadPool.cpp
+++ b/MMCore/ThreadPool.cpp
@@ -27,18 +27,18 @@
 #include "Task.h"
 
 #include <boost/foreach.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/thread/locks.hpp>
 
 #include <algorithm>
 #include <cassert>
+#include <memory>
 
 ThreadPool::ThreadPool()
     : abortFlag_(false)
 {
     const size_t hwThreadCount = std::max<size_t>(1, boost::thread::hardware_concurrency());
     for (size_t n = 0; n < hwThreadCount; ++n)
-        threads_.push_back(boost::make_shared<boost::thread>(&ThreadPool::ThreadFunc, this));
+        threads_.push_back(std::make_shared<boost::thread>(&ThreadPool::ThreadFunc, this));
 }
 
 ThreadPool::~ThreadPool()
@@ -49,7 +49,7 @@ ThreadPool::~ThreadPool()
     }
     cv_.notify_all();
 
-    BOOST_FOREACH(const boost::shared_ptr<boost::thread>& thread, threads_)
+    BOOST_FOREACH(const std::shared_ptr<boost::thread>& thread, threads_)
         thread->join();
 }
 

--- a/MMCore/ThreadPool.h
+++ b/MMCore/ThreadPool.h
@@ -47,7 +47,7 @@ private:
     void ThreadFunc();
 
 private:
-    // TODO: Should use boost::unique_ptr but that's available since boost 1.57
+    // TODO: Should use unique_ptr
     std::vector<std::shared_ptr<boost::thread> > threads_;
     bool abortFlag_;
     boost::mutex mx_;

--- a/MMCore/ThreadPool.h
+++ b/MMCore/ThreadPool.h
@@ -24,10 +24,10 @@
 
 #pragma once
 
-#include <boost/smart_ptr/shared_ptr.hpp>
 #include <boost/thread.hpp>
 
 #include <deque>
+#include <memory>
 #include <vector>
 
 class Task;
@@ -48,7 +48,7 @@ private:
 
 private:
     // TODO: Should use boost::unique_ptr but that's available since boost 1.57
-    std::vector<boost::shared_ptr<boost::thread> > threads_;
+    std::vector<std::shared_ptr<boost::thread> > threads_;
     bool abortFlag_;
     boost::mutex mx_;
     boost::condition_variable cv_;

--- a/MMCore/ThreadPool.h
+++ b/MMCore/ThreadPool.h
@@ -24,10 +24,11 @@
 
 #pragma once
 
-#include <boost/thread.hpp>
-
+#include <condition_variable>
 #include <deque>
 #include <memory>
+#include <mutex>
+#include <thread>
 #include <vector>
 
 class Task;
@@ -48,9 +49,9 @@ private:
 
 private:
     // TODO: Should use unique_ptr
-    std::vector<std::shared_ptr<boost::thread> > threads_;
+    std::vector<std::shared_ptr<std::thread> > threads_;
     bool abortFlag_;
-    boost::mutex mx_;
-    boost::condition_variable cv_;
+    std::mutex mx_;
+    std::condition_variable cv_;
     std::deque<Task*> queue_;
 };

--- a/MMCore/unittest/Logger-Tests.cpp
+++ b/MMCore/unittest/Logger-Tests.cpp
@@ -3,10 +3,10 @@
 #include "Logging/Logging.h"
 
 #include <boost/bind.hpp>
-#include <boost/thread.hpp>
 
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 using namespace mm::logging;
@@ -88,12 +88,12 @@ TEST(LoggerTests, SyncAndThreaded)
 
    c->AddSink(std::make_shared<StdErrLogSink>(), SinkModeSynchronous);
 
-   std::vector< std::shared_ptr<boost::thread> > threads;
+   std::vector< std::shared_ptr<std::thread> > threads;
    std::vector< std::shared_ptr<LoggerTestThreadFunc> > funcs;
    for (unsigned i = 0; i < 10; ++i)
    {
       funcs.push_back(std::make_shared<LoggerTestThreadFunc>(i, c));
-      threads.push_back(std::make_shared<boost::thread>(
+      threads.push_back(std::make_shared<std::thread>(
                &LoggerTestThreadFunc::Run, funcs[i].get()));
    }
    for (unsigned i = 0; i < threads.size(); ++i)
@@ -108,12 +108,12 @@ TEST(LoggerTests, AsyncAndThreaded)
 
    c->AddSink(std::make_shared<StdErrLogSink>(), SinkModeAsynchronous);
 
-   std::vector< std::shared_ptr<boost::thread> > threads;
+   std::vector< std::shared_ptr<std::thread> > threads;
    std::vector< std::shared_ptr<LoggerTestThreadFunc> > funcs;
    for (unsigned i = 0; i < 10; ++i)
    {
       funcs.push_back(std::make_shared<LoggerTestThreadFunc>(i, c));
-      threads.push_back(std::make_shared<boost::thread>(
+      threads.push_back(std::make_shared<std::thread>(
                &LoggerTestThreadFunc::Run, funcs[i].get()));
    }
    for (unsigned i = 0; i < threads.size(); ++i)

--- a/MMCore/unittest/Logger-Tests.cpp
+++ b/MMCore/unittest/Logger-Tests.cpp
@@ -2,8 +2,7 @@
 
 #include "Logging/Logging.h"
 
-#include <boost/bind.hpp>
-
+#include <functional>
 #include <memory>
 #include <string>
 #include <thread>

--- a/MMCore/unittest/Logger-Tests.cpp
+++ b/MMCore/unittest/Logger-Tests.cpp
@@ -3,9 +3,9 @@
 #include "Logging/Logging.h"
 
 #include <boost/bind.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/thread.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -14,10 +14,10 @@ using namespace mm::logging;
 
 TEST(LoggerTests, BasicSynchronous)
 {
-   boost::shared_ptr<LoggingCore> c =
-      boost::make_shared<LoggingCore>();
+   std::shared_ptr<LoggingCore> c =
+      std::make_shared<LoggingCore>();
 
-   c->AddSink(boost::make_shared<StdErrLogSink>(), SinkModeSynchronous);
+   c->AddSink(std::make_shared<StdErrLogSink>(), SinkModeSynchronous);
 
    Logger lgr = c->NewLogger("mylabel");
 
@@ -29,10 +29,10 @@ TEST(LoggerTests, BasicSynchronous)
 
 TEST(LoggerTests, BasicAsynchronous)
 {
-   boost::shared_ptr<LoggingCore> c =
-      boost::make_shared<LoggingCore>();
+   std::shared_ptr<LoggingCore> c =
+      std::make_shared<LoggingCore>();
 
-   c->AddSink(boost::make_shared<StdErrLogSink>(), SinkModeAsynchronous);
+   c->AddSink(std::make_shared<StdErrLogSink>(), SinkModeAsynchronous);
 
    Logger lgr = c->NewLogger("mylabel");
 
@@ -44,10 +44,10 @@ TEST(LoggerTests, BasicAsynchronous)
 
 TEST(LoggerTests, BasicLogStream)
 {
-   boost::shared_ptr<LoggingCore> c =
-      boost::make_shared<LoggingCore>();
+   std::shared_ptr<LoggingCore> c =
+      std::make_shared<LoggingCore>();
 
-   c->AddSink(boost::make_shared<StdErrLogSink>(), SinkModeSynchronous);
+   c->AddSink(std::make_shared<StdErrLogSink>(), SinkModeSynchronous);
 
    Logger lgr = c->NewLogger("mylabel");
 
@@ -58,11 +58,11 @@ TEST(LoggerTests, BasicLogStream)
 class LoggerTestThreadFunc
 {
    unsigned n_;
-   boost::shared_ptr<LoggingCore> c_;
+   std::shared_ptr<LoggingCore> c_;
 
 public:
    LoggerTestThreadFunc(unsigned n,
-         boost::shared_ptr<LoggingCore> c) :
+         std::shared_ptr<LoggingCore> c) :
       n_(n), c_(c)
    {}
 
@@ -83,17 +83,17 @@ public:
 
 TEST(LoggerTests, SyncAndThreaded)
 {
-   boost::shared_ptr<LoggingCore> c =
-      boost::make_shared<LoggingCore>();
+   std::shared_ptr<LoggingCore> c =
+      std::make_shared<LoggingCore>();
 
-   c->AddSink(boost::make_shared<StdErrLogSink>(), SinkModeSynchronous);
+   c->AddSink(std::make_shared<StdErrLogSink>(), SinkModeSynchronous);
 
-   std::vector< boost::shared_ptr<boost::thread> > threads;
-   std::vector< boost::shared_ptr<LoggerTestThreadFunc> > funcs;
+   std::vector< std::shared_ptr<boost::thread> > threads;
+   std::vector< std::shared_ptr<LoggerTestThreadFunc> > funcs;
    for (unsigned i = 0; i < 10; ++i)
    {
-      funcs.push_back(boost::make_shared<LoggerTestThreadFunc>(i, c));
-      threads.push_back(boost::make_shared<boost::thread>(
+      funcs.push_back(std::make_shared<LoggerTestThreadFunc>(i, c));
+      threads.push_back(std::make_shared<boost::thread>(
                &LoggerTestThreadFunc::Run, funcs[i].get()));
    }
    for (unsigned i = 0; i < threads.size(); ++i)
@@ -103,17 +103,17 @@ TEST(LoggerTests, SyncAndThreaded)
 
 TEST(LoggerTests, AsyncAndThreaded)
 {
-   boost::shared_ptr<LoggingCore> c =
-      boost::make_shared<LoggingCore>();
+   std::shared_ptr<LoggingCore> c =
+      std::make_shared<LoggingCore>();
 
-   c->AddSink(boost::make_shared<StdErrLogSink>(), SinkModeAsynchronous);
+   c->AddSink(std::make_shared<StdErrLogSink>(), SinkModeAsynchronous);
 
-   std::vector< boost::shared_ptr<boost::thread> > threads;
-   std::vector< boost::shared_ptr<LoggerTestThreadFunc> > funcs;
+   std::vector< std::shared_ptr<boost::thread> > threads;
+   std::vector< std::shared_ptr<LoggerTestThreadFunc> > funcs;
    for (unsigned i = 0; i < 10; ++i)
    {
-      funcs.push_back(boost::make_shared<LoggerTestThreadFunc>(i, c));
-      threads.push_back(boost::make_shared<boost::thread>(
+      funcs.push_back(std::make_shared<LoggerTestThreadFunc>(i, c));
+      threads.push_back(std::make_shared<boost::thread>(
                &LoggerTestThreadFunc::Run, funcs[i].get()));
    }
    for (unsigned i = 0; i < threads.size(); ++i)


### PR DESCRIPTION
Generally, functions and classes were replaced by simple find-and-replace, and #includes were fixed manually.

See commit messages for full list of replacements.