### PR TITLE
MMCore: use std::chrono::steady_clock for GetCurrentMMTime()

### DIFF
--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -32,6 +32,7 @@
 #include "CoreCallback.h"
 #include "DeviceManager.h"
 
+#include <cassert>
 #include <chrono>
 #include <string>
 #include <vector>
@@ -1055,6 +1056,14 @@ void CoreCallback::ClearPostedErrors()
 }
 
 
+static long long SteadyMicroseconds()
+{
+   using namespace std::chrono;
+   auto now = steady_clock::now().time_since_epoch();
+   auto usec = duration_cast<microseconds>(now);
+   return usec.count();
+}
+
 /**
  * Returns the number of microsecond tick
  * N.B. an unsigned long microsecond count rolls over in just over an hour!!!!
@@ -1064,13 +1073,10 @@ void CoreCallback::ClearPostedErrors()
  */
 unsigned long CoreCallback::GetClockTicksUs(const MM::Device* /*caller*/)
 {
-   using namespace std::chrono;
-   auto now = steady_clock::now();
-   auto usec = duration_cast<microseconds>(now.time_since_epoch()).count();
-   return static_cast<unsigned long>(usec);
+   return static_cast<unsigned long>(SteadyMicroseconds());
 }
 
 MM::MMTime CoreCallback::GetCurrentMMTime()
 {
-   return GetMMTimeNow();
+   return MM::MMTime::fromUs(SteadyMicroseconds());
 }

--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -77,11 +77,8 @@ public:
    int SetSerialCommand(const MM::Device*, const char* portName, const char* command, const char* term);
    int GetSerialAnswer(const MM::Device*, const char* portName, unsigned long ansLength, char* answerTxt, const char* term);
 
-   // Return value overflows in ~72 minutes on Windows
-   // Prefer std::chrono::steady_clock for time delta measurements
    /*Deprecated*/ unsigned long GetClockTicksUs(const MM::Device* caller);
 
-   // MMTime, in epoch beginning at 2000 01 01
    MM::MMTime GetCurrentMMTime();
 
    void Sleep(const MM::Device* caller, double intervalMs);

--- a/MMCore/CoreUtils.h
+++ b/MMCore/CoreUtils.h
@@ -27,19 +27,6 @@
 
 #include "../MMDevice/MMDevice.h"
 
-// suppress hideous boost warnings
-#ifdef WIN32
-#pragma warning( push )
-#pragma warning( disable : 4244 )
-#pragma warning( disable : 4127 )
-#endif
-
-#include "boost/date_time/posix_time/posix_time.hpp"
-
-#ifdef WIN32
-#pragma warning( pop )
-#endif
-
 #include <string>
 
 
@@ -99,14 +86,4 @@ inline std::string ToQuotedString<const char*>(char const* const& d)
    if (!d) // Don't quote if null
       return ToString(d);
    return "\"" + ToString(d) + "\"";
-}
-
-
-//NB we are starting the 'epoch' on 2000 01 01
-inline MM::MMTime GetMMTimeNow()
-{
-   auto t0 = boost::posix_time::microsec_clock::local_time();
-   boost::posix_time::ptime timet_start(boost::gregorian::date(2000,1,1)); 
-   boost::posix_time::time_duration diff = t0 - timet_start; 
-   return MM::MMTime( (double) diff.total_microseconds());
 }

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -113,7 +113,7 @@ using namespace std;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 10, MMCore_versionMinor = 2, MMCore_versionPatch = 2;
+const int MMCore_versionMajor = 10, MMCore_versionMinor = 3, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -58,6 +58,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <cstring>
 #include <fstream>
 #include <set>
@@ -1206,7 +1207,9 @@ void CMMCore::waitForDevice(std::shared_ptr<DeviceInstance> pDev) throw (CMMErro
 {
    LOG_DEBUG(coreLogger_) << "Waiting for device " << pDev->GetLabel() << "...";
 
-   MM::TimeoutMs timeout(GetMMTimeNow(),timeoutMs_);
+   auto now = std::chrono::steady_clock::now();
+   auto timeout = std::chrono::duration<long long, std::milli>(timeoutMs_);
+   auto deadline = now + timeout;
 
    while (true)
    {
@@ -1218,7 +1221,7 @@ void CMMCore::waitForDevice(std::shared_ptr<DeviceInstance> pDev) throw (CMMErro
          }
       }
 
-      if (timeout.expired(GetMMTimeNow()))
+      if (std::chrono::steady_clock::now() > deadline)
       {
          string label = pDev->GetLabel();
          std::ostringstream mez;

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1301,7 +1301,13 @@ namespace MM {
        */
       virtual int OnMagnifierChanged(const Device* caller) = 0;
 
+      // Deprecated: Return value overflows in ~72 minutes on Windows.
+      // Prefer std::chrono::steady_clock for time delta measurements.
       virtual unsigned long GetClockTicksUs(const Device* caller) = 0;
+
+      // Returns monotonic MMTime suitable for time delta measurements.
+      // Time zero is not fixed and may change on every launch.
+      // Prefer std::chrono::steady_clock::now() in new code.
       virtual MM::MMTime GetCurrentMMTime() = 0;
 
       // sequence acquisition


### PR DESCRIPTION
Closes #273.

This replaces the Boost-based implementation that purported to use the time since 2000-01-01, but actually added a time-zone-dependent offset. The new implementation has no fixed epoch (time zero) but uses a monotonic clock and is suitable for time delta measurement (which is what MM::MMTime is used for).

Setting to draft until I finish testing.