### PR TITLE
Make MMTime data members private

### DIFF
--- a/DeviceAdapters/PICAM/PICAMUniversal.cpp
+++ b/DeviceAdapters/PICAM/PICAMUniversal.cpp
@@ -2441,7 +2441,7 @@ int Universal::StartSequenceAcquisition(long numImages, double interval_ms, bool
    char label[MM::MaxStrLength];
    GetLabel(label);
    ostringstream os;
-   os << "Started sequence on " << label << ", at " << startTime_.serialize() << ", with " << numImages << " and " << interval_ms << " ms" << endl;
+   os << "Started sequence on " << label << ", at " << startTime_.toString() << ", with " << numImages << " and " << interval_ms << " ms" << endl;
    LogMessage(os.str().c_str());
 
    return DEVICE_OK;

--- a/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
@@ -1914,7 +1914,7 @@ int Universal::StartSequenceAcquisition(long numImages, double interval_ms, bool
     isAcquiring_ = true;
 
     std::ostringstream os;
-    os << "Started sequence on " << deviceLabel_ << ", at " << startTime_.serialize()
+    os << "Started sequence on " << deviceLabel_ << ", at " << startTime_.toString()
         << ", with " << numImages << " frames, " << interval_ms << " ms interval and "
         << (stopOnOverflow ? "" : "don't ") << "stop on overflow" << std::endl;
     LogAdapterMessage(os.str().c_str());

--- a/DeviceAdapters/Ximea/XIMEACamera.cpp
+++ b/DeviceAdapters/Ximea/XIMEACamera.cpp
@@ -311,8 +311,7 @@ int XimeaCamera::SnapImage()
 		}
 
 		// store time stamp data
-		readoutStartTime_.sec_ = image.GetTimeStampSec();
-		readoutStartTime_.uSec_ = image.GetTimeStampUSec();
+		readoutStartTime_ = MM::MMTime(image.GetTimeStampSec(), image.GetTimeStampUSec());
 
 		if (!isAcqRunning)
 		{
@@ -332,7 +331,7 @@ int XimeaCamera::SnapImage()
 	}
 
 	// use time of first successfully captured frame for sequence start
-	if (sequenceStartTime_.sec_ == 0 && sequenceStartTime_.uSec_ == 0)
+	if (sequenceStartTime_ == MM::MMTime{})
 	{
 		sequenceStartTime_ = readoutStartTime_;
 	}
@@ -777,8 +776,7 @@ int XimeaCamera::StartSequenceAcquisition(long numImages, double interval_ms, bo
 		return DEVICE_ERR;
 	}
 
-	sequenceStartTime_.sec_ = 0;
-	sequenceStartTime_.uSec_ = 0;
+	sequenceStartTime_ = MM::MMTime{};
 
 	imageCounter_ = 0;
 	seq_thd_->Start(numImages, interval_ms);

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -890,7 +890,7 @@ protected:
    {
       std::ostringstream os;
       MM::MMTime t = end-start;
-      os << message << t.sec_ << " seconds and " << t.uSec_ / 1000.0 << " msec";
+      os << message << t.toString() << " seconds";
       if (callback_)
          return callback_->LogMessage(this, os.str().c_str(), debugOnly);
       return DEVICE_NO_CALLBACK_REGISTERED;

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -130,13 +130,6 @@ namespace MM {
             return MMTime(secs, 0);
          }
 
-         // Deprecated; use toString()
-         std::string serialize() {
-            std::ostringstream os;
-            os << sec_ << " " << uSec_;
-            return os.str().c_str();
-         }
-
          MMTime operator+(const MMTime &other) const
          {
             MMTime res(sec_ + other.sec_, uSec_ + other.uSec_);

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -48,12 +48,14 @@
 #include "DeviceUtils.h"
 #include "ImageMetadata.h"
 #include "DeviceThreads.h"
-#include <string>
-#include <cstring>
+
 #include <climits>
 #include <cstdlib>
-#include <vector>
+#include <cstring>
+#include <iomanip>
 #include <sstream>
+#include <string>
+#include <vector>
 
 
 #ifdef MODULE_EXPORTS
@@ -96,11 +98,10 @@ namespace MM {
     */
    class MMTime
    {
-      public:
-         // Data members are public but new code should avoid direct access
          long sec_;
          long uSec_;
 
+      public:
          MMTime() : sec_(0), uSec_(0) {}
 
          explicit MMTime(double uSecTotal)
@@ -129,7 +130,7 @@ namespace MM {
             return MMTime(secs, 0);
          }
 
-         // Deprecated
+         // Deprecated; use toString()
          std::string serialize() {
             std::ostringstream os;
             os << sec_ << " " << uSec_;
@@ -185,6 +186,12 @@ namespace MM {
          double getUsec() const
          {
             return sec_ * 1.0e6 + uSec_;
+         }
+
+         std::string toString() const {
+            std::ostringstream s;
+            s << sec_ << '.' << std::setfill('0') << std::right << std::setw(6) << uSec_;
+            return s.str();
          }
 
       private:


### PR DESCRIPTION
So that we can change the internal representation without affecting user code.
Fortunately only 1 device adapter (XIMEA) needed small changes.