### PR TITLE
Zaber: Skip build when ZML not found

### DIFF
--- a/DeviceAdapters/Makefile.am
+++ b/DeviceAdapters/Makefile.am
@@ -65,6 +65,9 @@ endif
 if BUILD_V4L2
    V4L = Video4Linux
 endif
+if BUILD_ZABER
+   ZABER = Zaber
+endif
 
 # Please keep these ASCII-lexically sorted (pass through sort(1)).
 SUBDIRS = \
@@ -90,6 +93,7 @@ SUBDIRS = \
 	$(SPOT) \
 	$(USBMANAGER) \
 	$(V4L) \
+	$(ZABER) \
 	AAAOTF \
 	AOTF \
 	ASIFW1000 \
@@ -203,7 +207,6 @@ SUBDIRS = \
 	Xcite \
 	YodnE600 \
 	Yokogawa \
-	Zaber \
 	ZeissCAN \
 	ZeissCAN29 \
 	kdv \

--- a/DeviceAdapters/Zaber/Makefile.am
+++ b/DeviceAdapters/Zaber/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS) -I$(MMTHIRDPARTYPUBLIC)/Zaber/zaber-motion/include
+AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS) $(ZML_CPPFLAGS)
 
 deviceadapter_LTLIBRARIES = libmmgr_dal_Zaber.la
 libmmgr_dal_Zaber_la_SOURCES = \
@@ -18,24 +18,7 @@ libmmgr_dal_Zaber_la_SOURCES = \
 	ConnectionManager.h \
 	Stage.cpp \
 	Stage.h
-libmmgr_dal_Zaber_la_LIBADD = $(MMDEVAPI_LIBADD)
-
-if HOST_LINUX
-ZML_DIR_LIB = $(MMTHIRDPARTYPUBLIC)/Zaber/zaber-motion/linux-amd64/lib
-RPATH_FLAGS = -Wl,-rpath -Wl,\$$ORIGIN
-dist_deviceadapter_DATA = \
-	$(ZML_DIR_LIB)/libzml.so.3.4 \
-	$(ZML_DIR_LIB)/libzaber-motion-lib-linux-amd64.so.3.4.3
-endif
-
-if HOST_OSX
-ZML_DIR_LIB = $(MMTHIRDPARTYPUBLIC)/Zaber/zaber-motion/darwin/lib
-RPATH_FLAGS = -Wl,-rpath -Wl,@loader_path
-dist_deviceadapter_DATA = \
-	$(ZML_DIR_LIB)/libzaber-motion-lib-darwin-uni.3.4.3.dylib \
-	$(ZML_DIR_LIB)/libzml.3.4.dylib
-endif
-
-libmmgr_dal_Zaber_la_LDFLAGS = $(MMDEVAPI_LDFLAGS) -L$(ZML_DIR_LIB) -lzml $(RPATH_FLAGS)
+libmmgr_dal_Zaber_la_LIBADD = $(MMDEVAPI_LIBADD) $(ZML_LIBS)
+libmmgr_dal_Zaber_la_LDFLAGS = $(MMDEVAPI_LDFLAGS) $(ZML_LDFLAGS)
 
 EXTRA_DIST = Zaber.vcxproj Zaber.vcxproj.filters license.txt

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -39,8 +39,6 @@ AC_SUBST(MMDEVAPI_LDFLAGS)
 
 # Location of third party public files
 thirdpartypublic="${micromanager_path}/../3rdpartypublic"
-MMTHIRDPARTYPUBLIC="${thirdpartypublic}"
-AC_SUBST(MMTHIRDPARTYPUBLIC)
 
 MM_INSTALL_DIRS
 
@@ -395,6 +393,27 @@ AS_IF([test "x$want_opencv" != xno],
 
 
 AM_CONDITIONAL([BUILD_OPENCV], [test "x$use_opencv" = xyes])
+
+# Zaber Motion Library (hack: only support 3rdpartypublic copy currently)
+AC_MSG_CHECKING([for Zaber Motion Library in 3rdpartypublic])
+zml_header_to_check="${thirdpartypublic}/Zaber/zaber-motion/include/zaber/motion/library.h"
+AM_CONDITIONAL([BUILD_ZABER], [test -f $zml_header_to_check])
+if test -f "$zml_header_to_check"; then
+   AC_MSG_RESULT([found])
+   ZML_CPPFLAGS="-I${thirdpartypublic}/Zaber/zaber-motion/include"
+   ZML_LIBS="-lzml"
+   case $host in
+      *linux*)
+         ZML_LDFLAGS="-L${thirdpartypublic}/Zaber/zaber-motion/linux-amd64/lib" ;;
+      *apple-darwin*)
+         ZML_LDFLAGS="-L${thirdpartypublic}/Zaber/zaber-motion/darwin/lib" ;;
+   esac
+else
+   AC_MSG_RESULT([not found])
+fi
+AC_SUBST(ZML_CPPFLAGS)
+AC_SUBST(ZML_LIBS)
+AC_SUBST(ZML_LDFLAGS)
 
 
 # Only build ... when the code is there


### PR DESCRIPTION
Closes #368.

Without this, 3rdpartypublic is required for the Mac/Linux build. We want to keep it so that only 3rdpartypublic/classext is required on those platforms (and not even that with `--without-java`).

This change also removes the special rpath flags. In the official macOS build, dependency paths are handled by a spearate script. On Linux, the only currently supported way is to build on the system where MM will be run, so (I hope) it is not necessary to use a special flag.