### PR TITLE
MMCore: Cosmetic changes to thread pool and task classes

### DIFF
--- a/MMCore/Semaphore.cpp
+++ b/MMCore/Semaphore.cpp
@@ -26,7 +26,6 @@
 #include <mutex>
 
 Semaphore::Semaphore()
-    : count_(0)
 {
 }
 

--- a/MMCore/Semaphore.h
+++ b/MMCore/Semaphore.h
@@ -27,7 +27,7 @@
 #include <cstddef>
 #include <mutex>
 
-class Semaphore/* final*/
+class Semaphore final
 {
 public:
     explicit Semaphore();
@@ -37,7 +37,7 @@ public:
     void Release(size_t count = 1);
 
 private:
-    size_t count_;
-    std::mutex mx_;
-    std::condition_variable cv_;
+    size_t count_{ 0 };
+    std::mutex mx_{};
+    std::condition_variable cv_{};
 };

--- a/MMCore/Task.h
+++ b/MMCore/Task.h
@@ -34,8 +34,8 @@ public:
     explicit Task(std::shared_ptr<Semaphore> semaphore, size_t taskIndex, size_t totalTaskCount);
     virtual ~Task();
 
-    Task(const Task&)/* = delete*/;
-    Task& operator=(const Task&)/* = delete*/;
+    Task(const Task&) = delete;
+    Task& operator=(const Task&) = delete;
 
     virtual void Execute() = 0;
     void Done();

--- a/MMCore/TaskSet.cpp
+++ b/MMCore/TaskSet.cpp
@@ -24,15 +24,12 @@
 #include "TaskSet.h"
 
 #include <cassert>
-#include <memory>
 
 TaskSet::TaskSet(std::shared_ptr<ThreadPool> pool)
     : pool_(pool),
-    semaphore_(std::make_shared<Semaphore>()),
-    tasks_(),
-    usedTaskCount_(0)
+    semaphore_(std::make_shared<Semaphore>())
 {
-    assert(pool != NULL);
+    assert(pool);
 }
 
 TaskSet::~TaskSet()

--- a/MMCore/TaskSet.h
+++ b/MMCore/TaskSet.h
@@ -36,8 +36,8 @@ public:
     explicit TaskSet(std::shared_ptr<ThreadPool> pool);
     virtual ~TaskSet();
 
-    TaskSet(const TaskSet&)/* = delete*/;
-    TaskSet& operator=(const TaskSet&)/* = delete*/;
+    TaskSet(const TaskSet&) = delete;
+    TaskSet& operator=(const TaskSet&) = delete;
 
     size_t GetUsedTaskCount() const;
 
@@ -45,10 +45,9 @@ public:
     virtual void Wait();
 
 protected:
-    //template<class T,
-    //    // Private param to enforce the type T derives from Task class
-    //    typename std::enable_if<std::is_base_of<Task, T>::value, int>::type = 0>
-    template<class T>
+    template<class T,
+        // Private param to enforce the type T derives from Task class
+        typename std::enable_if<std::is_base_of<Task, T>::value, int>::type = 0>
     void CreateTasks()
     {
         const size_t taskCount = pool_->GetSize();
@@ -66,6 +65,6 @@ protected:
 protected:
     const std::shared_ptr<ThreadPool> pool_;
     const std::shared_ptr<Semaphore> semaphore_;
-    std::vector<Task*> tasks_;
-    size_t usedTaskCount_;
+    std::vector<Task*> tasks_{};
+    size_t usedTaskCount_{ 0 };
 };

--- a/MMCore/TaskSet_CopyMemory.cpp
+++ b/MMCore/TaskSet_CopyMemory.cpp
@@ -28,10 +28,7 @@
 #include <cstring>
 
 TaskSet_CopyMemory::ATask::ATask(std::shared_ptr<Semaphore> semDone, size_t taskIndex, size_t totalTaskCount)
-    : Task(semDone, taskIndex, totalTaskCount),
-    dst_(NULL),
-    src_(NULL),
-    bytes_(0)
+    : Task(semDone, taskIndex, totalTaskCount)
 {
 }
 
@@ -67,8 +64,8 @@ TaskSet_CopyMemory::TaskSet_CopyMemory(std::shared_ptr<ThreadPool> pool)
 
 void TaskSet_CopyMemory::SetUp(void* dst, const void* src, size_t bytes)
 {
-    assert(dst != NULL);
-    assert(src != NULL);
+    assert(dst);
+    assert(src);
     assert(bytes > 0);
 
     // Call memcpy directly without threading for small frames up to 1MB

--- a/MMCore/TaskSet_CopyMemory.h
+++ b/MMCore/TaskSet_CopyMemory.h
@@ -35,12 +35,12 @@ private:
 
         void SetUp(void* dst, const void* src, size_t bytes, size_t usedTaskCount);
 
-        virtual void Execute()/* override*/;
+        virtual void Execute() override;
 
     private:
-        void* dst_;
-        const void* src_;
-        size_t bytes_;
+        void* dst_{ nullptr };
+        const void* src_{ nullptr };
+        size_t bytes_{ 0 };
     };
 
 public:
@@ -48,8 +48,8 @@ public:
 
     void SetUp(void* dst, const void* src, size_t bytes);
 
-    virtual void Execute()/* override*/;
-    virtual void Wait()/* override*/;
+    virtual void Execute() override;
+    virtual void Wait() override;
 
     // Helper blocking method calling SetUp, Execute and Wait
     void MemCopy(void* dst, const void* src, size_t bytes);

--- a/MMCore/ThreadPool.h
+++ b/MMCore/ThreadPool.h
@@ -33,7 +33,7 @@
 
 class Task;
 
-class ThreadPool/* final*/
+class ThreadPool final
 {
 public:
     explicit ThreadPool();
@@ -48,10 +48,9 @@ private:
     void ThreadFunc();
 
 private:
-    // TODO: Should use unique_ptr
-    std::vector<std::shared_ptr<std::thread> > threads_;
-    bool abortFlag_;
-    std::mutex mx_;
-    std::condition_variable cv_;
-    std::deque<Task*> queue_;
+    std::vector<std::unique_ptr<std::thread>> threads_{};
+    bool abortFlag_{ false };
+    std::mutex mx_{};
+    std::condition_variable cv_{};
+    std::deque<Task*> queue_{};
 };


### PR DESCRIPTION
The ```ThreadPool``` and related task classes were originally developed as a part of PVCAM device adapter and later copied to MMCore where the same functionality is needed. So far these classes are not considered a part of public API of MMCore, thus we have two copies.

This PR basically synchronizes the implementation with changes done in PVCAM adapter, namely using ```std::unique_ptr``` to store thread instances (that addressed a TODO note), restricting the task types to derive from ```Task``` base class, used C++11 keywords like ```override``` or ```final```.
The two copies of each file now differ only in one line in the copyright header comment stating the actual module name the code belongs to.