### PR TITLE
ASIStage: use fast serial commands for CRISP

### DIFF
--- a/DeviceAdapters/ASIStage/ASIBase.h
+++ b/DeviceAdapters/ASIStage/ASIBase.h
@@ -13,6 +13,43 @@
 #include "ASIStage.h"
 #include <string>
 
+// The ASIStage device adapter does not implement a hub device, each device could be connected to a different MS2000, 
+// that's why the build name, compile date, and version are queried every time.
+
+// This data structure is used to store MS2000 version data.
+class VersionData
+{
+public:
+	VersionData() : major_(0), minor_(0), rev_('-') { }
+	VersionData(int major, int minor, char rev) : major_(major), minor_(minor), rev_(rev) { }
+	void setMajor(int major) { major_ = major;  }
+	void setMinor(int minor) { minor_ = minor; }
+	void setRev(char rev) { rev_ = rev; }
+	int getMajor() const { return major_; }
+	int getMinor() const { return minor_; }
+	char getRev() const { return rev_; }
+	bool isVersionAtLeast(int major, int minor, char rev) const
+	{
+		if (major_ < major)
+		{
+			return false;
+		}
+		if (minor_ < minor)
+		{
+			return false;
+		}
+		if (rev_ < rev)
+		{
+			return false;
+		}
+		return true;
+	}
+private:
+	int major_;
+	int minor_;
+	char rev_;
+};
+
 // Note: concrete device classes deriving ASIBase must set core_ in Initialize()
 class ASIBase
 {
@@ -32,6 +69,7 @@ public:
 	int ParseResponseAfterPosition(const std::string& answer, const unsigned int position, double& value) const;
 	int ParseResponseAfterPosition(const std::string& answer, const unsigned int position, const unsigned int count, double& value) const;
 	int ResponseStartsWithColonA(const std::string& answer) const;
+	VersionData ExtractVersionData(const std::string& version) const;
 
 protected:
 	int OnVersion(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -44,7 +82,8 @@ protected:
 	MM::Device* device_;
 	std::string oldstagePrefix_;
 	std::string port_;
+	VersionData versionData_;
 	unsigned int compileDay_; // "days" since Jan 1 2000 since the firmware was compiled according to (compile day + 31*(compile month-1) + 12*31*(compile year-2000))
 };
 
-#endif // _ASIBASE_H_
+#endif // end _ASIBASE_H_

--- a/DeviceAdapters/ASIStage/ASICRISP.h
+++ b/DeviceAdapters/ASIStage/ASICRISP.h
@@ -60,6 +60,9 @@ public:
 	int OnSum(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnOffset(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnState(MM::PropertyBase* pProp, MM::ActionType eAct);
+	// For backwards compatibility with MS2000 firmware < 9.2o
+	int OnSumLegacy(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnDitherErrorLegacy(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
 	int GetFocusState(std::string& focusState);

--- a/DeviceAdapters/ASIStage/ASIStage.h
+++ b/DeviceAdapters/ASIStage/ASIStage.h
@@ -95,6 +95,7 @@ const char* const g_CRISP_Unknown = "Unknown";
 
 const char* const g_CRISPOffsetPropertyName = "Lock Offset";
 const char* const g_CRISPSumPropertyName = "Sum";
+const char* const g_CRISPDitherErrorPropertyName = "Dither Error";
 const char* const g_CRISPStatePropertyName = "CRISP State Character";
 
 MM::DeviceDetectionStatus ASICheckSerialPort(MM::Device& device, MM::Core& core, std::string portToCheck, double answerTimeoutMs);


### PR DESCRIPTION
Use LK T? and LK Y? instead of EXTRA X? when new firmware is detected (>= 9.2o).