### PR TITLE
Remove Boost dependency from MMCore build

### DIFF
--- a/DeviceAdapters/DirectElectron/vsprojects/DEClientLib.vcxproj
+++ b/DeviceAdapters/DirectElectron/vsprojects/DEClientLib.vcxproj
@@ -50,7 +50,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\src\DEMessaging;$(MM_PROTOBUF_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\DEMessaging;$(MM_BOOST_INCLUDEDIR);$(MM_PROTOBUF_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WIN32_WINNT=0x0501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <PrecompiledHeader>
@@ -58,7 +58,7 @@
     </ClCompile>
     <Lib>
       <AdditionalDependencies>libprotobuf.lib;DEMessaging.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(MM_PROTOBUF_LIBDIR);$(TargetDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_BOOST_LIBDIR);$(MM_PROTOBUF_LIBDIR);$(TargetDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -66,14 +66,14 @@
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\src\DEMessaging;$(MM_PROTOBUF_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\DEMessaging;$(MM_BOOST_INCLUDEDIR);$(MM_PROTOBUF_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WIN32_WINNT=0x0501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>
       </PrecompiledHeader>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>libprotobuf.lib;DEMessaging.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(MM_PROTOBUF_LIBDIR);$(TargetDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_BOOST_LIBDIR);$(MM_PROTOBUF_LIBDIR);$(TargetDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DeviceAdapters/DirectElectron/vsprojects/DEMessaging.vcxproj
+++ b/DeviceAdapters/DirectElectron/vsprojects/DEMessaging.vcxproj
@@ -50,14 +50,14 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(MM_PROTOBUF_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_BOOST_INCLUDEDIR);$(MM_PROTOBUF_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WIN32_WINNT=0x0501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <PrecompiledHeader>
       </PrecompiledHeader>
     </ClCompile>
     <Lib>
-      <AdditionalLibraryDirectories>$(MM_PROTOBUF_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_BOOST_LIBDIR);$(MM_PROTOBUF_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -65,13 +65,13 @@
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(MM_PROTOBUF_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_BOOST_INCLUDEDIR);$(MM_PROTOBUF_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WIN32_WINNT=0x0501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>
       </PrecompiledHeader>
     </ClCompile>
     <Lib>
-      <AdditionalLibraryDirectories>$(MM_PROTOBUF_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_BOOST_LIBDIR);$(MM_PROTOBUF_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/MMCore/Makefile.am
+++ b/MMCore/Makefile.am
@@ -1,14 +1,10 @@
-
 AUTOMAKE_OPTIONS = foreign subdir-objects
 
-# BOOST_THREAD_VERSION must be set to 2 to compile with old versions of Boost
-# (before 2 became the default).
-AM_CPPFLAGS = $(BOOST_CPPFLAGS) -DBOOST_THREAD_VERSION=2 -DBOOST_THREAD_DONT_PROVIDE_CONDITION
-AM_LDFLAGS = $(BOOST_LDFLAGS) $(MMCORE_APPLEHOST_LDFLAGS)
+AM_LDFLAGS = $(MMCORE_APPLEHOST_LDFLAGS)
 
 noinst_LTLIBRARIES = libMMCore.la
 
-libMMCore_la_LIBADD = $(BOOST_SYSTEM_LIB) $(BOOST_DATE_TIME_LIB) $(BOOST_THREAD_LIB) ../MMDevice/libMMDevice.la
+libMMCore_la_LIBADD = ../MMDevice/libMMDevice.la
 
 libMMCore_la_SOURCES = \
 	../MMDevice/FixSnprintf.h \

--- a/MMCore/unittest/Makefile.am
+++ b/MMCore/unittest/Makefile.am
@@ -4,6 +4,6 @@ check_PROGRAMS = \
 	LoggingSplitEntryIntoLines-Tests \
 	Logger-Tests
 AM_DEFAULT_SOURCE_EXT = .cpp
-AM_CPPFLAGS = $(GMOCK_CPPFLAGS) -I.. $(BOOST_CPPFLAGS)
+AM_CPPFLAGS = $(GMOCK_CPPFLAGS) -I..
 LDADD = ../../../testing/libgmock.la ../libMMCore.la
 TESTS = $(check_PROGRAMS)

--- a/MMCoreJ_wrap/Makefile.am
+++ b/MMCoreJ_wrap/Makefile.am
@@ -12,7 +12,7 @@ AUTOMAKE_OPTIONS = foreign subdir-objects
 # nothing Linux-specific about this.)
 # TODO The flag should come from configure.
 AM_CXXFLAGS = -fno-strict-aliasing
-AM_CPPFLAGS = $(JNI_CPPFLAGS) $(BOOST_CPPFLAGS) -DBOOST_THREAD_VERSION=2
+AM_CPPFLAGS = $(JNI_CPPFLAGS)
 
 
 # This ugly list of headers is necessary to trigger the rebuild of the

--- a/MMDevice/unittest/Makefile.am
+++ b/MMDevice/unittest/Makefile.am
@@ -2,6 +2,6 @@ check_PROGRAMS = \
 	FloatPropertyTruncation-Tests \
 	MMTime-Tests
 AM_DEFAULT_SOURCE_EXT = .cpp
-AM_CPPFLAGS = $(GMOCK_CPPFLAGS) -I.. $(BOOST_CPPFLAGS)
+AM_CPPFLAGS = $(GMOCK_CPPFLAGS) -I..
 LDADD = ../../../testing/libgmock.la ../libMMDevice.la
 TESTS = $(check_PROGRAMS)

--- a/buildscripts/VisualStudio/MMCommon.props
+++ b/buildscripts/VisualStudio/MMCommon.props
@@ -25,14 +25,12 @@
       <WarningLevel>Level4</WarningLevel>
       <DisableSpecificWarnings>4127;4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <ExceptionHandling>Sync</ExceptionHandling>
-      <AdditionalIncludeDirectories>$(MM_BOOST_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/buildscripts/VisualStudio/MMDeviceAdapter.props
+++ b/buildscripts/VisualStudio/MMDeviceAdapter.props
@@ -8,8 +8,11 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MM_MMDEVICE_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_MMDEVICE_INCLUDEDIR);$(MM_BOOST_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup />
 </Project>


### PR DESCRIPTION
On Unix, remove flags from Makefile.am (configure.ac in the micro-manager repo needs separate update).

On Windows, no longer provide Boost incdir/libdir in MMCommon.props, but instead make it the default in MMDeviceAdapter.props and add to non-device-adapter projects that require Boost.