### PR TITLE
MMCore: Add missing include for std::memcpy()

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -59,7 +59,8 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
+#include <cstring>
 #include <fstream>
 #include <set>
 #include <sstream>
@@ -5870,7 +5871,7 @@ vector<char> CMMCore::readFromSerialPort(const char* portLabel) throw (CMMError)
    vector<char> data;
    data.resize(read, 0);
    if (read > 0)
-      memcpy(&(data[0]), answerBuf, read);
+      std::memcpy(&(data[0]), answerBuf, read);
 
    return data;
 }

--- a/MMCore/TaskSet_CopyMemory.cpp
+++ b/MMCore/TaskSet_CopyMemory.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstring>
 
 TaskSet_CopyMemory::ATask::ATask(std::shared_ptr<Semaphore> semDone, size_t taskIndex, size_t totalTaskCount)
     : Task(semDone, taskIndex, totalTaskCount),
@@ -55,7 +56,7 @@ void TaskSet_CopyMemory::ATask::Execute()
     void* dst = static_cast<char*>(dst_) + chunkOffset;
     const void* src = static_cast<const char*>(src_) + chunkOffset;
 
-    memcpy(dst, src, chunkBytes);
+    std::memcpy(dst, src, chunkBytes);
 }
 
 TaskSet_CopyMemory::TaskSet_CopyMemory(std::shared_ptr<ThreadPool> pool)
@@ -76,7 +77,7 @@ void TaskSet_CopyMemory::SetUp(void* dst, const void* src, size_t bytes)
     usedTaskCount_ = std::min<size_t>(1 + bytes / 1000000, tasks_.size());
     if (usedTaskCount_ == 1)
     {
-        memcpy(dst, src, bytes);
+        std::memcpy(dst, src, bytes);
         return;
     }
 


### PR DESCRIPTION
Exposed on Linux by previous change (#265).