### PR TITLE
TriggerScopeMM: Attempt to deal with garbage send to COM port earlier.

### DIFF
--- a/DeviceAdapters/TriggerScopeMM/TriggerScopeMM.cpp
+++ b/DeviceAdapters/TriggerScopeMM/TriggerScopeMM.cpp
@@ -256,39 +256,39 @@ MM::DeviceDetectionStatus CTriggerScopeMMHub::DetectDevice(void)
          MMThreadGuard myLock(lock_);
          PurgeComPort(port_.c_str());
 
-         std::string answer;
-         int ret = SendAndReceiveNoCheck("*", answer);
+std::string answer;
+int ret = SendAndReceiveNoCheck("*", answer);
 
-         if(answer.length() > 0)
-	      {
-            size_t idx = answer.find("ARC TRIGGERSCOPE 16");
-            if(idx!=string::npos)
-            {
-               if (answer.substr(answer.length() - 2, 2) == "MM") 
-               {
-                  result = MM::CanCommunicate;
-               }
-            }
-         }
-            
-         if( DEVICE_OK != ret )
-         {
-            LogMessageCode(ret,true);
-         }
-         else
-         {
-            // to succeed must reach here....
-            result = MM::CanCommunicate;
-         }
-         pS->Shutdown();
-         // always restore the AnswerTimeout to the default
-         GetCoreCallback()->SetDeviceProperty(port_.c_str(), "AnswerTimeout", answerTO);
+if (answer.length() > 0)
+{
+   size_t idx = answer.find("ARC TRIGGERSCOPE 16");
+   if (idx != string::npos)
+   {
+      if (answer.substr(answer.length() - 2, 2) == "MM")
+      {
+         result = MM::CanCommunicate;
+      }
+   }
+}
+
+if (DEVICE_OK != ret)
+{
+   LogMessageCode(ret, true);
+}
+else
+{
+   // to succeed must reach here....
+   result = MM::CanCommunicate;
+}
+pS->Shutdown();
+// always restore the AnswerTimeout to the default
+GetCoreCallback()->SetDeviceProperty(port_.c_str(), "AnswerTimeout", answerTO);
 
       }
    }
-   catch(...)
+   catch (...)
    {
-      LogMessage("Exception in DetectDevice!",false);
+      LogMessage("Exception in DetectDevice!", false);
    }
 
    return result;
@@ -303,7 +303,7 @@ MM::DeviceDetectionStatus CTriggerScopeMMHub::DetectDevice(void)
 * Shutdown() was not called.
 */
 CTriggerScopeMMHub::~CTriggerScopeMMHub(void)
-{                                                             
+{
    Shutdown();
    delete pResourceLock_;
 }
@@ -338,7 +338,7 @@ int CTriggerScopeMMHub::Initialize()
    ret = Purge();
    if (ret != DEVICE_OK)
       return ret;
-	firmwareVer_  = 0.0;
+   firmwareVer_ = 0.0;
    std::string answer = "";
    ret = SendAndReceiveNoCheck("*", answer);
    int attempts = 1;
@@ -351,30 +351,42 @@ int CTriggerScopeMMHub::Initialize()
    if (ret != DEVICE_OK)
       return ret;
 
-   if(answer.length()>0)
+   if (answer.length() > 0) {
+      // first check if the device returned an error.  This can happen
+      // when something else send bytes to the port before we did
+      size_t idx = answer.find("ERROR_UNKNOWN_COMMAND");
+      if (idx != string::npos) {
+         ret = SendAndReceiveNoCheck("*", answer);
+         if (ret != DEVICE_OK) {
+            return ret;
+         }
+      }
+   }
+
+   if (answer.length() > 0)
 	{
       size_t idx = answer.find("ARC TRIGGERSCOPE 16");
-      if(idx!=string::npos)
+      if (idx != string::npos)
          bTS16_ = true;			
 
       idx = answer.find("ARC_LED 16");
-      if (idx!=string::npos)
+      if (idx != string::npos)
       bTS16_ = true;			
 				
       idx = answer.find("ARC TRIGGERSCOPE");
 
-      if (idx==string::npos)   
+      if (idx == string::npos)   
          idx = answer.find("ARC_LED");
 
-      if (idx!=string::npos)
+      if (idx != string::npos)
       {
          idx = answer.find("v.");
-         if (idx!=string::npos)
+         if (idx != string::npos)
             firmwareVer_ = atof(&(answer.c_str()[idx+2]));
          else
          {
             idx = answer.find("v");
-            if (idx!=string::npos)
+            if (idx != string::npos)
                firmwareVer_ = atof(&(answer.c_str()[idx+1]));
          }
          if (answer.substr(answer.length() - 2, 2) != "MM") 

--- a/DeviceAdapters/TriggerScopeMM/TriggerScopeMMTTL.cpp
+++ b/DeviceAdapters/TriggerScopeMM/TriggerScopeMMTTL.cpp
@@ -58,7 +58,7 @@ CTriggerScopeMMTTL::CTriggerScopeMMTTL(uint8_t pinGroup) :
 
 void CTriggerScopeMMTTL::GetName(char* name) const
 {	
-   if(pinGroup_ == 1)
+   if(pinGroup_ == 0)
    {
 	   CDeviceUtils::CopyLimitedString(name, g_TriggerScopeMMTTLDeviceName1);   
    }
@@ -136,12 +136,12 @@ int CTriggerScopeMMTTL::Initialize()
    for (long ttlNr = 1; ttlNr <= 8; ttlNr ++) 
    {
       long pinNr = ttlNr + (pinGroup_ * 8l);
-      std::ostringstream os;
+      std::ostringstream oss;
       if (pinNr == 9) 
-         os << "TTL-" << std::setfill('0') << std::setw(2) << pinNr;
+         oss << "TTL-" << std::setfill('0') << std::setw(2) << pinNr;
       else
-         os << "TTL-" << pinNr;
-      std::string propName = os.str();
+         oss << "TTL-" << pinNr;
+      std::string propName = oss.str();
       CPropertyActionEx* pActEx = new CPropertyActionEx(this, &CTriggerScopeMMTTL::OnTTL, ttlNr - 1);
       nRet = CreateProperty(propName.c_str(), "0", MM::Integer, false, pActEx, false);
       if (nRet != DEVICE_OK)
@@ -309,8 +309,8 @@ int CTriggerScopeMMTTL::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
       int val = -1;
       for (unsigned int i=0; i < sequence.size(); i++)                       
       {
-         std::istringstream os (sequence[i]);
-         os >> val;
+         std::istringstream oss (sequence[i]);
+         oss >> val;
          if (val < 0 || val > 255)
             return ERR_INVALID_VALUE;
       }  
@@ -323,30 +323,30 @@ int CTriggerScopeMMTTL::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
          return ret;
 
       // then send the sequence
-      std::ostringstream cout;
-      cout << "PDO" << (int) pinGroup_ << "-0";
+      std::ostringstream cmd;
+      cmd << "PDO" << (int) pinGroup_ << "-0";
 
       for(std::vector<std::string>::iterator it = sequence.begin(); it != sequence.end(); ++it) 
       {
-         cout << "-" << *it;
+         cmd << "-" << *it;
       }
 
-      return pHub_->SendAndReceive(cout.str().c_str());
+      return pHub_->SendAndReceive(cmd.str().c_str());
                                                                                                                       
    }                                                                         
    else if (eAct == MM::StartSequence)
    { 
-      std::ostringstream cout;
-      cout << "PDS" << (int) pinGroup_ << "-1-" << (int) sequenceTransitionOnRising_;
+      std::ostringstream cmd;
+      cmd << "PDS" << (int) pinGroup_ << "-1-" << (int) sequenceTransitionOnRising_;
 
-      return pHub_->SendAndReceive(cout.str().c_str());
+      return pHub_->SendAndReceive(cmd.str().c_str());
     }
    else if (eAct == MM::StopSequence)                                        
    {
-      std::ostringstream cout;
-      cout << "PDS" << (int) pinGroup_ << "-0-" << (int) sequenceTransitionOnRising_;
+      std::ostringstream cmd;
+      cmd << "PDS" << (int) pinGroup_ << "-0-" << (int) sequenceTransitionOnRising_;
 
-      return pHub_->SendAndReceive(cout.str().c_str());
+      return pHub_->SendAndReceive(cmd.str().c_str());
    }                                                                         
 
    return DEVICE_OK;


### PR DESCRIPTION
If another device (in this case the RAP UGA40) send data to the COM port before TriggerScopeMM initialization, the device would fail.  This PR fixes that problem, by requesting device identification once more when the device returns an error.

Also, fixes wrong TTL device name, and several compiler warnings.