### PR TITLE
Make MMTime handle negative values correctly

### DIFF
--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -98,22 +98,18 @@ namespace MM {
     */
    class MMTime
    {
-         long sec_;
-         long uSec_;
+         long long microseconds_;
 
       public:
-         MMTime() : sec_(0), uSec_(0) {}
+         MMTime() : microseconds_(0LL) {}
 
-         explicit MMTime(double uSecTotal)
-         {
-            sec_ = (long) (uSecTotal / 1.0e6);
-            uSec_ = (long) (uSecTotal - sec_ * 1.0e6);
-         }
+         explicit MMTime(double uSecTotal) :
+            microseconds_(static_cast<long long>(uSecTotal))
+         {}
 
-         explicit MMTime(long sec, long uSec) : sec_(sec), uSec_(uSec)
-         {
-            Normalize();
-         }
+         explicit MMTime(long sec, long uSec) :
+            microseconds_(sec * 1'000'000LL + uSec)
+         {}
 
          static MMTime fromUs(double us)
          {
@@ -132,83 +128,65 @@ namespace MM {
 
          MMTime operator+(const MMTime &other) const
          {
-            MMTime res(sec_ + other.sec_, uSec_ + other.uSec_);
-            return res;
+            return fromUs(microseconds_ + other.microseconds_);
          }
 
          MMTime operator-(const MMTime &other) const
          {
-            MMTime res(sec_ - other.sec_, uSec_ - other.uSec_);
-            return res;
+            return fromUs(microseconds_ - other.microseconds_);
          }
 
          bool operator>(const MMTime &other) const
          {
-            if (sec_ > other.sec_)
-               return true;
-            else if (sec_ < other.sec_)
-               return false;
+            return microseconds_ > other.microseconds_;
+         }
 
-            if (uSec_ > other.uSec_)
-               return true;
-            else
-               return false;
+         bool operator>=(const MMTime &other) const
+         {
+            return microseconds_ >= other.microseconds_;
          }
 
          bool operator<(const MMTime &other) const
          {
-            if (*this == other)
-               return false;
+            return microseconds_ < other.microseconds_;
+         }
 
-            return ! (*this > other);
+         bool operator<=(const MMTime &other) const
+         {
+            return microseconds_ <= other.microseconds_;
          }
 
          bool operator==(const MMTime &other) const
          {
-            if (sec_ == other.sec_ && uSec_ == other.uSec_)
-               return true;
-            else
-               return false;
+            return microseconds_ == other.microseconds_;
+         }
+
+         bool operator!=(const MMTime &other) const
+         {
+            return !(*this == other);
          }
 
          double getMsec() const
          {
-            return sec_ * 1000.0 + uSec_ / 1000.0;
+            return microseconds_ / 1000.0;
          }
 
          double getUsec() const
          {
-            return sec_ * 1.0e6 + uSec_;
+            return static_cast<double>(microseconds_);
          }
 
          std::string toString() const {
-            std::ostringstream s;
-            s << sec_ << '.' << std::setfill('0') << std::right << std::setw(6) << uSec_;
+            long long absUs = std::abs(microseconds_);
+            long long seconds = absUs / 1'000'000LL;
+            long long fracUs = absUs - seconds * 1'000'000LL;
+            const char *sign = microseconds_ < 0 ? "-" : "";
+
+            using namespace std;
+            ostringstream s;
+            s << sign << seconds << '.' <<
+                  setfill('0') << right << setw(6) << fracUs;
             return s.str();
-         }
-
-      private:
-         void Normalize()
-         {
-            if (sec_ < 0)
-            {
-               sec_ = 0L;
-               uSec_ = 0L;
-               return;
-            }
-
-            if (uSec_ < 0)
-            {
-               sec_--;
-               uSec_ = 1000000L + uSec_;
-            }
-
-            long overflow = uSec_ / 1000000L;
-            if (overflow > 0)
-            {
-               sec_ += overflow;
-               uSec_ -= overflow * 1000000L;
-            }
          }
    };
 

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -111,9 +111,16 @@ namespace MM {
             microseconds_(sec * 1'000'000LL + uSec)
          {}
 
-         static MMTime fromUs(double us)
+         static MMTime fromUs(long long us)
          {
-            return MMTime(us);
+            // Work around our lack of a constructor that directly sets the
+            // internal representation.
+            // (Note that we cannot add a constructor from 'long long' because
+            // many existing uses would then get an error (ambiguous with the
+            // 'double' overload).)
+            MMTime ret;
+            ret.microseconds_ = us;
+            return ret;
          }
 
          static MMTime fromMs(double ms)

--- a/MMDevice/unittest/MMTime-Tests.cpp
+++ b/MMDevice/unittest/MMTime-Tests.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+
+#include "MMDevice.h"
+
+using namespace MM;
+
+
+TEST(MMTimeTests, RoundTripNegativeValues)
+{
+    ASSERT_DOUBLE_EQ(0.0, MMTime(-0.4).getUsec());
+    ASSERT_DOUBLE_EQ(-1.0, MMTime(-1.0).getUsec());
+    ASSERT_DOUBLE_EQ(-1'000'000.0, MMTime(-1'000'000.0).getUsec());
+
+    ASSERT_DOUBLE_EQ(-1.0, MMTime(0, -1).getUsec());
+    ASSERT_DOUBLE_EQ(-1'000'000.0, MMTime(-1, 0).getUsec());
+    ASSERT_DOUBLE_EQ(-999'999.0, MMTime(-1, 1).getUsec());
+    ASSERT_DOUBLE_EQ(-1'000'001.0, MMTime(-1, -1).getUsec());
+}
+
+
+TEST(MMTimeTests, ToString)
+{
+    using namespace std::literals::string_literals;
+    ASSERT_EQ("0.000000"s, MMTime{}.toString());
+    ASSERT_EQ("0.000001"s, MMTime(0, 1).toString());
+    ASSERT_EQ("-0.000001"s, MMTime(0, -1).toString());
+    ASSERT_EQ("-0.000001"s, MMTime(-1, 999'999).toString());
+    ASSERT_EQ("1.000000"s, MMTime(1, 0).toString());
+    ASSERT_EQ("-1.000000"s, MMTime(-1, 0).toString());
+    ASSERT_EQ("-1.000001"s, MMTime(-1, -1).toString());
+    ASSERT_EQ("-0.999999"s, MMTime(-1, 1).toString());
+}
+
+
+TEST(MMTimeTests, Arithmetic)
+{
+    ASSERT_EQ(MMTime(5.0), MMTime(3.0) + MMTime(2.0));
+    ASSERT_EQ(MMTime(1.0), MMTime(3.0) - MMTime(2.0));
+    ASSERT_EQ(MMTime(-5.0), MMTime(-3.0) + MMTime(-2.0));
+    ASSERT_EQ(MMTime(-1.0), MMTime(-3.0) - MMTime(-2.0));
+}
+
+
+TEST(MMTimeTests, Comparison)
+{
+    ASSERT_TRUE(MMTime(5.0) == MMTime(5.0));
+    ASSERT_TRUE(MMTime(5.0) >= MMTime(5.0));
+    ASSERT_TRUE(MMTime(5.0) <= MMTime(5.0));
+    ASSERT_FALSE(MMTime(5.0) != MMTime(5.0));
+    ASSERT_TRUE(MMTime(3.0) > MMTime(2.0));
+    ASSERT_TRUE(MMTime(3.0) >= MMTime(2.0));
+    ASSERT_TRUE(MMTime(2.0) < MMTime(3.0));
+    ASSERT_TRUE(MMTime(2.0) <= MMTime(3.0));
+}
+
+
+TEST(MMTimeTests, FromNumbers)
+{
+    ASSERT_EQ(MMTime(1.0), MMTime::fromUs(1.0));
+    ASSERT_EQ(MMTime(1'000.0), MMTime::fromMs(1.0));
+    ASSERT_EQ(MMTime(1'000'000.0), MMTime::fromSeconds(1));
+}
+
+
+TEST(MMTimeTests, ToNumbers)
+{
+    ASSERT_DOUBLE_EQ(1.0, MMTime(1.0).getUsec());
+    ASSERT_DOUBLE_EQ(1.0, MMTime(1000.0).getMsec());
+}
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}

--- a/MMDevice/unittest/Makefile.am
+++ b/MMDevice/unittest/Makefile.am
@@ -1,5 +1,6 @@
 check_PROGRAMS = \
-	FloatPropertyTruncation-Tests
+	FloatPropertyTruncation-Tests \
+	MMTime-Tests
 AM_DEFAULT_SOURCE_EXT = .cpp
 AM_CPPFLAGS = $(GMOCK_CPPFLAGS) -I.. $(BOOST_CPPFLAGS)
 LDADD = ../../../testing/libgmock.la ../libMMDevice.la


### PR DESCRIPTION
- It looks like the previous behavior forced negative values to zero, except that if `sec_ >= 0` and `uSec_ < 0` it will store `sec_ = -1`; also, if constructed from a negative `double`, it will store negative `sec_` (clearly a bug).

- Therefore, any code that results in negative MMTime values is probably already broken (such code is probably rare).

- Most usage would benefit from making negative values work as expected. However, if the result is used as an argument to sleep, there could be trouble (because the argument will be interpreted as unsigned) if we change the behavior away from clamping to zero. Fortunately, on review of all uses of `CDeviceUtil::SleepMs()`, `Sleep()`, `sleep()`, `usleep()`, and `nanosleep()`, it does not appear that any derive their argument from an `MMTime` (at least in an obvious way).

- The risk of introducing bugs by changing the behavior to handle negative values correctly is not absolutely zero, but I think it is sufficiently low that it is worth making the change (and any such cases are likely already partially broken). The risk of existing or future code having a bug under the current behavior is probably greater.