### PR TITLE
NIDAQ: Fix bug causing blanking property to disappear

### DIFF
--- a/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
@@ -165,6 +165,10 @@ int DigitalOutputPort::Shutdown()
    if (!initialized_)
       return DEVICE_OK;
 
+   if (blanking_)
+       GetHub()->StopDOBlankingAndSequence(portWidth_);
+   blanking_ = false; 
+
    SetState(0);
    int err = StopTask();
 


### PR DESCRIPTION
NIDAQ: Fix bug causing blanking property to disappear when reloading the device adapter when blanking is on. Fixed by checking for blanking in the Shutdown function and stop blanking if it was on.