### PR TITLE
Update FlyCap2 version check in Point Grey device adapter

### DIFF
--- a/DeviceAdapters/PointGrey/PointGrey.cpp
+++ b/DeviceAdapters/PointGrey/PointGrey.cpp
@@ -262,8 +262,8 @@ int PointGrey::Initialize()
 
    // BE AWARE: This version number needs to be updated if/when MM is 
    // linked against another PGR version
-   if (pVersion.major != 2 || pVersion.minor != 10 || pVersion.type != 3 || pVersion.build != 266) {
-      SetErrorText(ALLERRORS, "Flycapture2_v100.dll is not version 2.10.3.266.  Micro-Manager works correctly only with that version");
+   if (pVersion.major != 2 || pVersion.minor != 13 || pVersion.type != 3 || pVersion.build != 61) {
+      SetErrorText(ALLERRORS, "Flycapture2_v100.dll is not version 2.13.3.61.  Micro-Manager works correctly only with that version");
       return ALLERRORS;
    }
 


### PR DESCRIPTION
This change addresses the problem with the Point Grey device adapter that is described in #363 . MM is currently compiled against FlyCap 2.13.3.61, but a version check in the device adapter code requires a DLL from version 2.10.3.266. This mismatch renders the current device adapter code unusable.

I verified that this change works on a Flir Grasshopper3 U3-23S6M.