### PR TITLE
MMCoreJ.i: added code to make adding the system cache to tagged images conditional.

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -113,7 +113,7 @@ using namespace std;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 10, MMCore_versionMinor = 3, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 10, MMCore_versionMinor = 4, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -642,6 +642,16 @@
 %}
 
 %typemap(javacode) CMMCore %{
+   Boolean includeSystemCache_ = true;
+
+   public Boolean includeSystemCache() { 
+      return includeSystemCache_;
+   }
+   public void setIncludeSystemCache(Boolean state) {
+      includeSystemCache_ = state;
+   }
+
+
    private JSONObject metadataToMap(Metadata md) {
       JSONObject tags = new JSONObject();
       for (String key:md.GetKeys()) {
@@ -723,12 +733,14 @@
    private TaggedImage createTaggedImage(Object pixels, Metadata md) throws java.lang.Exception {
       JSONObject tags = metadataToMap(md);
       PropertySetting setting;
-      Configuration config = getSystemStateCache();
-      for (int i = 0; i < config.size(); ++i) {
-         setting = config.getSetting(i);
-         String key = setting.getDeviceLabel() + "-" + setting.getPropertyName();
-         String value = setting.getPropertyValue();
-          tags.put(key, value);
+      if (includeSystemCache_) {
+         Configuration config = getSystemStateCache();
+         for (int i = 0; i < config.size(); ++i) {
+            setting = config.getSetting(i);
+            String key = setting.getDeviceLabel() + "-" + setting.getPropertyName();
+            String value = setting.getPropertyValue();
+             tags.put(key, value);
+         }
       }
       tags.put("BitDepth", getImageBitDepth());
       tags.put("PixelSizeUm", getPixelSizeUm(true));

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -642,12 +642,12 @@
 %}
 
 %typemap(javacode) CMMCore %{
-   private Boolean includeSystemStateCache_ = true;
+   private boolean includeSystemStateCache_ = true;
 
-   public Boolean getIncludeSystemStateCache() { 
+   public boolean getIncludeSystemStateCache() { 
       return includeSystemStateCache_;
    }
-   public void setIncludeSystemStateCache(Boolean state) {
+   public void setIncludeSystemStateCache(boolean state) {
       includeSystemStateCache_ = state;
    }
 

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -642,13 +642,13 @@
 %}
 
 %typemap(javacode) CMMCore %{
-   Boolean includeSystemCache_ = true;
+   private Boolean includeSystemStateCache_ = true;
 
-   public Boolean includeSystemCache() { 
-      return includeSystemCache_;
+   public Boolean getIncludeSystemStateCache() { 
+      return includeSystemStateCache_;
    }
-   public void setIncludeSystemCache(Boolean state) {
-      includeSystemCache_ = state;
+   public void setIncludeSystemStateCache(Boolean state) {
+      includeSystemStateCache_ = state;
    }
 
 
@@ -733,7 +733,7 @@
    private TaggedImage createTaggedImage(Object pixels, Metadata md) throws java.lang.Exception {
       JSONObject tags = metadataToMap(md);
       PropertySetting setting;
-      if (includeSystemCache_) {
+      if (includeSystemStateCache_) {
          Configuration config = getSystemStateCache();
          for (int i = 0; i < config.size(); ++i) {
             setting = config.getSetting(i);


### PR DESCRIPTION
That was remarkably simple.  However, do not merge (yet).  Consequences are unexpected: In both Live and Snap mode, the "user" tags contain the system state cache, which disappear after running `mmc.setIncludeSystemCache(true)` in the script panel.  However, the system cache is also contained in the "device" tags, presumably entered somewhere upstream in the code.  That makes me believe we should remove the addition of the systemStateCache altogether. There is some work needed to do so, because running an MDA with 3 Z positions after `mmc.setIncludeSystemCache(true)` results in:

```
2022-11-24T07:59:59.783280 tid33644 [IFO,App] 
                                    [       ] java.lang.IllegalArgumentException: Failed to convert TaggedImage tags to metadata in Thread[TaggedImage sink thread,6,main]
                                    [       ]   at org.micromanager.data.internal.DefaultImage.<init>(DefaultImage.java:113)
                                    [       ]   at org.micromanager.data.internal.DefaultImage.<init>(DefaultImage.java:82)
                                    [       ]   at org.micromanager.acquisition.internal.DefaultTaggedImageSink$1.run(DefaultTaggedImageSink.java:68)
                                    [       ] Caused by: java.lang.NullPointerException
                                    [       ]   at org.micromanager.data.internal.PropertyKey$48.extractFromGsonObject(PropertyKey.java:1256)
                                    [       ]   at org.micromanager.internal.propertymap.NonPropertyMapJSONFormats$MetadataFormat.fromGson(NonPropertyMapJSONFormats.java:212)
                                    [       ]   at org.micromanager.data.internal.DefaultImage.<init>(DefaultImage.java:111)
                                    [       ]   at org.micromanager.data.internal.DefaultImage.<init>(DefaultImage.java:82)
                                    [       ]   at org.micromanager.acquisition.internal.DefaultTaggedImageSink$1.run(DefaultTaggedImageSink.java:68)
```

Working on that now. 