### PR TITLE
Throw object, not pointer, in C++

### DIFF
--- a/MMCore/ConfigGroup.h
+++ b/MMCore/ConfigGroup.h
@@ -397,7 +397,7 @@ public:
    { 
       if (affineMatrix.size() != 6) 
       {
-         throw new CMMError("PixelConfig affineMatrix must have 6 elements");
+         throw CMMError("PixelConfig affineMatrix must have 6 elements");
       }
       for (unsigned int i=0; i < affineMatrix.size(); i++) 
       {


### PR DESCRIPTION
This does not currently cause problems because the argument is pre-checked by `CMMCore::setPixelSizeAffine()`, but fixing to avoid future problems.