### PR TITLE
MMCore: Add missing header for std::memset()

### DIFF
--- a/MMCore/Devices/DeviceInstance.h
+++ b/MMCore/Devices/DeviceInstance.h
@@ -25,6 +25,7 @@
 
 #include <boost/utility.hpp>
 
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <string>
@@ -133,7 +134,7 @@ protected:
        */
       DeviceStringBuffer(const DeviceInstance* instance, const std::string& functionName) :
          instance_(instance), funcName_(functionName)
-      { memset(buf_, 0, sizeof(buf_)); }
+      { std::memset(buf_, 0, sizeof(buf_)); }
 
       char* GetBuffer() { return buf_; }
       std::string Get() const { Check(); return buf_; }

--- a/MMCore/LoadableModules/LoadedDeviceAdapter.h
+++ b/MMCore/LoadableModules/LoadedDeviceAdapter.h
@@ -29,6 +29,7 @@
 
 #include <boost/utility.hpp>
 
+#include <cstring>
 #include <memory>
 
 class CMMCore;
@@ -77,7 +78,7 @@ private:
       ModuleStringBuffer(const LoadedDeviceAdapter* module,
             const std::string& functionName) :
          module_(module), funcName_(functionName)
-      { memset(buf_, 0, sizeof(buf_)); }
+      { std::memset(buf_, 0, sizeof(buf_)); }
 
       char* GetBuffer() { return buf_; }
       size_t GetMaxStrLen() { return sizeof(buf_) - 1; }


### PR DESCRIPTION
Error exposed on Linux by previous change (#264).