### PR TITLE
Save AutoShutter state in saveSystemConfiguration()

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -6707,6 +6707,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
    {
       os << MM::g_CFGCommand_Property << ',' << MM::g_Keyword_CoreDevice << ',' << MM::g_Keyword_CoreFocus << ',' << focus->GetLabel() << endl;
    }
+   os << MM::g_CFGCommand_Property << ',' << MM::g_Keyword_CoreDevice << ',' << MM::g_Keyword_CoreAutoShutter << ',' << (getAutoShutter() ? '1' : '0') << endl;
 }
 
 /**


### PR DESCRIPTION
This complements #372 to bring the information saved by `saveSystemConfiguration()` equivalent to the MMStudio Hardware Configuration Wizard.