### PR TITLE
The stage won't be on movement when a move call is finished.

### DIFF
--- a/DeviceAdapters/Standa8SMC4/Standa8SMC4.cpp
+++ b/DeviceAdapters/Standa8SMC4/Standa8SMC4.cpp
@@ -349,6 +349,8 @@ int Standa8SMC4Z::SetPositionUm(double pos)
       return DEVICE_UNKNOWN_POSITION;
    }
 
+   command_wait_for_stop(device_, 1);
+
    // Set future position
    OnStagePositionChanged(pos);
 
@@ -403,6 +405,8 @@ int Standa8SMC4Z::SetPositionSteps(long steps)
    {
       return DEVICE_UNKNOWN_POSITION;
    }
+
+   command_wait_for_stop(device_, 1);
 
    // Set future position
    OnStagePositionChanged(steps * unitMultiplier_);
@@ -1015,6 +1019,9 @@ int Standa8SMC4XY::SetPositionUm(double x, double y)
       return DEVICE_UNKNOWN_POSITION;
    }
 
+   command_wait_for_stop(deviceX_, 1);
+   command_wait_for_stop(deviceY_, 1);
+
    // Set future position
    OnXYStagePositionChanged(x, y);
 
@@ -1079,6 +1086,9 @@ int Standa8SMC4XY::SetRelativePositionUm(double dx, double dy)
    {
       return DEVICE_UNKNOWN_POSITION;
    }
+
+   command_wait_for_stop(deviceX_, 1);
+   command_wait_for_stop(deviceY_, 1);
 
    // Set future position
    UpdatePositions(dx, dy);

--- a/DeviceAdapters/Standa8SMC4/Standa8SMC4.vcxproj
+++ b/DeviceAdapters/Standa8SMC4/Standa8SMC4.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -68,7 +68,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\XIMC\ximc-2.10.5\ximc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\XIMC\ximc-2.8.4\ximc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -76,7 +76,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\XIMC\ximc-2.7.6\ximc\win64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPRIVATE)\XIMC\ximc-2.8.4\ximc\win64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>libximc.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
We use the Standa8SMC4 with a XY stage and observed that when we use a multipoint acquisition in u-manager the images would be blurry.

We realised that one the trigger signal was send the stage was still moving so adding the wait to finish movement fix the wrong behaviour.

I also updated the expected version of `libximc` to `2.8.4` so this call can be found. The current version in the documentation can't be found in the official webpage from Standa: https://files.xisupport.com/Software.en.html


It would be good to also update the webpage and documentation with the right version so it's consistent but I don't know where to find this information.