### PR TITLE
Zaber: Revert C++17 requirement

### DIFF
--- a/DeviceAdapters/Zaber/Makefile.am
+++ b/DeviceAdapters/Zaber/Makefile.am
@@ -1,7 +1,4 @@
-# We require C++17 because libzml is C++17. Setting the C++ standard for
-# individual device adapters is a hack and should not be imitated except when
-# there is no other option.
-AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS) -I$(MMTHIRDPARTYPUBLIC)/Zaber/zaber-motion/include -std=c++17 -Wno-dynamic-exception-spec
+AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS) -I$(MMTHIRDPARTYPUBLIC)/Zaber/zaber-motion/include
 
 deviceadapter_LTLIBRARIES = libmmgr_dal_Zaber.la
 libmmgr_dal_Zaber_la_SOURCES = \

--- a/DeviceAdapters/Zaber/Zaber.vcxproj
+++ b/DeviceAdapters/Zaber/Zaber.vcxproj
@@ -60,7 +60,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;MODULE_EXPORTS;_USRDLL;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)\Zaber\zaber-motion\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
With corrected ZML on 3rdpartypublic, C++17 is no longer required.

See https://github.com/micro-manager/mmCoreAndDevices/pull/359#issuecomment-1696564608