### PR TITLE
Require SWIG 2.x or 3.x to build MMCoreJ

### DIFF
--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -24,6 +24,10 @@
 // CVS:           $Id: MMCoreJ.i 16466 2017-08-23 21:46:52Z nico $
 //
 
+#if SWIG_VERSION < 0x020000 || SWIG_VERSION >= 0x040000
+#error SWIG 2.x or 3.x is currently required to build MMCoreJ
+#endif
+
 %module (directors="1") MMCoreJ
 %feature("director") MMEventCallback;
 


### PR DESCRIPTION
Building with SWIG 4+ results in errors, possibly later in the build (in MMStudio, because SWIG 4 changed some of the wrapped types). Until now, this was confusing and has resulted in multiple issues filed. (See #37.)

Until we have a proper fix for SWIG 4, let's make it fail immediately with the correct error message.