### PR TITLE
MMCore: Replace most uses of Boost.Date_Time with std::chrono

### DIFF
--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -63,7 +63,7 @@ bool CircularBuffer::Initialize(unsigned channels, unsigned int w, unsigned int 
 {
    MMThreadGuard guard(g_bufferLock);
    imageNumbers_.clear();
-   startTime_ = GetMMTimeNow();
+   startTime_ = std::chrono::steady_clock::now();
 
    bool ret = true;
    try
@@ -128,7 +128,7 @@ void CircularBuffer::Clear()
    insertIndex_=0; 
    saveIndex_=0; 
    overflow_ = false;
-   startTime_ = GetMMTimeNow();
+   startTime_ = std::chrono::steady_clock::now();
    imageNumbers_.clear();
 }
 
@@ -233,8 +233,10 @@ bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned 
       if (!md.HasTag(MM::g_Keyword_Elapsed_Time_ms))
       {
          // if time tag was not supplied by the camera insert current timestamp
-         MM::MMTime timestamp = GetMMTimeNow();
-         md.PutImageTag(MM::g_Keyword_Elapsed_Time_ms, CDeviceUtils::ConvertToString((timestamp - startTime_).getMsec()));
+         using namespace std::chrono;
+         auto elapsed = steady_clock::now() - startTime_;
+         md.PutImageTag(MM::g_Keyword_Elapsed_Time_ms,
+            std::to_string(duration_cast<milliseconds>(elapsed).count()));
       }
 
       boost::posix_time::ptime t = boost::posix_time::microsec_clock::local_time();

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -63,8 +63,7 @@ bool CircularBuffer::Initialize(unsigned channels, unsigned int w, unsigned int 
 {
    MMThreadGuard guard(g_bufferLock);
    imageNumbers_.clear();
-   boost::posix_time::ptime t = boost::posix_time::microsec_clock::local_time();
-   startTime_ = GetMMTimeNow(t);
+   startTime_ = GetMMTimeNow();
 
    bool ret = true;
    try
@@ -129,8 +128,7 @@ void CircularBuffer::Clear()
    insertIndex_=0; 
    saveIndex_=0; 
    overflow_ = false;
-   boost::posix_time::ptime t = boost::posix_time::microsec_clock::local_time();
-   startTime_ = GetMMTimeNow(t);
+   startTime_ = GetMMTimeNow();
    imageNumbers_.clear();
 }
 
@@ -232,13 +230,14 @@ bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned 
          ++imageNumbers_[cameraName];
       }
 
-      boost::posix_time::ptime t = boost::posix_time::microsec_clock::local_time();
       if (!md.HasTag(MM::g_Keyword_Elapsed_Time_ms))
       {
          // if time tag was not supplied by the camera insert current timestamp
-         MM::MMTime timestamp = GetMMTimeNow(t);
+         MM::MMTime timestamp = GetMMTimeNow();
          md.PutImageTag(MM::g_Keyword_Elapsed_Time_ms, CDeviceUtils::ConvertToString((timestamp - startTime_).getMsec()));
       }
+
+      boost::posix_time::ptime t = boost::posix_time::microsec_clock::local_time();
       tStream << t;
       md.PutImageTag(MM::g_Keyword_Metadata_TimeInCore, tStream.str().c_str());
       tStream.str(std::string());

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -30,7 +30,11 @@
 
 #include "../MMDevice/DeviceUtils.h"
 
+#include <chrono>
+#include <cstdio>
+#include <ctime>
 #include <memory>
+#include <string>
 
 
 const long long bytesInMB = 1 << 20;
@@ -53,8 +57,6 @@ CircularBuffer::CircularBuffer(unsigned int memorySizeMB) :
    threadPool_(std::make_shared<ThreadPool>()),
    tasksMemCopy_(std::make_shared<TaskSet_CopyMemory>(threadPool_))
 {
-   facet = new boost::posix_time::time_facet("%Y-%m-%d %H:%M:%s");
-   tStream.imbue(std::locale(tStream.getloc(), facet));
 }
 
 CircularBuffer::~CircularBuffer() {}
@@ -154,6 +156,33 @@ unsigned long CircularBuffer::GetRemainingImageCount() const
    return (unsigned long)(insertIndex_ - saveIndex_);
 }
 
+static std::string FormatLocalTime(std::chrono::time_point<std::chrono::system_clock> tp) {
+   using namespace std::chrono;
+   auto us = duration_cast<microseconds>(tp.time_since_epoch());
+   auto secs = duration_cast<seconds>(us);
+   auto whole = duration_cast<microseconds>(secs);
+   auto frac = static_cast<int>((us - whole).count());
+
+   // As of C++14/17, it is simpler (and probably faster) to use C functions for
+   // date-time formatting
+
+   std::time_t t(secs.count()); // time_t is seconds on platforms we support
+   std::tm tmstruct;
+   std::tm *ptm;
+#ifdef _WIN32 // Windows localtime() is documented thread-safe
+   ptm = std::localtime(&t);
+#else // POSIX has localtime_r()
+   ptm = localtime_r(&t, &tmstruct);
+#endif
+
+   // Format as "yyyy-mm-dd hh:mm:ss.uuuuuu" (26 chars)
+   const char *timeFmt = "%Y-%m-%d %H:%M:%S";
+   char buf[32];
+   std::size_t len = std::strftime(buf, sizeof(buf), timeFmt, ptm);
+   std::snprintf(buf + len, sizeof(buf) - len, ".%06d", frac);
+   return buf;
+}
+
 /**
 * Inserts a single image in the buffer.
 */
@@ -239,11 +268,11 @@ bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned 
             std::to_string(duration_cast<milliseconds>(elapsed).count()));
       }
 
-      boost::posix_time::ptime t = boost::posix_time::microsec_clock::local_time();
-      tStream << t;
-      md.PutImageTag(MM::g_Keyword_Metadata_TimeInCore, tStream.str().c_str());
-      tStream.str(std::string());
-      tStream.clear();
+      // Note: It is not ideal to use local time. I think this tag is rarely
+      // used. Consider replacing with UTC (micro)seconds-since-epoch (with
+      // different tag key) after addressing current usage.
+      auto now = std::chrono::system_clock::now();
+      md.PutImageTag(MM::g_Keyword_Metadata_TimeInCore, FormatLocalTime(now));
 
       md.PutImageTag("Width",width);
       md.PutImageTag("Height",height);

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -31,8 +31,6 @@
 #include "../MMDevice/DeviceThreads.h"
 #include "../MMDevice/MMDevice.h"
 
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 #include <chrono>
 #include <memory>
 #include <vector>
@@ -100,7 +98,4 @@ private:
 
    std::shared_ptr<ThreadPool> threadPool_;
    std::shared_ptr<TaskSet_CopyMemory> tasksMemCopy_;
-
-   boost::posix_time::time_facet * facet;
-   std::ostringstream tStream;
 };

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -33,6 +33,7 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -83,7 +84,7 @@ private:
    unsigned int height_;
    unsigned int pixDepth_;
    long imageCounter_;
-   MM::MMTime startTime_;
+   std::chrono::time_point<std::chrono::steady_clock> startTime_;
    std::map<std::string, long> imageNumbers_;
 
    // Invariants:

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -32,7 +32,7 @@
 #include "CoreCallback.h"
 #include "DeviceManager.h"
 
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -1055,27 +1055,22 @@ void CoreCallback::ClearPostedErrors()
 }
 
 
-
-
-
-
 /**
  * Returns the number of microsecond tick
  * N.B. an unsigned long microsecond count rolls over in just over an hour!!!!
- * NOTE: This method is 'obsolete.'
+ *
+ * This method is obsolete and deprecated.
+ * Prefer std::chrono::steady_clock for time delta measurements
  */
 unsigned long CoreCallback::GetClockTicksUs(const MM::Device* /*caller*/)
 {
-	using namespace boost::posix_time;
-	using namespace boost::gregorian;
-	boost::posix_time::ptime t = boost::posix_time::microsec_clock::local_time();
-	boost::gregorian::date today( day_clock::local_day());
-	boost::posix_time::ptime timet_start(today); 
-	time_duration diff = t - timet_start; 
-	return (unsigned long) diff.total_microseconds();
+   using namespace std::chrono;
+   auto now = steady_clock::now();
+   auto usec = duration_cast<microseconds>(now.time_since_epoch()).count();
+   return static_cast<unsigned long>(usec);
 }
 
 MM::MMTime CoreCallback::GetCurrentMMTime()
-{		
-	return GetMMTimeNow();
+{
+   return GetMMTimeNow();
 }

--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -77,9 +77,11 @@ public:
    int SetSerialCommand(const MM::Device*, const char* portName, const char* command, const char* term);
    int GetSerialAnswer(const MM::Device*, const char* portName, unsigned long ansLength, char* answerTxt, const char* term);
 
-	unsigned long GetClockTicksUs(const MM::Device* caller);
+   // Return value overflows in ~72 minutes on Windows
+   // Prefer std::chrono::steady_clock for time delta measurements
+   /*Deprecated*/ unsigned long GetClockTicksUs(const MM::Device* caller);
 
-	// MMTime, in epoch beginning at 2000 01 01
+   // MMTime, in epoch beginning at 2000 01 01
    MM::MMTime GetCurrentMMTime();
 
    void Sleep(const MM::Device* caller, double intervalMs);

--- a/MMCore/CoreUtils.h
+++ b/MMCore/CoreUtils.h
@@ -103,16 +103,10 @@ inline std::string ToQuotedString<const char*>(char const* const& d)
 
 
 //NB we are starting the 'epoch' on 2000 01 01
-inline MM::MMTime GetMMTimeNow(boost::posix_time::ptime t0)
+inline MM::MMTime GetMMTimeNow()
 {
+   auto t0 = boost::posix_time::microsec_clock::local_time();
    boost::posix_time::ptime timet_start(boost::gregorian::date(2000,1,1)); 
    boost::posix_time::time_duration diff = t0 - timet_start; 
    return MM::MMTime( (double) diff.total_microseconds());
 }
-
-//NB we are starting the 'epoch' on 2000 01 01
-inline MM::MMTime GetMMTimeNow()
-{
-   return GetMMTimeNow(boost::posix_time::microsec_clock::local_time());
-}
-

--- a/MMCore/Logging/GenericPacketQueue.h
+++ b/MMCore/Logging/GenericPacketQueue.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <boost/date_time/posix_time/posix_time_types.hpp>
-
 #include <chrono>
 #include <condition_variable>
 #include <functional>

--- a/MMCore/Logging/Metadata.h
+++ b/MMCore/Logging/Metadata.h
@@ -25,7 +25,8 @@
 #include <pthread.h>
 #endif
 
-#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <chrono>
+#include <string>
 
 
 namespace mm
@@ -36,16 +37,9 @@ namespace logging
 namespace internal
 {
 
-
-typedef boost::posix_time::ptime TimestampType;
-
-// Note: Boost's local_time() internally calls the C library function
-// localtime_r() or localtime(). On the platforms we are interested in, either
-// the thread-safe localtime_r() is provided (OS X, Linux), or localtime() is
-// made thread-safe by using thread-local storage (Windows).
-inline TimestampType
+inline std::chrono::time_point<std::chrono::system_clock>
 Now()
-{ return boost::posix_time::microsec_clock::local_time(); }
+{ return std::chrono::system_clock::now(); }
 
 
 #ifdef _WIN32
@@ -89,7 +83,7 @@ public:
 
 class StampData
 {
-   internal::TimestampType time_;
+   std::chrono::time_point<std::chrono::system_clock> time_;
    internal::ThreadIdType tid_;
 
 public:
@@ -99,7 +93,9 @@ public:
       tid_ = internal::GetTid();
    }
 
-   internal::TimestampType GetTimestamp() const { return time_; }
+   std::chrono::time_point<std::chrono::system_clock> GetTimestamp() const
+   { return time_; }
+
    internal::ThreadIdType GetThreadId() const { return tid_; }
 };
 

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -114,7 +114,7 @@ using namespace std;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 10, MMCore_versionMinor = 2, MMCore_versionPatch = 1;
+const int MMCore_versionMajor = 10, MMCore_versionMinor = 2, MMCore_versionPatch = 2;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -56,8 +56,6 @@
 #include "MMEventCallback.h"
 #include "PluginManager.h"
 
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 #include <algorithm>
 #include <cassert>
 #include <cstring>

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -114,7 +114,7 @@ using namespace std;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 10, MMCore_versionMinor = 2, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 10, MMCore_versionMinor = 2, MMCore_versionPatch = 1;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/PluginManager.cpp
+++ b/MMCore/PluginManager.cpp
@@ -38,8 +38,6 @@
 #include "LoadableModules/LoadedDeviceAdapter.h"
 #include "PluginManager.h"
 
-#include <boost/algorithm/string.hpp>
-
 #include <cstring>
 #include <fstream>
 #include <memory>

--- a/MMCore/TaskSet.h
+++ b/MMCore/TaskSet.h
@@ -27,8 +27,6 @@
 #include "Task.h"
 #include "ThreadPool.h"
 
-#include <boost/utility/enable_if.hpp>
-
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Convert all but `MM::Time` (`GetCurrentMMTime()`) implementation, which requires resolving #273.

Setting as draft until I finish testing.