### PR TITLE
MMCore: Retire boost::noncopyable

### DIFF
--- a/MMCore/Devices/DeviceInstance.h
+++ b/MMCore/Devices/DeviceInstance.h
@@ -23,8 +23,6 @@
 #include "../Error.h"
 #include "../Logging/Logger.h"
 
-#include <boost/utility.hpp>
-
 #include <cstring>
 #include <functional>
 #include <memory>
@@ -60,7 +58,7 @@ typedef std::function<void (MM::Device*)> DeleteDeviceFunction;
  * DeviceInstance is an RAII class: the raw device instance is created in the
  * constructor, and destroyed in the destructor.
  */
-class DeviceInstance : boost::noncopyable
+class DeviceInstance
 {
 protected:
    MM::Device* pImpl_;
@@ -75,6 +73,9 @@ private:
    mm::logging::Logger coreLogger_;
 
 public:
+   DeviceInstance(const DeviceInstance&) = delete;
+   DeviceInstance& operator=(const DeviceInstance&) = delete;
+
    std::shared_ptr<LoadedDeviceAdapter> GetAdapterModule() const /* final */ { return adapter_; }
    std::string GetLabel() const /* final */ { return label_; }
    std::string GetDescription() const /* final */ { return description_; }
@@ -121,13 +122,16 @@ protected:
     *
     * For usage, see, e.g., the definition for DeviceInstance::GetName().
     */
-   class DeviceStringBuffer : boost::noncopyable
+   class DeviceStringBuffer
    {
       char buf_[MM::MaxStrLength + 1];
       const DeviceInstance* instance_;
       const std::string& funcName_;
 
    public:
+      DeviceStringBuffer(const DeviceStringBuffer&) = delete;
+      DeviceStringBuffer& operator=(const DeviceStringBuffer&) = delete;
+
       /**
        * instance and functionName must stay in scope during the lifetime of
        * the DeviceStringBuffer.

--- a/MMCore/LoadableModules/LoadedDeviceAdapter.h
+++ b/MMCore/LoadableModules/LoadedDeviceAdapter.h
@@ -27,8 +27,6 @@
 #include "../../MMDevice/ModuleInterface.h"
 #include "../Logging/Logger.h"
 
-#include <boost/utility.hpp>
-
 #include <cstring>
 #include <memory>
 
@@ -39,10 +37,12 @@ class DeviceInstance;
 
 
 class LoadedDeviceAdapter /* final */ :
-	boost::noncopyable,
 	public std::enable_shared_from_this<LoadedDeviceAdapter>
 {
 public:
+   LoadedDeviceAdapter(const LoadedDeviceAdapter&) = delete;
+   LoadedDeviceAdapter& operator=(const LoadedDeviceAdapter&) = delete;
+
    LoadedDeviceAdapter(const std::string& name, const std::string& filename);
 
    // TODO Unload() should mark the instance invalid (or require instance
@@ -68,13 +68,16 @@ private:
    /**
     * \brief Utility class for getting fixed-length strings from the module
     */
-   class ModuleStringBuffer : boost::noncopyable
+   class ModuleStringBuffer
    {
       char buf_[MM::MaxStrLength + 1];
       const LoadedDeviceAdapter* module_;
       const std::string& funcName_;
 
    public:
+      ModuleStringBuffer(const ModuleStringBuffer&) = delete;
+      ModuleStringBuffer& operator=(const ModuleStringBuffer&) = delete;
+
       ModuleStringBuffer(const LoadedDeviceAdapter* module,
             const std::string& functionName) :
          module_(module), funcName_(functionName)

--- a/MMCore/LoadableModules/LoadedModule.h
+++ b/MMCore/LoadableModules/LoadedModule.h
@@ -21,15 +21,17 @@
 
 #pragma once
 
-#include <boost/utility.hpp>
 #include <string>
 
 
 class LoadedModuleImpl;
 
-class LoadedModule /* final */ : boost::noncopyable
+class LoadedModule /* final */
 {
 public:
+   LoadedModule(const LoadedModule&) = delete;
+   LoadedModule& operator=(const LoadedModule&) = delete;
+
    explicit LoadedModule(const std::string& filename);
    ~LoadedModule();
 

--- a/MMCore/LoadableModules/LoadedModuleImpl.h
+++ b/MMCore/LoadableModules/LoadedModuleImpl.h
@@ -24,11 +24,12 @@
 
 #include "LoadedModule.h"
 
-#include <boost/utility.hpp>
-
-class LoadedModuleImpl : boost::noncopyable
+class LoadedModuleImpl
 {
 public:
+   LoadedModuleImpl(const LoadedModuleImpl&) = delete;
+   LoadedModuleImpl& operator=(const LoadedModuleImpl&) = delete;
+
    static LoadedModuleImpl* NewPlatformImpl(const std::string& filename);
 
    virtual ~LoadedModuleImpl() {}

--- a/MMCore/Logging/GenericLogger.h
+++ b/MMCore/Logging/GenericLogger.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <boost/utility.hpp>
-
 #include <functional>
 #include <sstream>
 #include <string>
@@ -55,7 +53,7 @@ public:
  * Log an entry upon destruction.
  */
 template <class TLogger>
-class GenericLogStream : public std::ostringstream, boost::noncopyable
+class GenericLogStream : public std::ostringstream
 {
 public:
    typedef typename TLogger::EntryDataType EntryDataType;
@@ -65,6 +63,9 @@ public:
    bool used_;
 
 public:
+   GenericLogStream(const GenericLogStream&) = delete;
+   GenericLogStream& operator=(const GenericLogStream&) = delete;
+
    GenericLogStream(const TLogger& logger, EntryDataType level) :
       logger_(logger),
       level_(level),

--- a/MMCore/Logging/GenericStreamSink.h
+++ b/MMCore/Logging/GenericStreamSink.h
@@ -18,8 +18,6 @@
 
 #include "GenericSink.h"
 
-#include <boost/utility.hpp>
-
 #include <exception>
 #include <fstream>
 #include <iostream>
@@ -122,7 +120,7 @@ public:
 
 
 template <class TMetadata, class UFormatter>
-class GenericFileLogSink : public GenericSink<TMetadata>, boost::noncopyable
+class GenericFileLogSink : public GenericSink<TMetadata>
 {
    std::string filename_;
    std::ofstream fileStream_;
@@ -131,6 +129,9 @@ class GenericFileLogSink : public GenericSink<TMetadata>, boost::noncopyable
 public:
    typedef GenericSink<TMetadata> Super;
    typedef typename Super::PacketArrayType PacketArrayType;
+
+   GenericFileLogSink(const GenericFileLogSink&) = delete;
+   GenericFileLogSink& operator=(const GenericFileLogSink&) = delete;
 
    GenericFileLogSink(const std::string& filename, bool append = false) :
       filename_(filename),


### PR DESCRIPTION
Replace it with the C++11+ way (copy constructor and copy assignment operator deleted).