### PR TITLE
save pixel size settings in saveSystemConfiguration

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -7327,7 +7327,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
       
       os << MM::g_CFGCommand_PixelSize_um << ',' << configs[j] << ',' << getPixelSizeUmByID(configs[j].c_str()) << endl;
 
-      std::vector<double> affine = getPixelSizeAffine(configs[j].c_str());
+      std::vector<double> affine = getPixelSizeAffineByID(configs[j].c_str());
       os << MM::g_CFGCommand_PixelSizeAffine << ',' << configs[j] << ',';
       for (size_t i = 0; i < affine.size(); ++i) {
          os << affine[i];


### PR DESCRIPTION
This PR would add PixelSizeConfigs to the output of `saveSystemConfiguration` (similar to MMStudio's output).

@marktsuchida, haven't tested this locally, so let me know if there's any CI to confirm that stuff works, or if this repo just relies on local testing / visual inspection