### PR TITLE
Add State Sequencing to DStateDevice

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -2824,7 +2824,7 @@ numPos_(10),
 initialized_(false),
 changedTime_(0.0),
 busy_(false),
-sequenceOn_(true),
+sequenceOn_(false),
 gateOpen_(true),
 position_(0),
 isClosed_(true)
@@ -2918,7 +2918,7 @@ int CDemoStateDevice::Initialize()
    // Sequence
    // -----
    pAct = new CPropertyAction(this, &CDemoStateDevice::OnSequence);
-   ret = CreateProperty("Sequence", "On", MM::String, false, pAct);
+   ret = CreateProperty("Sequence", "Off", MM::String, false, pAct);
    if (ret != DEVICE_OK)
        return ret;
    AddAllowedValue("Sequence", "On");

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -432,7 +432,7 @@ public:
    int Shutdown();
   
    void GetName(char* pszName) const;
-   bool Busy() { return busy_; };
+   bool Busy();
   
 
    // action interface
@@ -449,6 +449,7 @@ private:
    uint16_t numPatterns_;
    long numPos_;
    bool initialized_;
+   MM::MMTime changedTime_;
    bool busy_;
    bool sequenceOn_;
    bool gateOpen_;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -432,18 +432,27 @@ public:
    int Shutdown();
   
    void GetName(char* pszName) const;
-   bool Busy();
-   unsigned long GetNumberOfPositions()const {return numPos_;}
+   bool Busy() { return busy_;  }
+  
 
    // action interface
    // ----------------
+   unsigned long GetNumberOfPositions()const { return numPos_; }
    int OnState(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnNumberOfStates(MM::PropertyBase* pProp, MM::ActionType eAct);
 
+   int OnSequence(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int SetGateOpen(bool open);
+   int GetGateOpen(bool& open);
+
 private:
+   uint16_t numPatterns_;
    long numPos_;
    bool initialized_;
-   MM::MMTime changedTime_;
+   bool busy_;
+   bool sequenceOn_;
+   bool gateOpen_;
+   bool isClosed_;
    long position_;
 };
 

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -432,12 +432,12 @@ public:
    int Shutdown();
   
    void GetName(char* pszName) const;
-   bool Busy() { return busy_;  }
+   bool Busy() { return busy_; };
   
 
    // action interface
    // ----------------
-   unsigned long GetNumberOfPositions()const { return numPos_; }
+   unsigned long GetNumberOfPositions()const { return numPos_; };
    int OnState(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnNumberOfStates(MM::PropertyBase* pProp, MM::ActionType eAct);
 


### PR DESCRIPTION
This PR adds the ability to sequence the State property of the `DStateDevice`. This is helpful in testing the channel sequencing capabilities of the acquisition engine as in https://github.com/micro-manager/pycro-manager/pull/458.

Here I also remove the Delay capability of the `DStateDevice`, which overlaps in functionality with `DWheel`.

In a future PR, I plan to rename the device from `DemoCamera` to `DemoHub` and separate the device across individual `.cpp` files.