### PR TITLE
MMCore: Deprecate user id/host name/MAC functions

### DIFF
--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -629,9 +629,9 @@ public:
 
    /** \name Miscellaneous. */
    ///@{
-   std::string getUserId() const;
-   std::string getHostName() const;
-   std::vector<std::string> getMACAddresses(void);
+   MMCORE_DEPRECATED(std::string getUserId() const);
+   MMCORE_DEPRECATED(std::string getHostName() const);
+   MMCORE_DEPRECATED(std::vector<std::string> getMACAddresses(void));
    ///@}
 
 private:


### PR DESCRIPTION
These never really belonged in MMCore (they are only there because it was a convenient place to get C++ functions wrapped for Java) and these days there are better alternatives in Java and Python. Removing these has a small benefit of simplifying the build config on macOS (and potentially Windows), aside from removing code that need maintenance (the macOS implementation currently gets a deprecation warning).