### PR TITLE
Make MMTime safer to use

### DIFF
--- a/DeviceAdapters/ASIFW1000/ASIFW1000.cpp
+++ b/DeviceAdapters/ASIFW1000/ASIFW1000.cpp
@@ -1001,10 +1001,7 @@ bool Shutter::Busy()
 {
    //TODO: using the SQ command and shutters with sensors, we can check wether the shutter is open or closed.  This need checking for sensors on initialization, and will also need caching of the last requested position
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-   else
-      return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int Shutter::Shutdown()

--- a/DeviceAdapters/AmScope/SequenceThread.cpp
+++ b/DeviceAdapters/AmScope/SequenceThread.cpp
@@ -55,9 +55,9 @@ void SequenceThread::Start(long numImages, double intervalMs)
    stop_ = false;
    suspend_=false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_= camera_->GetCurrentMMTime();
-   lastFrameTime_ = 0;
+   lastFrameTime_ = MM::MMTime{};
 }
 
 bool SequenceThread::IsStopped(){

--- a/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
+++ b/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
@@ -1845,7 +1845,7 @@ void MySequenceThread::Start(long numImages, double intervalMs)
    stop_ = false;
    suspend_ = false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_ = camera_->GetCurrentMMTime();
 }
 

--- a/DeviceAdapters/Arduino/Arduino.cpp
+++ b/DeviceAdapters/Arduino/Arduino.cpp
@@ -1247,10 +1247,7 @@ bool CArduinoShutter::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
 
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-   else
-       return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int CArduinoShutter::Initialize()

--- a/DeviceAdapters/Arduino32bitBoards/Arduino32bitBoards.cpp
+++ b/DeviceAdapters/Arduino32bitBoards/Arduino32bitBoards.cpp
@@ -1335,10 +1335,7 @@ bool CArduino32Shutter::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
 
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-   else
-       return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int CArduino32Shutter::Initialize()

--- a/DeviceAdapters/CNCMicroscope/ArduinoNeoPixelShutter/ArduinoNeoPixelShutter.cpp
+++ b/DeviceAdapters/CNCMicroscope/ArduinoNeoPixelShutter/ArduinoNeoPixelShutter.cpp
@@ -332,10 +332,7 @@ bool CArduinoNeoPixelShutter::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
 
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-   else
-       return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int CArduinoNeoPixelShutter::Initialize()

--- a/DeviceAdapters/CSUW1/CSUW1.cpp
+++ b/DeviceAdapters/CSUW1/CSUW1.cpp
@@ -617,10 +617,7 @@ int Shutter::Initialize()
 bool Shutter::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-
-   return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int Shutter::Shutdown()
@@ -1471,10 +1468,7 @@ int NIRShutter::Initialize()
 bool NIRShutter::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-
-   return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int NIRShutter::Shutdown()

--- a/DeviceAdapters/Conix/Conix.cpp
+++ b/DeviceAdapters/Conix/Conix.cpp
@@ -417,11 +417,7 @@ int HexaFluor::Shutdown()
 bool HexaFluor::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-
-   if (interval < (1000.0 * GetDelayMs()) )
-      return true;
-
-   return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 

--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -1219,9 +1219,9 @@ void MySequenceThread::Start(long numImages, double intervalMs)
    stop_ = false;
    suspend_=false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_= camera_->GetCurrentMMTime();
-   lastFrameTime_ = 0;
+   lastFrameTime_ = MM::MMTime{};
 }
 
 bool MySequenceThread::IsStopped(){

--- a/DeviceAdapters/IDS_uEye/IDS_uEye.cpp
+++ b/DeviceAdapters/IDS_uEye/IDS_uEye.cpp
@@ -1445,9 +1445,9 @@ void MySequenceThread::Start(long numImages, double intervalMs)
    stop_ = false;
    suspend_=false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_= camera_->GetCurrentMMTime();
-   lastFrameTime_ = 0;
+   lastFrameTime_ = MM::MMTime{};
 }
 
 bool MySequenceThread::IsStopped(){

--- a/DeviceAdapters/K8055/K8055.cpp
+++ b/DeviceAdapters/K8055/K8055.cpp
@@ -506,11 +506,7 @@ void CK8055Shutter::GetName(char* name) const
 bool CK8055Shutter::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-   else
-       return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int CK8055Shutter::Initialize()

--- a/DeviceAdapters/K8061/K8061.cpp
+++ b/DeviceAdapters/K8061/K8061.cpp
@@ -536,11 +536,7 @@ void CK8061Shutter::GetName(char* name) const
 bool CK8061Shutter::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-
-   if (interval < (1000.0 < GetDelayMs() ))
-      return true;
-   else
-       return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int CK8061Shutter::Initialize()

--- a/DeviceAdapters/LeicaDMR/LeicaDMR.cpp
+++ b/DeviceAdapters/LeicaDMR/LeicaDMR.cpp
@@ -453,8 +453,8 @@ int Lamp::Initialize()
       return ret;
 
   // Set timer for the Busy signal, or we'll get a time-out the first time we check the state of the shutter, for good measure, go back 5s into the past
-   changedTime_ = GetCurrentMMTime() - 5000000; 
-   
+   changedTime_ = GetCurrentMMTime() - MM::MMTime::fromSeconds(5);
+
    // Check current intensity of lamp
    ret = g_hub.GetLampIntensity(*this, *GetCoreCallback(), intensity_);
    if (DEVICE_OK != ret)
@@ -497,10 +497,7 @@ int Lamp::Initialize()
 bool Lamp::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-
-   return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int Lamp::Shutdown()
@@ -654,8 +651,8 @@ int RLShutter::Initialize()
       return ret;
 
   // Set timer for the Busy signal, or we'll get a time-out the first time we check the state of the shutter, for good measure, go back 5s into the past
-   changedTime_ = GetCurrentMMTime() - 5000000; 
-   
+   changedTime_ = GetCurrentMMTime() - MM::MMTime::fromSeconds(5);
+
    // State
    CPropertyAction* pAct = new CPropertyAction (this, &RLShutter::OnState);
    ret = CreateProperty(MM::g_Keyword_State, "0", MM::Integer, false, pAct); 
@@ -681,8 +678,7 @@ bool RLShutter::Busy()
    // TODO: determine whether we need to use delay
    /*
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
    */
    return false;
 }
@@ -801,8 +797,8 @@ int ZStage::Initialize()
       return ret;
 
   // Set timer for the Busy signal, or we'll get a time-out the first time we check the state of the shutter, for good measure, go back 5s into the past
-   changedTime_ = GetCurrentMMTime() - 5000000; 
-   
+   changedTime_ = GetCurrentMMTime() - MM::MMTime::fromSeconds(5);
+
    // Position
    // There are two reference frames.  An absolute reference frame (implemeted here)
    // and a relative reference frame, implemented with a upper and lower lower limit

--- a/DeviceAdapters/LeicaDMR/LeicaDMRHub.cpp
+++ b/DeviceAdapters/LeicaDMR/LeicaDMRHub.cpp
@@ -168,7 +168,8 @@ int LeicaDMRHub::GetRLModulePosition(MM::Device& device, MM::Core& core, int& po
    pos = 0;
    MM::MMTime start = core.GetCurrentMMTime();
    int ret;
-   while (pos == 0 && (core.GetCurrentMMTime() - start < 500000) ) {
+   while (pos == 0 &&
+         (core.GetCurrentMMTime() - start < MM::MMTime::fromMs(500))) {
       ret = GetCommand(device, core, rLFA_, 10, pos);
       if (ret != DEVICE_OK)
          return ret;

--- a/DeviceAdapters/LeicaDMSTC/LeicaDMSTC.cpp
+++ b/DeviceAdapters/LeicaDMSTC/LeicaDMSTC.cpp
@@ -303,7 +303,7 @@ int XYStage::Initialize()
 	// Do not implement a position property as it can lead to trouble!
 
 	// Set timer for the Busy signal, or we'll get a time-out the first time we check the state of the shutter, for good measure, go back 5s into the past
-	changedTime_ = GetCurrentMMTime() - 5000000; 
+	changedTime_ = GetCurrentMMTime() - MM::MMTime::fromSeconds(5);
 
 	initialized_ = true;
 

--- a/DeviceAdapters/Ludl/Ludl.cpp
+++ b/DeviceAdapters/Ludl/Ludl.cpp
@@ -1405,7 +1405,7 @@ bool Shutter::Busy()
 {
    // First check delay, then query controller
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-   if (interval < (1000.0 * GetDelayMs()))
+   if (interval < MM::MMTime::fromMs(GetDelayMs()))
          return true;
 
    clearPort(*this, *GetCoreCallback(), GetPort().c_str());

--- a/DeviceAdapters/MatrixVision/mvIMPACT_Acquire_Device.cpp
+++ b/DeviceAdapters/MatrixVision/mvIMPACT_Acquire_Device.cpp
@@ -1214,9 +1214,9 @@ void MySequenceThread::Start( long numImages, double intervalMs )
    stop_ = false;
    suspend_ = false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_ = pmvIMPACT_Acquire_Device_->GetCurrentMMTime();
-   lastFrameTime_ = 0;
+   lastFrameTime_ = MM::MMTime{};
 }
 
 //-----------------------------------------------------------------------------

--- a/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.cpp
+++ b/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.cpp
@@ -1668,9 +1668,9 @@ void MySequenceThread::Start(long numImages, double intervalMs)
    stop_ = false;
    suspend_=false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_= camera_->GetCurrentMMTime();
-   lastFrameTime_ = 0;
+   lastFrameTime_ = MM::MMTime{};
 }
 
 bool MySequenceThread::IsStopped(){

--- a/DeviceAdapters/Neos/Neos.cpp
+++ b/DeviceAdapters/Neos/Neos.cpp
@@ -150,11 +150,7 @@ int Neos::Shutdown()
 bool Neos::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-
-   if (interval < (1000.0 * GetDelayMs()))                                                               
-       return true;
-
-   return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 

--- a/DeviceAdapters/NikonTE2000/TEHub.cpp
+++ b/DeviceAdapters/NikonTE2000/TEHub.cpp
@@ -896,7 +896,8 @@ int TEHub::ExecuteCommand(MM::Device& device, MM::Core& core, const char* type, 
          else
          {
             CDeviceUtils::SleepMs(delayMs);
-            if ( (core.GetCurrentMMTime() - startTime) > (maxTimeMs*1000.0) )
+            if ((core.GetCurrentMMTime() - startTime) >
+                  MM::MMTime::fromMs(maxTimeMs))
                done = true;
          }
       }

--- a/DeviceAdapters/Okolab/OkolabDevice.cpp
+++ b/DeviceAdapters/Okolab/OkolabDevice.cpp
@@ -1016,9 +1016,9 @@ void OkolabThread::Start(double intervalMs)
 	_stop = false;
 	_suspend = false;
 	activate();
-	_actualDuration = 0;
+	_actualDuration = MM::MMTime{};
 	_startTime = _device->GetCurrentMMTime();
-	_lastFrameTime = 0;
+	_lastFrameTime = MM::MMTime{};
 	Sleep(THREAD_SLEEP_MS);
 }
 

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
@@ -920,9 +920,9 @@ void MySequenceThread::Start(long numImages, double intervalMs)
    stop_ = false;
    suspend_=false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_= camera_->GetCurrentMMTime();
-   lastFrameTime_ = 0;
+   lastFrameTime_ = MM::MMTime{};
 }
 
 bool MySequenceThread::IsStopped(){

--- a/DeviceAdapters/OxxiusCombiner/Oxxius_combiner.cpp
+++ b/DeviceAdapters/OxxiusCombiner/Oxxius_combiner.cpp
@@ -565,9 +565,11 @@ int OxxiusCombinerHub::QueryCommand(MM::Device* device, MM::Core* core, const un
 		while (!done) {
 			counter++;
 			ret = core->GetSerialAnswer(device, port_.c_str(), RCV_BUF_LENGTH, rcvBuf_, "\r\n");
-			if ( (ret == DEVICE_OK) ||  ( (core->GetCurrentMMTime() - startTime) > (maxTimeMs*1000.0) ) )
+			if ((ret == DEVICE_OK) ||
+				((core->GetCurrentMMTime() - startTime) >
+				 MM::MMTime::fromMs(maxTimeMs))) {
 				done = true;
-			else {
+			} else {
 				CDeviceUtils::SleepMs(delayMs);
 				delayMs *= 2;
 			}

--- a/DeviceAdapters/PeCon2000/PeCon2000.cpp
+++ b/DeviceAdapters/PeCon2000/PeCon2000.cpp
@@ -375,7 +375,7 @@ struct is_older_than {
    inline is_older_than(MM::MMTime now, double delta) : now(now), delta(delta) {};
 
    inline bool operator()(const MM::MMTime& then) {
-      return (now - then) > delta;
+      return (now - then) > MM::MMTime(delta);
    }
 };
 

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
@@ -6098,9 +6098,9 @@ void MySequenceThread::Start(long numImages, double intervalMs)
    stop_ = false;
    suspend_=false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_= camera_->GetCurrentMMTime();
-   lastFrameTime_ = 0;
+   lastFrameTime_ = MM::MMTime{};
 }
 
 bool MySequenceThread::IsStopped(){

--- a/DeviceAdapters/SpectralLMM5/SpectralLMM5.cpp
+++ b/DeviceAdapters/SpectralLMM5/SpectralLMM5.cpp
@@ -568,9 +568,7 @@ void LMM5Shutter::GetName(char* pszName) const
 bool LMM5Shutter::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-   return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int LMM5Shutter::SetOpen(bool open)

--- a/DeviceAdapters/Spinnaker/SpinnakerCamera.cpp
+++ b/DeviceAdapters/Spinnaker/SpinnakerCamera.cpp
@@ -1717,9 +1717,9 @@ void SpinnakerAcquisitionThread::Start(long numImages, double intervalMs)
    m_stop = false;
    m_suspend = false;
    activate();
-   m_actualDuration = 0;
+   m_actualDuration = MM::MMTime{};
    m_startTime = m_spkrCam->GetCurrentMMTime();
-   m_lastFrameTime = 0;
+   m_lastFrameTime = MM::MMTime{};
    m_spkrCam->allocateImageBuffer(m_spkrCam->GetImageBufferSize(), m_spkrCam->m_cam->PixelFormat.GetValue());
 
    if (numImages == -1)

--- a/DeviceAdapters/SutterLambda/SutterLambda.cpp
+++ b/DeviceAdapters/SutterLambda/SutterLambda.cpp
@@ -212,7 +212,9 @@ int SutterUtils::GoOnLine(MM::Device& device, MM::Core& core,
       if (answer == 238)
          responseReceived = true;
    }
-   while( !responseReceived && (core.GetCurrentMMTime() - startTime) < (answerTimeoutMs * 1000.0) );
+   while (!responseReceived &&
+         (core.GetCurrentMMTime() - startTime) <
+         MM::MMTime::fromMs(answerTimeoutMs));
    if (!responseReceived)
       return ERR_NO_ANSWER;
 
@@ -294,7 +296,9 @@ int SutterUtils::GetStatus(MM::Device& device, MM::Core& core,
          responseReceived = true;
       CDeviceUtils::SleepMs(2);
    }
-   while( !responseReceived && (core.GetCurrentMMTime() - startTime) < (answerTimeoutMs * 1000.0) );
+   while (!responseReceived &&
+         (core.GetCurrentMMTime() - startTime) <
+         MM::MMTime::fromMs(answerTimeoutMs));
    if (!responseReceived)
       return ERR_NO_ANSWER;
 
@@ -313,7 +317,10 @@ int SutterUtils::GetStatus(MM::Device& device, MM::Core& core,
       }
       CDeviceUtils::SleepMs(2);
    }
-   while( !responseReceived && (core.GetCurrentMMTime() - startTime) < (answerTimeoutMs * 1000.0) && j < 22);
+   while (!responseReceived &&
+         (core.GetCurrentMMTime() - startTime) <
+         MM::MMTime::fromMs(answerTimeoutMs) &&
+         j < 22);
    if (!responseReceived)
       return ERR_NO_ANSWER;
 
@@ -1498,7 +1505,9 @@ bool ShutterOnTenDashTwo::SetShutterPosition(bool state)
       LogMessage("busy entering SetShutterPosition",true);
 
    MM::MMTime startTime = GetCurrentMMTime();
-   while (::g_Busy[port_] && (GetCurrentMMTime() - startTime) < (g_busyTimeoutMs * 1000.0) )
+   while (::g_Busy[port_] &&
+         (GetCurrentMMTime() - startTime) <
+         MM::MMTime::fromMs(g_busyTimeoutMs))
    {
       CDeviceUtils::SleepMs(10);
    }
@@ -2090,7 +2099,9 @@ bool ShutterOn721::SetLEDState(long led, bool state)
       LogMessage("busy entering SetShutterPosition",true);
 
    MM::MMTime startTime = GetCurrentMMTime();
-   while (::g_Busy[port_] && (GetCurrentMMTime() - startTime) < (g_busyTimeoutMs * 1000.0) )
+   while (::g_Busy[port_] &&
+         (GetCurrentMMTime() - startTime) <
+         MM::MMTime::fromMs(g_busyTimeoutMs))
    {
       CDeviceUtils::SleepMs(10);
    }
@@ -2199,7 +2210,9 @@ bool ShutterOn721::GetLEDStates(int *state)
       LogMessage("busy entering SetShutterPosition",true);
 
    MM::MMTime startTime = GetCurrentMMTime();
-   while (::g_Busy[port_] && (GetCurrentMMTime() - startTime) < (g_busyTimeoutMs * 1000.0) )
+   while (::g_Busy[port_] &&
+         (GetCurrentMMTime() - startTime) <
+         MM::MMTime::fromMs(g_busyTimeoutMs))
    {
       CDeviceUtils::SleepMs(10);
    }
@@ -2320,7 +2333,9 @@ bool ShutterOn721::SetLEDPower(long led, long power)
       LogMessage("busy entering SetLEDPower",true);
 
    MM::MMTime startTime = GetCurrentMMTime();
-   while (::g_Busy[port_] && (GetCurrentMMTime() - startTime) < (g_busyTimeoutMs * 1000.0) )
+   while (::g_Busy[port_] &&
+         (GetCurrentMMTime() - startTime) <
+         MM::MMTime::fromMs(g_busyTimeoutMs))
    {
       CDeviceUtils::SleepMs(10);
    }

--- a/DeviceAdapters/SutterLambda2/WheelBase.h
+++ b/DeviceAdapters/SutterLambda2/WheelBase.h
@@ -362,7 +362,7 @@ int WheelBase<U>::OnDelay(MM::PropertyBase* pProp, MM::ActionType eAct)
 		double delay;
 		pProp->Get(delay);
 		this->SetDelayMs(delay);
-		delay_ = delay * 1000;
+		delay_ = MM::MMTime::fromMs(delay);
 	}
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/TUCam/MMTUCam.cpp
+++ b/DeviceAdapters/TUCam/MMTUCam.cpp
@@ -2619,9 +2619,9 @@ void CTUCamThread::Start(long numImages, double intervalMs)
     stop_ = false;
     suspend_=false;
     activate();
-    actualDuration_ = 0;
+    actualDuration_ = MM::MMTime{};
     startTime_= camera_->GetCurrentMMTime();
-    lastFrameTime_ = 0;
+    lastFrameTime_ = MM::MMTime{};
 }
 
 bool CTUCamThread::IsStopped()

--- a/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.cpp
+++ b/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.cpp
@@ -730,9 +730,9 @@ void MySequenceThread::Start(long numImages, double intervalMs)
    stop_ = false;
    suspend_=false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_= camera_->GetCurrentMMTime();
-   lastFrameTime_ = 0;
+   lastFrameTime_ = MM::MMTime{};
 }
 
 bool MySequenceThread::IsStopped(){

--- a/DeviceAdapters/TwainCamera/CameraSequenceThread.h
+++ b/DeviceAdapters/TwainCamera/CameraSequenceThread.h
@@ -32,9 +32,9 @@ public:
       stop_ = false;
       suspend_=false;
       activate();
-      actualDuration_ = 0;
+      actualDuration_ = MM::MMTime{};
       startTime_= camera_->GetCurrentMMTime();
-      lastFrameTime_ = 0;
+      lastFrameTime_ = MM::MMTime{};
    }
    bool IsStopped(){
       MMThreadGuard(this->stopLock_);

--- a/DeviceAdapters/UniversalMMHubSerial/ummhSerial.cpp
+++ b/DeviceAdapters/UniversalMMHubSerial/ummhSerial.cpp
@@ -313,7 +313,7 @@ MM::MMTime UniHub::GetTimeout(string devicename) {
 		UmmhGeneric* p = static_cast<UmmhGeneric*>(pDevice);
 		return p->GetTimeout();
 	}
-	return 0;
+	return {};
 }
 
 void UniHub::SetTimeout(string devicename, MM::MMTime val) {
@@ -360,7 +360,7 @@ MM::MMTime UniHub::GetLastCommandTime(string devicename) {
 		UmmhGeneric* p = static_cast<UmmhGeneric*>(pDevice);
 		return p->GetLastCommandTime();
 	}
-	return 0;
+	return {};
 }
 
 void UniHub::SetLastCommandTime(string devicename, MM::MMTime val) {

--- a/DeviceAdapters/UniversalMMHubUsb/ummhUsb.cpp
+++ b/DeviceAdapters/UniversalMMHubUsb/ummhUsb.cpp
@@ -445,7 +445,7 @@ MM::MMTime UniHub::GetTimeout(string devicename) {
 		UmmhCamera* p = static_cast<UmmhCamera*>(pDevice);
 		return p->GetTimeout();
 	}
-	return 0;
+	return {};
 }
 
 void UniHub::SetTimeout(string devicename, MM::MMTime val) {
@@ -500,7 +500,7 @@ MM::MMTime UniHub::GetLastCommandTime(string devicename) {
 		UmmhCamera* p = static_cast<UmmhCamera*>(pDevice);
 		return p->GetLastCommandTime();
 	}
-	return 0;
+	return {};
 }
 
 void UniHub::SetLastCommandTime(string devicename, MM::MMTime val) {
@@ -3879,9 +3879,9 @@ void MySequenceThread::Start(long numImages, double intervalMs)
    stop_ = false;
    suspend_=false;
    activate();
-   actualDuration_ = 0;
+   actualDuration_ = MM::MMTime{};
    startTime_= camera_->GetCurrentMMTime();
-   lastFrameTime_ = 0;
+   lastFrameTime_ = MM::MMTime{};
 }
 
 bool MySequenceThread::IsStopped(){

--- a/DeviceAdapters/VariLC/VariLC.cpp
+++ b/DeviceAdapters/VariLC/VariLC.cpp
@@ -662,7 +662,7 @@ int VariLC::OnGetFromVariLC(MM::PropertyBase* pProp, MM::ActionType eAct)
 	  if (initializedDelay_) {
 		SetDelayMs(delayT);
 	  }
-	  delay = delayT*1000;
+	  delay = MM::MMTime::fromMs(delayT);
    }
    return DEVICE_OK;
 }

--- a/DeviceAdapters/VarispecLCTF/VarispecLCTF.cpp
+++ b/DeviceAdapters/VarispecLCTF/VarispecLCTF.cpp
@@ -499,7 +499,7 @@ int VarispecLCTF::OnDelay(MM::PropertyBase* pProp, MM::ActionType eAct)
       if (initializedDelay_) {
          SetDelayMs(delayT);
       }
-      delay_ = delayT * 1000;
+      delay_ = MM::MMTime::fromMs(delayT);
    }
    return DEVICE_OK;
 }

--- a/DeviceAdapters/Ximea/XIMEACamera.cpp
+++ b/DeviceAdapters/Ximea/XIMEACamera.cpp
@@ -1680,9 +1680,9 @@ void XiSequenceThread::Start(long numImages, double intervalMs)
 	stop_ = false;
 	suspend_ = false;
 	activate();
-	actualDuration_ = 0;
+	actualDuration_ = MM::MMTime{};
 	startTime_ = camera_->GetCurrentMMTime();
-	lastFrameTime_ = 0;
+	lastFrameTime_ = MM::MMTime{};
 }
 
 //***********************************************************************

--- a/DeviceAdapters/Yokogawa/CSU22.cpp
+++ b/DeviceAdapters/Yokogawa/CSU22.cpp
@@ -429,11 +429,7 @@ int FilterSet::Initialize()
 bool FilterSet::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-  
-   if (interval < (1000.0 * GetDelayMs() ))
-       return true;
-
-   return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int FilterSet::Shutdown()

--- a/DeviceAdapters/Yokogawa/CSUX.cpp
+++ b/DeviceAdapters/Yokogawa/CSUX.cpp
@@ -327,10 +327,7 @@ bool FilterWheel::Busy()
    // TODO: figure out how speed commadn affects Busy
    MM::MMTime now = GetCurrentMMTime();
    // each position moved takes 33 msec
-   if ((now - lastMoveTime_) < (posMoved_ * 33))
-      return true;
- 
-   return false;
+   return (now - lastMoveTime_) < MM::MMTime::fromMs(posMoved_ * 33);
 }
 
 int FilterWheel::Shutdown()
@@ -605,10 +602,7 @@ int Shutter::Initialize()
 bool Shutter::Busy()
 {
    MM::MMTime interval = GetCurrentMMTime() - changedTime_;
-   if (interval < (1000.0 * GetDelayMs() ))
-      return true;
-
-   return false;
+   return interval < MM::MMTime::fromMs(GetDelayMs());
 }
 
 int Shutter::Shutdown()

--- a/DeviceAdapters/ZeissAxioZoom/ZeissAxioZoom.h
+++ b/DeviceAdapters/ZeissAxioZoom/ZeissAxioZoom.h
@@ -157,8 +157,8 @@ class ZeissMonitoringThread;
  */
 struct ZeissDeviceInfo {
    ZeissDeviceInfo(){
-      lastUpdateTime = 0;
-      lastRequestTime = 0;
+      lastUpdateTime = MM::MMTime{};
+      lastRequestTime = MM::MMTime{};
       currentPos = 0;
       targetPos = 0;
       maxPos = 0;

--- a/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
+++ b/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
@@ -131,8 +131,8 @@ class ZeissMonitoringThread;
  */
 struct ZeissDeviceInfo {
    ZeissDeviceInfo(){
-      lastUpdateTime = 0;
-      lastRequestTime = 0;
+      lastUpdateTime = MM::MMTime{};
+      lastRequestTime = MM::MMTime{};
       currentPos = 0;
       targetPos = 0;
       maxPos = 0;

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1638,9 +1638,9 @@ protected:
          stop_ = false;
          suspend_=false;
          activate();
-         actualDuration_ = 0;
+         actualDuration_ = MM::MMTime{};
          startTime_= camera_->GetCurrentMMTime();
-         lastFrameTime_ = 0;
+         lastFrameTime_ = MM::MMTime{};
       }
       bool IsStopped(){
          MMThreadGuard g(this->stopLock_);

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -220,12 +220,12 @@ namespace MM {
    {
    public:
       // arguments:  MMTime start time, millisecond interval time
-      TimeoutMs(const MMTime startTime, const unsigned long intervalMs) :
+      explicit TimeoutMs(const MMTime startTime, const unsigned long intervalMs) :
          startTime_(startTime),
          interval_(0, 1000*intervalMs)
       {
       }
-      TimeoutMs(const MMTime startTime, const MMTime interval) :
+      explicit TimeoutMs(const MMTime startTime, const MMTime interval) :
          startTime_(startTime),
          interval_(interval)
       {

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -103,13 +103,13 @@ namespace MM {
 
          MMTime() : sec_(0), uSec_(0) {}
 
-         MMTime(double uSecTotal)
+         explicit MMTime(double uSecTotal)
          {
             sec_ = (long) (uSecTotal / 1.0e6);
             uSec_ = (long) (uSecTotal - sec_ * 1.0e6);
          }
 
-         MMTime(long sec, long uSec) : sec_(sec), uSec_(uSec)
+         explicit MMTime(long sec, long uSec) : sec_(sec), uSec_(uSec)
          {
             Normalize();
          }


### PR DESCRIPTION
With this change, implicit conversion from `double` to `MMTime` is no longer allowed.

This means that code like
```c++
MM::MMTime t = ...;
if (t < 1000.0) {
    ...
}
```
is no longer allowed. Instead, the comparison should be `t < MM::MMTime::fromMs(1)` (for example).

Many device adapters needed small changes for this. See the commit messages for more details on these changes. Two device adapters (K8061 and Yokogawa CSUX) were found to have bugs that were fixed here. All other changes should preserve behavior exactly. One device adapter (PeCon2000) was found to have a potential bug, but current behavior was kept.

Although code changes were needed, these changes do not affect the binary interface and therefore do not require the device interface version to be incremented.