### PR TITLE
MMCore: Enforce pre/post initialization rules

### DIFF
--- a/MMCore/Devices/AutoFocusInstance.cpp
+++ b/MMCore/Devices/AutoFocusInstance.cpp
@@ -22,13 +22,13 @@
 #include "AutoFocusInstance.h"
 
 
-int AutoFocusInstance::SetContinuousFocusing(bool state) { return GetImpl()->SetContinuousFocusing(state); }
-int AutoFocusInstance::GetContinuousFocusing(bool& state) { return GetImpl()->GetContinuousFocusing(state); }
-bool AutoFocusInstance::IsContinuousFocusLocked() { return GetImpl()->IsContinuousFocusLocked(); }
-int AutoFocusInstance::FullFocus() { return GetImpl()->FullFocus(); }
-int AutoFocusInstance::IncrementalFocus() { return GetImpl()->IncrementalFocus(); }
-int AutoFocusInstance::GetLastFocusScore(double& score) { return GetImpl()->GetLastFocusScore(score); }
-int AutoFocusInstance::GetCurrentFocusScore(double& score) { return GetImpl()->GetCurrentFocusScore(score); }
-int AutoFocusInstance::AutoSetParameters() { return GetImpl()->AutoSetParameters(); }
-int AutoFocusInstance::GetOffset(double &offset) { return GetImpl()->GetOffset(offset); }
-int AutoFocusInstance::SetOffset(double offset) { return GetImpl()->SetOffset(offset); }
+int AutoFocusInstance::SetContinuousFocusing(bool state) { RequireInitialized(); return GetImpl()->SetContinuousFocusing(state); }
+int AutoFocusInstance::GetContinuousFocusing(bool& state) { RequireInitialized(); return GetImpl()->GetContinuousFocusing(state); }
+bool AutoFocusInstance::IsContinuousFocusLocked() { RequireInitialized(); return GetImpl()->IsContinuousFocusLocked(); }
+int AutoFocusInstance::FullFocus() { RequireInitialized(); return GetImpl()->FullFocus(); }
+int AutoFocusInstance::IncrementalFocus() { RequireInitialized(); return GetImpl()->IncrementalFocus(); }
+int AutoFocusInstance::GetLastFocusScore(double& score) { RequireInitialized(); return GetImpl()->GetLastFocusScore(score); }
+int AutoFocusInstance::GetCurrentFocusScore(double& score) { RequireInitialized(); return GetImpl()->GetCurrentFocusScore(score); }
+int AutoFocusInstance::AutoSetParameters() { RequireInitialized(); return GetImpl()->AutoSetParameters(); }
+int AutoFocusInstance::GetOffset(double &offset) { RequireInitialized(); return GetImpl()->GetOffset(offset); }
+int AutoFocusInstance::SetOffset(double offset) { RequireInitialized(); return GetImpl()->SetOffset(offset); }

--- a/MMCore/Devices/CameraInstance.cpp
+++ b/MMCore/Devices/CameraInstance.cpp
@@ -22,14 +22,15 @@
 #include "CameraInstance.h"
 
 
-int CameraInstance::SnapImage() { return GetImpl()->SnapImage(); }
-const unsigned char* CameraInstance::GetImageBuffer() { return GetImpl()->GetImageBuffer(); }
-const unsigned char* CameraInstance::GetImageBuffer(unsigned channelNr) { return GetImpl()->GetImageBuffer(channelNr); }
-const unsigned int* CameraInstance::GetImageBufferAsRGB32() { return GetImpl()->GetImageBufferAsRGB32(); }
-unsigned CameraInstance::GetNumberOfComponents() const { return GetImpl()->GetNumberOfComponents(); }
+int CameraInstance::SnapImage() { RequireInitialized(); return GetImpl()->SnapImage(); }
+const unsigned char* CameraInstance::GetImageBuffer() { RequireInitialized(); return GetImpl()->GetImageBuffer(); }
+const unsigned char* CameraInstance::GetImageBuffer(unsigned channelNr) { RequireInitialized(); return GetImpl()->GetImageBuffer(channelNr); }
+const unsigned int* CameraInstance::GetImageBufferAsRGB32() { RequireInitialized(); return GetImpl()->GetImageBufferAsRGB32(); }
+unsigned CameraInstance::GetNumberOfComponents() const { RequireInitialized(); return GetImpl()->GetNumberOfComponents(); }
 
 std::string CameraInstance::GetComponentName(unsigned component)
 {
+   RequireInitialized();
    DeviceStringBuffer nameBuf(this, "GetComponentName");
    int err = GetImpl()->GetComponentName(component, nameBuf.GetBuffer());
    ThrowIfError(err, "Cannot get component name at index " +
@@ -37,35 +38,37 @@ std::string CameraInstance::GetComponentName(unsigned component)
    return nameBuf.Get();
 }
 
-int unsigned CameraInstance::GetNumberOfChannels() const { return GetImpl()->GetNumberOfChannels(); }
+int unsigned CameraInstance::GetNumberOfChannels() const { RequireInitialized(); return GetImpl()->GetNumberOfChannels(); }
 
 std::string CameraInstance::GetChannelName(unsigned channel)
 {
+   RequireInitialized();
    DeviceStringBuffer nameBuf(this, "GetChannelName");
    int err = GetImpl()->GetChannelName(channel, nameBuf.GetBuffer());
    ThrowIfError(err, "Cannot get channel name at index " + ToString(channel));
    return nameBuf.Get();
 }
 
-long CameraInstance::GetImageBufferSize()const { return GetImpl()->GetImageBufferSize(); }
-unsigned CameraInstance::GetImageWidth() const { return GetImpl()->GetImageWidth(); }
-unsigned CameraInstance::GetImageHeight() const { return GetImpl()->GetImageHeight(); }
-unsigned CameraInstance::GetImageBytesPerPixel() const { return GetImpl()->GetImageBytesPerPixel(); }
-unsigned CameraInstance::GetBitDepth() const { return GetImpl()->GetBitDepth(); }
-double CameraInstance::GetPixelSizeUm() const { return GetImpl()->GetPixelSizeUm(); }
-int CameraInstance::GetBinning() const { return GetImpl()->GetBinning(); }
-int CameraInstance::SetBinning(int binSize) { return GetImpl()->SetBinning(binSize); }
-void CameraInstance::SetExposure(double exp_ms) { return GetImpl()->SetExposure(exp_ms); }
-double CameraInstance::GetExposure() const { return GetImpl()->GetExposure(); }
-int CameraInstance::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize) { return GetImpl()->SetROI(x, y, xSize, ySize); }
-int CameraInstance::GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize) { return GetImpl()->GetROI(x, y, xSize, ySize); }
-int CameraInstance::ClearROI() { return GetImpl()->ClearROI(); }
+long CameraInstance::GetImageBufferSize() const { RequireInitialized(); return GetImpl()->GetImageBufferSize(); }
+unsigned CameraInstance::GetImageWidth() const { RequireInitialized(); return GetImpl()->GetImageWidth(); }
+unsigned CameraInstance::GetImageHeight() const { RequireInitialized(); return GetImpl()->GetImageHeight(); }
+unsigned CameraInstance::GetImageBytesPerPixel() const { RequireInitialized(); return GetImpl()->GetImageBytesPerPixel(); }
+unsigned CameraInstance::GetBitDepth() const { RequireInitialized(); return GetImpl()->GetBitDepth(); }
+double CameraInstance::GetPixelSizeUm() const { RequireInitialized(); return GetImpl()->GetPixelSizeUm(); }
+int CameraInstance::GetBinning() const { RequireInitialized(); return GetImpl()->GetBinning(); }
+int CameraInstance::SetBinning(int binSize) { RequireInitialized(); return GetImpl()->SetBinning(binSize); }
+void CameraInstance::SetExposure(double exp_ms) { RequireInitialized(); return GetImpl()->SetExposure(exp_ms); }
+double CameraInstance::GetExposure() const { RequireInitialized(); return GetImpl()->GetExposure(); }
+int CameraInstance::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize) { RequireInitialized(); return GetImpl()->SetROI(x, y, xSize, ySize); }
+int CameraInstance::GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize) { RequireInitialized(); return GetImpl()->GetROI(x, y, xSize, ySize); }
+int CameraInstance::ClearROI() { RequireInitialized(); return GetImpl()->ClearROI(); }
 
 /**
  * Queries if the camera supports multiple simultaneous ROIs.
  */
 bool CameraInstance::SupportsMultiROI()
 {
+   RequireInitialized();
    return GetImpl()->SupportsMultiROI();
 }
 
@@ -76,6 +79,7 @@ bool CameraInstance::SupportsMultiROI()
  */
 bool CameraInstance::IsMultiROISet()
 {
+   RequireInitialized();
    return GetImpl()->IsMultiROISet();
 }
 
@@ -85,6 +89,7 @@ bool CameraInstance::IsMultiROISet()
  */
 int CameraInstance::GetMultiROICount(unsigned int& count)
 {
+   RequireInitialized();
    return GetImpl()->GetMultiROICount(count);
 }
 
@@ -101,6 +106,7 @@ int CameraInstance::SetMultiROI(const unsigned int* xs, const unsigned int* ys,
       const unsigned* widths, const unsigned int* heights,
       unsigned numROIs)
 {
+   RequireInitialized();
    return GetImpl()->SetMultiROI(xs, ys, widths, heights, numROIs);
 }
 
@@ -117,17 +123,19 @@ int CameraInstance::SetMultiROI(const unsigned int* xs, const unsigned int* ys,
 int CameraInstance::GetMultiROI(unsigned* xs, unsigned* ys, unsigned* widths,
       unsigned* heights, unsigned* length)
 {
+   RequireInitialized();
    return GetImpl()->GetMultiROI(xs, ys, widths, heights, length);
 }
 
-int CameraInstance::StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow) { return GetImpl()->StartSequenceAcquisition(numImages, interval_ms, stopOnOverflow); }
-int CameraInstance::StartSequenceAcquisition(double interval_ms) { return GetImpl()->StartSequenceAcquisition(interval_ms); }
-int CameraInstance::StopSequenceAcquisition() { return GetImpl()->StopSequenceAcquisition(); }
-int CameraInstance::PrepareSequenceAcqusition() { return GetImpl()->PrepareSequenceAcqusition(); }
-bool CameraInstance::IsCapturing() { return GetImpl()->IsCapturing(); }
+int CameraInstance::StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow) { RequireInitialized(); return GetImpl()->StartSequenceAcquisition(numImages, interval_ms, stopOnOverflow); }
+int CameraInstance::StartSequenceAcquisition(double interval_ms) { RequireInitialized(); return GetImpl()->StartSequenceAcquisition(interval_ms); }
+int CameraInstance::StopSequenceAcquisition() { RequireInitialized(); return GetImpl()->StopSequenceAcquisition(); }
+int CameraInstance::PrepareSequenceAcqusition() { RequireInitialized(); return GetImpl()->PrepareSequenceAcqusition(); }
+bool CameraInstance::IsCapturing() { RequireInitialized(); return GetImpl()->IsCapturing(); }
 
 std::string CameraInstance::GetTags()
 {
+   RequireInitialized();
    // TODO Probably makes sense to deserialize here.
    // Also note the danger of limiting serialized metadata to MM::MaxStrLength
    // (CCameraBase takes no precaution to limit string length; it is an
@@ -137,12 +145,12 @@ std::string CameraInstance::GetTags()
    return serializedMetadataBuf.Get();
 }
 
-void CameraInstance::AddTag(const char* key, const char* deviceLabel, const char* value) { return GetImpl()->AddTag(key, deviceLabel, value); }
-void CameraInstance::RemoveTag(const char* key) { return GetImpl()->RemoveTag(key); }
-int CameraInstance::IsExposureSequenceable(bool& isSequenceable) const { return GetImpl()->IsExposureSequenceable(isSequenceable); }
-int CameraInstance::GetExposureSequenceMaxLength(long& nrEvents) const { return GetImpl()->GetExposureSequenceMaxLength(nrEvents); }
-int CameraInstance::StartExposureSequence() { return GetImpl()->StartExposureSequence(); }
-int CameraInstance::StopExposureSequence() { return GetImpl()->StopExposureSequence(); }
-int CameraInstance::ClearExposureSequence() { return GetImpl()->ClearExposureSequence(); }
-int CameraInstance::AddToExposureSequence(double exposureTime_ms) { return GetImpl()->AddToExposureSequence(exposureTime_ms); }
-int CameraInstance::SendExposureSequence() const { return GetImpl()->SendExposureSequence(); }
+void CameraInstance::AddTag(const char* key, const char* deviceLabel, const char* value) { RequireInitialized(); return GetImpl()->AddTag(key, deviceLabel, value); }
+void CameraInstance::RemoveTag(const char* key) { RequireInitialized(); return GetImpl()->RemoveTag(key); }
+int CameraInstance::IsExposureSequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsExposureSequenceable(isSequenceable); }
+int CameraInstance::GetExposureSequenceMaxLength(long& nrEvents) const { RequireInitialized(); return GetImpl()->GetExposureSequenceMaxLength(nrEvents); }
+int CameraInstance::StartExposureSequence() { RequireInitialized(); return GetImpl()->StartExposureSequence(); }
+int CameraInstance::StopExposureSequence() { RequireInitialized(); return GetImpl()->StopExposureSequence(); }
+int CameraInstance::ClearExposureSequence() { RequireInitialized(); return GetImpl()->ClearExposureSequence(); }
+int CameraInstance::AddToExposureSequence(double exposureTime_ms) { RequireInitialized(); return GetImpl()->AddToExposureSequence(exposureTime_ms); }
+int CameraInstance::SendExposureSequence() const { RequireInitialized(); return GetImpl()->SendExposureSequence(); }

--- a/MMCore/Devices/DeviceInstance.cpp
+++ b/MMCore/Devices/DeviceInstance.cpp
@@ -122,6 +122,13 @@ DeviceInstance::ThrowIfError(int code, const std::string& message) const
 }
 
 void
+DeviceInstance::RequireInitialized() const
+{
+   if (!initialized_)
+      ThrowError("Operation not permitted on uninitialized device");
+}
+
+void
 DeviceInstance::DeviceStringBuffer::ThrowBufferOverflowError() const
 {
    std::string label(instance_ ? instance_->GetLabel() : "<unknown>");
@@ -159,6 +166,9 @@ void
 DeviceInstance::SetProperty(const std::string& name,
       const std::string& value) const
 {
+   if (initialized_ && GetPropertyInitStatus(name.c_str()))
+      ThrowError("Cannot set pre-init property after initialization");
+
    LOG_DEBUG(Logger()) << "Will set property \"" << name << "\" to \"" <<
       value << "\"";
 
@@ -315,7 +325,10 @@ DeviceInstance::GetErrorText(int code) const
 
 bool
 DeviceInstance::Busy()
-{ return pImpl_->Busy(); }
+{
+   RequireInitialized();
+   return pImpl_->Busy();
+}
 
 double
 DeviceInstance::GetDelayMs() const
@@ -332,12 +345,19 @@ DeviceInstance::UsesDelay()
 void
 DeviceInstance::Initialize()
 {
+   // Device initialization can only be attempted once per instance lifetime.
+   if (initializeCalled_)
+      ThrowError("Device already initialized (or initialization already attempted)");
+   initializeCalled_ = true;
    ThrowIfError(pImpl_->Initialize());
+   initialized_ = true;
 }
 
 void
 DeviceInstance::Shutdown()
 {
+   // Note we do not require device to be initialized before calling Shutdown().
+   initialized_ = false;
    ThrowIfError(pImpl_->Shutdown());
 }
 
@@ -357,7 +377,6 @@ void
 DeviceInstance::SetCallback(MM::Core* callback) { 
    pImpl_->SetCallback(callback); 
 }
-
 
 bool
 DeviceInstance::SupportsDeviceDetection()

--- a/MMCore/Devices/DeviceInstance.h
+++ b/MMCore/Devices/DeviceInstance.h
@@ -71,6 +71,8 @@ private:
    DeleteDeviceFunction deleteFunction_;
    mm::logging::Logger deviceLogger_;
    mm::logging::Logger coreLogger_;
+   bool initializeCalled_ = false;
+   bool initialized_ = false;
 
 public:
    DeviceInstance(const DeviceInstance&) = delete;
@@ -112,6 +114,7 @@ protected:
    void ThrowError(const std::string& message) const;
    void ThrowIfError(int code) const;
    void ThrowIfError(int code, const std::string& message) const;
+   void RequireInitialized() const;
 
    /// Utility class for getting fixed-length strings from the device interface.
    /**

--- a/MMCore/Devices/GalvoInstance.cpp
+++ b/MMCore/Devices/GalvoInstance.cpp
@@ -22,25 +22,26 @@
 #include "GalvoInstance.h"
 
 
-int GalvoInstance::PointAndFire(double x, double y, double time_us) { return GetImpl()->PointAndFire(x, y, time_us); }
-int GalvoInstance::SetSpotInterval(double pulseInterval_us) { return GetImpl()->SetSpotInterval(pulseInterval_us); }
-int GalvoInstance::SetPosition(double x, double y) { return GetImpl()->SetPosition(x, y); }
-int GalvoInstance::GetPosition(double& x, double& y) { return GetImpl()->GetPosition(x, y); }
-int GalvoInstance::SetIlluminationState(bool on) { return GetImpl()->SetIlluminationState(on); }
-double GalvoInstance::GetXRange() { return GetImpl()->GetXRange(); }
-double GalvoInstance::GetXMinimum() { return GetImpl()->GetXMinimum(); }
-double GalvoInstance::GetYRange() { return GetImpl()->GetYRange(); }
-double GalvoInstance::GetYMinimum() { return GetImpl()->GetYMinimum(); }
-int GalvoInstance::AddPolygonVertex(int polygonIndex, double x, double y) { return GetImpl()->AddPolygonVertex(polygonIndex, x, y); }
-int GalvoInstance::DeletePolygons() { return GetImpl()->DeletePolygons(); }
-int GalvoInstance::RunSequence() { return GetImpl()->RunSequence(); }
-int GalvoInstance::LoadPolygons() { return GetImpl()->LoadPolygons(); }
-int GalvoInstance::SetPolygonRepetitions(int repetitions) { return GetImpl()->SetPolygonRepetitions(repetitions); }
-int GalvoInstance::RunPolygons() { return GetImpl()->RunPolygons(); }
-int GalvoInstance::StopSequence() { return GetImpl()->StopSequence(); }
+int GalvoInstance::PointAndFire(double x, double y, double time_us) { RequireInitialized(); return GetImpl()->PointAndFire(x, y, time_us); }
+int GalvoInstance::SetSpotInterval(double pulseInterval_us) { RequireInitialized(); return GetImpl()->SetSpotInterval(pulseInterval_us); }
+int GalvoInstance::SetPosition(double x, double y) { RequireInitialized(); return GetImpl()->SetPosition(x, y); }
+int GalvoInstance::GetPosition(double& x, double& y) { RequireInitialized(); return GetImpl()->GetPosition(x, y); }
+int GalvoInstance::SetIlluminationState(bool on) { RequireInitialized(); return GetImpl()->SetIlluminationState(on); }
+double GalvoInstance::GetXRange() { RequireInitialized(); return GetImpl()->GetXRange(); }
+double GalvoInstance::GetXMinimum() { RequireInitialized(); return GetImpl()->GetXMinimum(); }
+double GalvoInstance::GetYRange() { RequireInitialized(); return GetImpl()->GetYRange(); }
+double GalvoInstance::GetYMinimum() { RequireInitialized(); return GetImpl()->GetYMinimum(); }
+int GalvoInstance::AddPolygonVertex(int polygonIndex, double x, double y) { RequireInitialized(); return GetImpl()->AddPolygonVertex(polygonIndex, x, y); }
+int GalvoInstance::DeletePolygons() { RequireInitialized(); return GetImpl()->DeletePolygons(); }
+int GalvoInstance::RunSequence() { RequireInitialized(); return GetImpl()->RunSequence(); }
+int GalvoInstance::LoadPolygons() { RequireInitialized(); return GetImpl()->LoadPolygons(); }
+int GalvoInstance::SetPolygonRepetitions(int repetitions) { RequireInitialized(); return GetImpl()->SetPolygonRepetitions(repetitions); }
+int GalvoInstance::RunPolygons() { RequireInitialized(); return GetImpl()->RunPolygons(); }
+int GalvoInstance::StopSequence() { RequireInitialized(); return GetImpl()->StopSequence(); }
 
 std::string GalvoInstance::GetChannel()
 {
+   RequireInitialized();
    DeviceStringBuffer nameBuf(this, "GetChannel");
    int err = GetImpl()->GetChannel(nameBuf.GetBuffer());
    ThrowIfError(err, "Cannot get current channel name");

--- a/MMCore/Devices/HubInstance.cpp
+++ b/MMCore/Devices/HubInstance.cpp
@@ -33,6 +33,8 @@
 std::vector<std::string>
 HubInstance::GetInstalledPeripheralNames()
 {
+   RequireInitialized();
+
    std::vector<MM::Device*> peripherals = GetInstalledPeripherals();
 
    std::vector<std::string> names;
@@ -59,6 +61,8 @@ HubInstance::GetInstalledPeripheralNames()
 std::string
 HubInstance::GetInstalledPeripheralDescription(const std::string& peripheralName)
 {
+   RequireInitialized();
+
    std::vector<MM::Device*> peripherals = GetInstalledPeripherals();
    for (std::vector<MM::Device*>::iterator it = peripherals.begin(), end = peripherals.end();
          it != end; ++it)

--- a/MMCore/Devices/ImageProcessorInstance.cpp
+++ b/MMCore/Devices/ImageProcessorInstance.cpp
@@ -22,4 +22,4 @@
 #include "ImageProcessorInstance.h"
 
 
-int ImageProcessorInstance::Process(unsigned char* buffer, unsigned width, unsigned height, unsigned byteDepth) { return GetImpl()->Process(buffer, width, height, byteDepth); }
+int ImageProcessorInstance::Process(unsigned char* buffer, unsigned width, unsigned height, unsigned byteDepth) { RequireInitialized(); return GetImpl()->Process(buffer, width, height, byteDepth); }

--- a/MMCore/Devices/MagnifierInstance.cpp
+++ b/MMCore/Devices/MagnifierInstance.cpp
@@ -22,4 +22,4 @@
 #include "MagnifierInstance.h"
 
 
-double MagnifierInstance::GetMagnification() { return GetImpl()->GetMagnification(); }
+double MagnifierInstance::GetMagnification() { RequireInitialized(); return GetImpl()->GetMagnification(); }

--- a/MMCore/Devices/SLMInstance.cpp
+++ b/MMCore/Devices/SLMInstance.cpp
@@ -22,26 +22,26 @@
 #include "SLMInstance.h"
 
 
-int SLMInstance::SetImage(unsigned char* pixels) { return GetImpl()->SetImage(pixels); }
-int SLMInstance::SetImage(unsigned int* pixels) { return GetImpl()->SetImage(pixels); }
-int SLMInstance::DisplayImage() { return GetImpl()->DisplayImage(); }
-int SLMInstance::SetPixelsTo(unsigned char intensity) { return GetImpl()->SetPixelsTo(intensity); }
-int SLMInstance::SetPixelsTo(unsigned char red, unsigned char green, unsigned char blue) { return GetImpl()->SetPixelsTo(red, green, blue); }
-int SLMInstance::SetExposure(double interval_ms) { return GetImpl()->SetExposure(interval_ms); }
-double SLMInstance::GetExposure() { return GetImpl()->GetExposure(); }
-unsigned SLMInstance::GetWidth() { return GetImpl()->GetWidth(); }
-unsigned SLMInstance::GetHeight() { return GetImpl()->GetHeight(); }
-unsigned SLMInstance::GetNumberOfComponents() { return GetImpl()->GetNumberOfComponents(); }
-unsigned SLMInstance::GetBytesPerPixel() { return GetImpl()->GetBytesPerPixel(); }
+int SLMInstance::SetImage(unsigned char* pixels) { RequireInitialized(); return GetImpl()->SetImage(pixels); }
+int SLMInstance::SetImage(unsigned int* pixels) { RequireInitialized(); return GetImpl()->SetImage(pixels); }
+int SLMInstance::DisplayImage() { RequireInitialized(); return GetImpl()->DisplayImage(); }
+int SLMInstance::SetPixelsTo(unsigned char intensity) { RequireInitialized(); return GetImpl()->SetPixelsTo(intensity); }
+int SLMInstance::SetPixelsTo(unsigned char red, unsigned char green, unsigned char blue) { RequireInitialized(); return GetImpl()->SetPixelsTo(red, green, blue); }
+int SLMInstance::SetExposure(double interval_ms) { RequireInitialized(); return GetImpl()->SetExposure(interval_ms); }
+double SLMInstance::GetExposure() { RequireInitialized(); return GetImpl()->GetExposure(); }
+unsigned SLMInstance::GetWidth() { RequireInitialized(); return GetImpl()->GetWidth(); }
+unsigned SLMInstance::GetHeight() { RequireInitialized(); return GetImpl()->GetHeight(); }
+unsigned SLMInstance::GetNumberOfComponents() { RequireInitialized(); return GetImpl()->GetNumberOfComponents(); }
+unsigned SLMInstance::GetBytesPerPixel() { RequireInitialized(); return GetImpl()->GetBytesPerPixel(); }
 int SLMInstance::IsSLMSequenceable(bool& isSequenceable)
-{ return GetImpl()->IsSLMSequenceable(isSequenceable); }
+{ RequireInitialized(); return GetImpl()->IsSLMSequenceable(isSequenceable); }
 int SLMInstance::GetSLMSequenceMaxLength(long& nrEvents)
-{ return GetImpl()->GetSLMSequenceMaxLength(nrEvents); }
-int SLMInstance::StartSLMSequence() { return GetImpl()->StartSLMSequence(); }
-int SLMInstance::StopSLMSequence() { return GetImpl()->StopSLMSequence(); }
-int SLMInstance::ClearSLMSequence() { return GetImpl()->ClearSLMSequence(); }
+{ RequireInitialized(); return GetImpl()->GetSLMSequenceMaxLength(nrEvents); }
+int SLMInstance::StartSLMSequence() { RequireInitialized(); return GetImpl()->StartSLMSequence(); }
+int SLMInstance::StopSLMSequence() { RequireInitialized(); return GetImpl()->StopSLMSequence(); }
+int SLMInstance::ClearSLMSequence() { RequireInitialized(); return GetImpl()->ClearSLMSequence(); }
 int SLMInstance::AddToSLMSequence(const unsigned char * pixels)
-{ return GetImpl()->AddToSLMSequence(pixels); }
+{ RequireInitialized(); return GetImpl()->AddToSLMSequence(pixels); }
 int SLMInstance::AddToSLMSequence(const unsigned int * pixels)
-{ return GetImpl()->AddToSLMSequence(pixels); }
-int SLMInstance::SendSLMSequence() { return GetImpl()->SendSLMSequence(); }
+{ RequireInitialized(); return GetImpl()->AddToSLMSequence(pixels); }
+int SLMInstance::SendSLMSequence() { RequireInitialized(); return GetImpl()->SendSLMSequence(); }

--- a/MMCore/Devices/SerialInstance.cpp
+++ b/MMCore/Devices/SerialInstance.cpp
@@ -22,9 +22,9 @@
 #include "SerialInstance.h"
 
 
-MM::PortType SerialInstance::GetPortType() const { return GetImpl()->GetPortType(); }
-int SerialInstance::SetCommand(const char* command, const char* term) { return GetImpl()->SetCommand(command, term); }
-int SerialInstance::GetAnswer(char* txt, unsigned maxChars, const char* term) { return GetImpl()->GetAnswer(txt, maxChars, term); }
-int SerialInstance::Write(const unsigned char* buf, unsigned long bufLen) { return GetImpl()->Write(buf, bufLen); }
-int SerialInstance::Read(unsigned char* buf, unsigned long bufLen, unsigned long& charsRead) { return GetImpl()->Read(buf, bufLen, charsRead); }
-int SerialInstance::Purge() { return GetImpl()->Purge(); }
+MM::PortType SerialInstance::GetPortType() const { RequireInitialized(); return GetImpl()->GetPortType(); }
+int SerialInstance::SetCommand(const char* command, const char* term) { RequireInitialized(); return GetImpl()->SetCommand(command, term); }
+int SerialInstance::GetAnswer(char* txt, unsigned maxChars, const char* term) { RequireInitialized(); return GetImpl()->GetAnswer(txt, maxChars, term); }
+int SerialInstance::Write(const unsigned char* buf, unsigned long bufLen) { RequireInitialized(); return GetImpl()->Write(buf, bufLen); }
+int SerialInstance::Read(unsigned char* buf, unsigned long bufLen, unsigned long& charsRead) { RequireInitialized(); return GetImpl()->Read(buf, bufLen, charsRead); }
+int SerialInstance::Purge() { RequireInitialized(); return GetImpl()->Purge(); }

--- a/MMCore/Devices/ShutterInstance.cpp
+++ b/MMCore/Devices/ShutterInstance.cpp
@@ -22,6 +22,6 @@
 #include "ShutterInstance.h"
 
 
-int ShutterInstance::SetOpen(bool open) { return GetImpl()->SetOpen(open); }
-int ShutterInstance::GetOpen(bool& open) { return GetImpl()->GetOpen(open); }
-int ShutterInstance::Fire(double deltaT) { return GetImpl()->Fire(deltaT); }
+int ShutterInstance::SetOpen(bool open) { RequireInitialized(); return GetImpl()->SetOpen(open); }
+int ShutterInstance::GetOpen(bool& open) { RequireInitialized(); return GetImpl()->GetOpen(open); }
+int ShutterInstance::Fire(double deltaT) { RequireInitialized(); return GetImpl()->Fire(deltaT); }

--- a/MMCore/Devices/SignalIOInstance.cpp
+++ b/MMCore/Devices/SignalIOInstance.cpp
@@ -22,15 +22,15 @@
 #include "SignalIOInstance.h"
 
 
-int SignalIOInstance::SetGateOpen(bool open) { return GetImpl()->SetGateOpen(open); }
-int SignalIOInstance::GetGateOpen(bool& open) { return GetImpl()->GetGateOpen(open); }
-int SignalIOInstance::SetSignal(double volts) { return GetImpl()->SetSignal(volts); }
-int SignalIOInstance::GetSignal(double& volts) { return GetImpl()->GetSignal(volts); }
-int SignalIOInstance::GetLimits(double& minVolts, double& maxVolts) { return GetImpl()->GetLimits(minVolts, maxVolts); }
-int SignalIOInstance::IsDASequenceable(bool& isSequenceable) const { return GetImpl()->IsDASequenceable(isSequenceable); }
-int SignalIOInstance::GetDASequenceMaxLength(long& nrEvents) const { return GetImpl()->GetDASequenceMaxLength(nrEvents); }
-int SignalIOInstance::StartDASequence() { return GetImpl()->StartDASequence(); }
-int SignalIOInstance::StopDASequence() { return GetImpl()->StopDASequence(); }
-int SignalIOInstance::ClearDASequence() { return GetImpl()->ClearDASequence(); }
-int SignalIOInstance::AddToDASequence(double voltage) { return GetImpl()->AddToDASequence(voltage); }
-int SignalIOInstance::SendDASequence() { return GetImpl()->SendDASequence(); }
+int SignalIOInstance::SetGateOpen(bool open) { RequireInitialized(); return GetImpl()->SetGateOpen(open); }
+int SignalIOInstance::GetGateOpen(bool& open) { RequireInitialized(); return GetImpl()->GetGateOpen(open); }
+int SignalIOInstance::SetSignal(double volts) { RequireInitialized(); return GetImpl()->SetSignal(volts); }
+int SignalIOInstance::GetSignal(double& volts) { RequireInitialized(); return GetImpl()->GetSignal(volts); }
+int SignalIOInstance::GetLimits(double& minVolts, double& maxVolts) { RequireInitialized(); return GetImpl()->GetLimits(minVolts, maxVolts); }
+int SignalIOInstance::IsDASequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsDASequenceable(isSequenceable); }
+int SignalIOInstance::GetDASequenceMaxLength(long& nrEvents) const { RequireInitialized(); return GetImpl()->GetDASequenceMaxLength(nrEvents); }
+int SignalIOInstance::StartDASequence() { RequireInitialized(); return GetImpl()->StartDASequence(); }
+int SignalIOInstance::StopDASequence() { RequireInitialized(); return GetImpl()->StopDASequence(); }
+int SignalIOInstance::ClearDASequence() { RequireInitialized(); return GetImpl()->ClearDASequence(); }
+int SignalIOInstance::AddToDASequence(double voltage) { RequireInitialized(); return GetImpl()->AddToDASequence(voltage); }
+int SignalIOInstance::SendDASequence() { RequireInitialized(); return GetImpl()->SendDASequence(); }

--- a/MMCore/Devices/StageInstance.cpp
+++ b/MMCore/Devices/StageInstance.cpp
@@ -22,17 +22,17 @@
 #include "StageInstance.h"
 
 
-int StageInstance::SetPositionUm(double pos) { return GetImpl()->SetPositionUm(pos); }
-int StageInstance::SetRelativePositionUm(double d) { return GetImpl()->SetRelativePositionUm(d); }
-int StageInstance::Move(double velocity) { return GetImpl()->Move(velocity); }
-int StageInstance::Stop() { return GetImpl()->Stop(); }
-int StageInstance::Home() { return GetImpl()->Home(); }
-int StageInstance::SetAdapterOriginUm(double d) { return GetImpl()->SetAdapterOriginUm(d); }
-int StageInstance::GetPositionUm(double& pos) { return GetImpl()->GetPositionUm(pos); }
-int StageInstance::SetPositionSteps(long steps) { return GetImpl()->SetPositionSteps(steps); }
-int StageInstance::GetPositionSteps(long& steps) { return GetImpl()->GetPositionSteps(steps); }
-int StageInstance::SetOrigin() { return GetImpl()->SetOrigin(); }
-int StageInstance::GetLimits(double& lower, double& upper) { return GetImpl()->GetLimits(lower, upper); }
+int StageInstance::SetPositionUm(double pos) { RequireInitialized(); return GetImpl()->SetPositionUm(pos); }
+int StageInstance::SetRelativePositionUm(double d) { RequireInitialized(); return GetImpl()->SetRelativePositionUm(d); }
+int StageInstance::Move(double velocity) { RequireInitialized(); return GetImpl()->Move(velocity); }
+int StageInstance::Stop() { RequireInitialized(); return GetImpl()->Stop(); }
+int StageInstance::Home() { RequireInitialized(); return GetImpl()->Home(); }
+int StageInstance::SetAdapterOriginUm(double d) { RequireInitialized(); return GetImpl()->SetAdapterOriginUm(d); }
+int StageInstance::GetPositionUm(double& pos) { RequireInitialized(); return GetImpl()->GetPositionUm(pos); }
+int StageInstance::SetPositionSteps(long steps) { RequireInitialized(); return GetImpl()->SetPositionSteps(steps); }
+int StageInstance::GetPositionSteps(long& steps) { RequireInitialized(); return GetImpl()->GetPositionSteps(steps); }
+int StageInstance::SetOrigin() { RequireInitialized(); return GetImpl()->SetOrigin(); }
+int StageInstance::GetLimits(double& lower, double& upper) { RequireInitialized(); return GetImpl()->GetLimits(lower, upper); }
 
 MM::FocusDirection
 StageInstance::GetFocusDirection()
@@ -57,14 +57,14 @@ StageInstance::SetFocusDirection(MM::FocusDirection direction)
    focusDirectionHasBeenSet_ = true;
 }
 
-int StageInstance::IsStageSequenceable(bool& isSequenceable) const { return GetImpl()->IsStageSequenceable(isSequenceable); }
-int StageInstance::IsStageLinearSequenceable(bool& isSequenceable) const { return GetImpl()->IsStageLinearSequenceable(isSequenceable); }
-bool StageInstance::IsContinuousFocusDrive() const { return GetImpl()->IsContinuousFocusDrive(); }
-int StageInstance::GetStageSequenceMaxLength(long& nrEvents) const { return GetImpl()->GetStageSequenceMaxLength(nrEvents); }
-int StageInstance::StartStageSequence() { return GetImpl()->StartStageSequence(); }
-int StageInstance::StopStageSequence() { return GetImpl()->StopStageSequence(); }
-int StageInstance::ClearStageSequence() { return GetImpl()->ClearStageSequence(); }
-int StageInstance::AddToStageSequence(double position) { return GetImpl()->AddToStageSequence(position); }
-int StageInstance::SendStageSequence() { return GetImpl()->SendStageSequence(); }
+int StageInstance::IsStageSequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsStageSequenceable(isSequenceable); }
+int StageInstance::IsStageLinearSequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsStageLinearSequenceable(isSequenceable); }
+bool StageInstance::IsContinuousFocusDrive() const { RequireInitialized(); return GetImpl()->IsContinuousFocusDrive(); }
+int StageInstance::GetStageSequenceMaxLength(long& nrEvents) const { RequireInitialized(); return GetImpl()->GetStageSequenceMaxLength(nrEvents); }
+int StageInstance::StartStageSequence() { RequireInitialized(); return GetImpl()->StartStageSequence(); }
+int StageInstance::StopStageSequence() { RequireInitialized(); return GetImpl()->StopStageSequence(); }
+int StageInstance::ClearStageSequence() { RequireInitialized(); return GetImpl()->ClearStageSequence(); }
+int StageInstance::AddToStageSequence(double position) { RequireInitialized(); return GetImpl()->AddToStageSequence(position); }
+int StageInstance::SendStageSequence() { RequireInitialized(); return GetImpl()->SendStageSequence(); }
 int StageInstance::SetStageLinearSequence(double dZ_um, long nSlices)
-{ return GetImpl()->SetStageLinearSequence(dZ_um, nSlices); }
+{ RequireInitialized(); return GetImpl()->SetStageLinearSequence(dZ_um, nSlices); }

--- a/MMCore/Devices/StateInstance.cpp
+++ b/MMCore/Devices/StateInstance.cpp
@@ -22,12 +22,13 @@
 #include "StateInstance.h"
 
 
-int StateInstance::SetPosition(long pos) { return GetImpl()->SetPosition(pos); }
-int StateInstance::SetPosition(const char* label) { return GetImpl()->SetPosition(label); }
-int StateInstance::GetPosition(long& pos) const { return GetImpl()->GetPosition(pos); }
+int StateInstance::SetPosition(long pos) { RequireInitialized(); return GetImpl()->SetPosition(pos); }
+int StateInstance::SetPosition(const char* label) { RequireInitialized(); return GetImpl()->SetPosition(label); }
+int StateInstance::GetPosition(long& pos) const { RequireInitialized(); return GetImpl()->GetPosition(pos); }
 
 std::string StateInstance::GetPositionLabel() const
 {
+   RequireInitialized();
    DeviceStringBuffer labelBuf(this, "GetPosition");
    int err = GetImpl()->GetPosition(labelBuf.GetBuffer());
    ThrowIfError(err, "Cannot get current position label");
@@ -36,14 +37,15 @@ std::string StateInstance::GetPositionLabel() const
 
 std::string StateInstance::GetPositionLabel(long pos) const
 {
+   RequireInitialized();
    DeviceStringBuffer labelBuf(this, "GetPositionLabel");
    int err = GetImpl()->GetPositionLabel(pos, labelBuf.GetBuffer());
    ThrowIfError(err, "Cannot get position label at index " + ToString(pos));
    return labelBuf.Get();
 }
 
-int StateInstance::GetLabelPosition(const char* label, long& pos) const { return GetImpl()->GetLabelPosition(label, pos); }
-int StateInstance::SetPositionLabel(long pos, const char* label) { return GetImpl()->SetPositionLabel(pos, label); }
-unsigned long StateInstance::GetNumberOfPositions() const { return GetImpl()->GetNumberOfPositions(); }
-int StateInstance::SetGateOpen(bool open) { return GetImpl()->SetGateOpen(open); }
-int StateInstance::GetGateOpen(bool& open) { return GetImpl()->GetGateOpen(open); }
+int StateInstance::GetLabelPosition(const char* label, long& pos) const { RequireInitialized(); return GetImpl()->GetLabelPosition(label, pos); }
+int StateInstance::SetPositionLabel(long pos, const char* label) { RequireInitialized(); return GetImpl()->SetPositionLabel(pos, label); }
+unsigned long StateInstance::GetNumberOfPositions() const { RequireInitialized(); return GetImpl()->GetNumberOfPositions(); }
+int StateInstance::SetGateOpen(bool open) { RequireInitialized(); return GetImpl()->SetGateOpen(open); }
+int StateInstance::GetGateOpen(bool& open) { RequireInitialized(); return GetImpl()->GetGateOpen(open); }

--- a/MMCore/Devices/XYStageInstance.cpp
+++ b/MMCore/Devices/XYStageInstance.cpp
@@ -22,27 +22,27 @@
 #include "XYStageInstance.h"
 
 
-int XYStageInstance::SetPositionUm(double x, double y) { return GetImpl()->SetPositionUm(x, y); }
-int XYStageInstance::SetRelativePositionUm(double dx, double dy) { return GetImpl()->SetRelativePositionUm(dx, dy); }
-int XYStageInstance::SetAdapterOriginUm(double x, double y) { return GetImpl()->SetAdapterOriginUm(x, y); }
-int XYStageInstance::GetPositionUm(double& x, double& y) { return GetImpl()->GetPositionUm(x, y); }
-int XYStageInstance::GetLimitsUm(double& xMin, double& xMax, double& yMin, double& yMax) { return GetImpl()->GetLimitsUm(xMin, xMax, yMin, yMax); }
-int XYStageInstance::Move(double vx, double vy) { return GetImpl()->Move(vx, vy); }
-int XYStageInstance::SetPositionSteps(long x, long y) { return GetImpl()->SetPositionSteps(x, y); }
-int XYStageInstance::GetPositionSteps(long& x, long& y) { return GetImpl()->GetPositionSteps(x, y); }
-int XYStageInstance::SetRelativePositionSteps(long x, long y) { return GetImpl()->SetRelativePositionSteps(x, y); }
-int XYStageInstance::Home() { return GetImpl()->Home(); }
-int XYStageInstance::Stop() { return GetImpl()->Stop(); }
-int XYStageInstance::SetOrigin() { return GetImpl()->SetOrigin(); }
-int XYStageInstance::SetXOrigin() { return GetImpl()->SetXOrigin(); }
-int XYStageInstance::SetYOrigin() { return GetImpl()->SetYOrigin(); }
-int XYStageInstance::GetStepLimits(long& xMin, long& xMax, long& yMin, long& yMax) { return GetImpl()->GetStepLimits(xMin, xMax, yMin, yMax); }
-double XYStageInstance::GetStepSizeXUm() { return GetImpl()->GetStepSizeXUm(); }
-double XYStageInstance::GetStepSizeYUm() { return GetImpl()->GetStepSizeYUm(); }
-int XYStageInstance::IsXYStageSequenceable(bool& isSequenceable) const { return GetImpl()->IsXYStageSequenceable(isSequenceable); }
-int XYStageInstance::GetXYStageSequenceMaxLength(long& nrEvents) const { return GetImpl()->GetXYStageSequenceMaxLength(nrEvents); }
-int XYStageInstance::StartXYStageSequence() { return GetImpl()->StartXYStageSequence(); }
-int XYStageInstance::StopXYStageSequence() { return GetImpl()->StopXYStageSequence(); }
-int XYStageInstance::ClearXYStageSequence() { return GetImpl()->ClearXYStageSequence(); }
-int XYStageInstance::AddToXYStageSequence(double positionX, double positionY) { return GetImpl()->AddToXYStageSequence(positionX, positionY); }
-int XYStageInstance::SendXYStageSequence() { return GetImpl()->SendXYStageSequence(); }
+int XYStageInstance::SetPositionUm(double x, double y) { RequireInitialized(); return GetImpl()->SetPositionUm(x, y); }
+int XYStageInstance::SetRelativePositionUm(double dx, double dy) { RequireInitialized(); return GetImpl()->SetRelativePositionUm(dx, dy); }
+int XYStageInstance::SetAdapterOriginUm(double x, double y) { RequireInitialized(); return GetImpl()->SetAdapterOriginUm(x, y); }
+int XYStageInstance::GetPositionUm(double& x, double& y) { RequireInitialized(); return GetImpl()->GetPositionUm(x, y); }
+int XYStageInstance::GetLimitsUm(double& xMin, double& xMax, double& yMin, double& yMax) { RequireInitialized(); return GetImpl()->GetLimitsUm(xMin, xMax, yMin, yMax); }
+int XYStageInstance::Move(double vx, double vy) { RequireInitialized(); return GetImpl()->Move(vx, vy); }
+int XYStageInstance::SetPositionSteps(long x, long y) { RequireInitialized(); return GetImpl()->SetPositionSteps(x, y); }
+int XYStageInstance::GetPositionSteps(long& x, long& y) { RequireInitialized(); return GetImpl()->GetPositionSteps(x, y); }
+int XYStageInstance::SetRelativePositionSteps(long x, long y) { RequireInitialized(); return GetImpl()->SetRelativePositionSteps(x, y); }
+int XYStageInstance::Home() { RequireInitialized(); return GetImpl()->Home(); }
+int XYStageInstance::Stop() { RequireInitialized(); return GetImpl()->Stop(); }
+int XYStageInstance::SetOrigin() { RequireInitialized(); return GetImpl()->SetOrigin(); }
+int XYStageInstance::SetXOrigin() { RequireInitialized(); return GetImpl()->SetXOrigin(); }
+int XYStageInstance::SetYOrigin() { RequireInitialized(); return GetImpl()->SetYOrigin(); }
+int XYStageInstance::GetStepLimits(long& xMin, long& xMax, long& yMin, long& yMax) { RequireInitialized(); return GetImpl()->GetStepLimits(xMin, xMax, yMin, yMax); }
+double XYStageInstance::GetStepSizeXUm() { RequireInitialized(); return GetImpl()->GetStepSizeXUm(); }
+double XYStageInstance::GetStepSizeYUm() { RequireInitialized(); return GetImpl()->GetStepSizeYUm(); }
+int XYStageInstance::IsXYStageSequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsXYStageSequenceable(isSequenceable); }
+int XYStageInstance::GetXYStageSequenceMaxLength(long& nrEvents) const { RequireInitialized(); return GetImpl()->GetXYStageSequenceMaxLength(nrEvents); }
+int XYStageInstance::StartXYStageSequence() { RequireInitialized(); return GetImpl()->StartXYStageSequence(); }
+int XYStageInstance::StopXYStageSequence() { RequireInitialized(); return GetImpl()->StopXYStageSequence(); }
+int XYStageInstance::ClearXYStageSequence() { RequireInitialized(); return GetImpl()->ClearXYStageSequence(); }
+int XYStageInstance::AddToXYStageSequence(double positionX, double positionY) { RequireInitialized(); return GetImpl()->AddToXYStageSequence(positionX, positionY); }
+int XYStageInstance::SendXYStageSequence() { RequireInitialized(); return GetImpl()->SendXYStageSequence(); }

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -113,7 +113,7 @@ using namespace std;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 10, MMCore_versionMinor = 4, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 10, MMCore_versionMinor = 5, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2740,13 +2740,17 @@ long CMMCore::getImageBufferSize()
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera) {
-      mm::DeviceModuleLockGuard guard(camera);
-      return camera->GetImageBufferSize();
+      try
+      {
+         mm::DeviceModuleLockGuard guard(camera);
+         return camera->GetImageBufferSize();
+      }
+      catch (const CMMError&) // Possibly uninitialized camera
+      {
+         // Fall through
+      }
    }
-   else
-   {
-      return 0;
-   }
+   return 0;
 }
 
 /**
@@ -2978,13 +2982,17 @@ bool CMMCore::isSequenceRunning() throw ()
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
    {
-      mm::DeviceModuleLockGuard guard(camera);
-	    return camera->IsCapturing();
+      try
+      {
+         mm::DeviceModuleLockGuard guard(camera);
+         return camera->IsCapturing();
+      }
+      catch (const CMMError&) // Possibly uninitialized camera
+      {
+         // Fall through
+      }
    }
-   else
-   {
-       return false;
-   }
+   return false;
 };
 
 /**
@@ -4084,13 +4092,19 @@ MM::PropertyType CMMCore::getPropertyType(const char* label, const char* propNam
 unsigned CMMCore::getImageWidth()
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
-   if (!camera)
+   if (camera)
    {
-      return 0;
+      try
+      {
+         mm::DeviceModuleLockGuard guard(camera);
+         return camera->GetImageWidth();
+      }
+      catch (const CMMError&) // Possibly uninitialized camera
+      {
+		 // Fall through
+      }
    }
-
-   mm::DeviceModuleLockGuard guard(camera);
-   return camera->GetImageWidth();
+   return 0;
 }
 
 /**
@@ -4100,13 +4114,19 @@ unsigned CMMCore::getImageWidth()
 unsigned CMMCore::getImageHeight()
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
-   if (!camera)
+   if (camera)
    {
-      return 0;
+      try
+      {
+         mm::DeviceModuleLockGuard guard(camera);
+         return camera->GetImageHeight();
+      }
+      catch (const CMMError&) // Possibly uninitialized camera
+      {
+         // Fall through
+      }
    }
-
-   mm::DeviceModuleLockGuard guard(camera);
-   return camera->GetImageHeight();
+   return 0;
 }
 
 /**
@@ -4117,13 +4137,19 @@ unsigned CMMCore::getImageHeight()
 unsigned CMMCore::getBytesPerPixel()
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
-   if (!camera)
+   if (camera)
    {
-      return 0;
+      try
+      {
+         mm::DeviceModuleLockGuard guard(camera);
+         return camera->GetImageBytesPerPixel();
+      }
+      catch (const CMMError&) // Possibly uninitialized camera
+      {
+         // Fall through
+      }
    }
-
-   mm::DeviceModuleLockGuard guard(camera);
-   return camera->GetImageBytesPerPixel();
+   return 0;
 }
 
 /**
@@ -4136,13 +4162,19 @@ unsigned CMMCore::getBytesPerPixel()
 unsigned CMMCore::getImageBitDepth()
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
-   if (!camera)
+   if (camera)
    {
-      return 0;
+      try
+      {
+         mm::DeviceModuleLockGuard guard(camera);
+         return camera->GetBitDepth();
+      }
+      catch (const CMMError&) // Possibly uninitialized camera
+      {
+         // Fall through
+      }
    }
-
-   mm::DeviceModuleLockGuard guard(camera);
-   return camera->GetBitDepth();
+   return 0;
 }
 
 /**
@@ -4152,12 +4184,19 @@ unsigned CMMCore::getImageBitDepth()
 unsigned CMMCore::getNumberOfComponents()
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
-   if (!camera)
+   if (camera)
    {
-      return 0;
+      try
+      {
+         mm::DeviceModuleLockGuard guard(camera);
+         return camera->GetNumberOfComponents();
+      }
+      catch (const CMMError&) // Possibly uninitialized camera
+      {
+         // Fall through
+      }
    }
-   mm::DeviceModuleLockGuard guard(camera);
-   return camera->GetNumberOfComponents();
+   return 0;
 }
 
 /**
@@ -4166,13 +4205,19 @@ unsigned CMMCore::getNumberOfComponents()
 unsigned CMMCore::getNumberOfCameraChannels()
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
-   if (!camera)
+   if (camera)
    {
-      return 0;
+      try
+      {
+         mm::DeviceModuleLockGuard guard(camera);
+         return camera->GetNumberOfChannels();
+      }
+      catch (const CMMError&) // Possibly uninitialized camera
+      {
+         // Fall through
+      }
    }
-
-   mm::DeviceModuleLockGuard guard(camera);
-   return camera->GetNumberOfChannels();
+   return 0;
 }
 
 /**
@@ -4181,13 +4226,19 @@ unsigned CMMCore::getNumberOfCameraChannels()
 string CMMCore::getCameraChannelName(unsigned int channelNr)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
-   if (!camera)
+   if (camera)
    {
-      return std::string();
+      try
+      {
+         mm::DeviceModuleLockGuard guard(camera);
+         return camera->GetChannelName(channelNr);
+      }
+      catch (const CMMError&) // Possibly uninitialized camera
+      {
+         // Fall through
+      }
    }
-
-   mm::DeviceModuleLockGuard guard(camera);
-   return camera->GetChannelName(channelNr);
+   return std::string();
 }
 
 /**
@@ -5479,8 +5530,15 @@ double CMMCore::getPixelSizeUm(bool cached)
       std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
       if (camera)
       {
-         mm::DeviceModuleLockGuard guard(camera);
-         pixSize *= camera->GetBinning();
+         try
+         {
+            mm::DeviceModuleLockGuard guard(camera);
+            pixSize *= camera->GetBinning();
+         }
+         catch (const CMMError&) // Possibly uninitialized camera
+         {
+            // Assume no binning
+         }
       }
 
       pixSize /= getMagnificationFactor();
@@ -5605,17 +5663,18 @@ double CMMCore::getMagnificationFactor() const
    vector<string> magnifiers = getLoadedDevicesOfType(MM::MagnifierDevice);
    for (size_t i=0; i<magnifiers.size(); i++)
    {
+      std::shared_ptr<MagnifierInstance> magnifier =
+         deviceManager_->GetDeviceOfType<MagnifierInstance>(magnifiers[i]);
+
       try
       {
-         std::shared_ptr<MagnifierInstance> magnifier =
-            deviceManager_->GetDeviceOfType<MagnifierInstance>(magnifiers[i]);
-
          mm::DeviceModuleLockGuard guard(magnifier);
          magnification *= magnifier->GetMagnification();
       }
       catch (const CMMError&)
       {
-         assert(!"Internal error in generating a list of specific devices");
+         // Most likely the magnifier was not initialized.
+         // Ignore it: only initialized magnifiers count.
       }
    }
    return magnification;
@@ -7026,15 +7085,20 @@ double CMMCore::getLastFocusScore()
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
-      mm::DeviceModuleLockGuard guard(autofocus);
-      double score;
-      int ret = autofocus->GetLastFocusScore(score);
-      if (ret != DEVICE_OK)
-         return 0.0;
-      return score;
+      try
+      {
+         mm::DeviceModuleLockGuard guard(autofocus);
+         double score;
+         int ret = autofocus->GetLastFocusScore(score);
+         if (ret == DEVICE_OK)
+            return score;
+      }
+      catch (const CMMError&) // Probably uninitialized device
+      {
+         // Fall through
+      }
    }
-   else
-      return 0.0;
+   return 0.0;
 }
 
 /**
@@ -7049,15 +7113,20 @@ double CMMCore::getCurrentFocusScore()
       currentAutofocusDevice_.lock();
    if (autofocus)
    {
-      mm::DeviceModuleLockGuard guard(autofocus);
-      double score;
-      int ret = autofocus->GetCurrentFocusScore(score);
-      if (ret != DEVICE_OK)
-         return 0.0;
-      return score;
+      try
+      {
+         mm::DeviceModuleLockGuard guard(autofocus);
+         double score;
+         int ret = autofocus->GetCurrentFocusScore(score);
+         if (ret == DEVICE_OK)
+            return score;
+      }
+      catch (const CMMError&) // Probably uninitialized device
+      {
+         // Fall through
+      }
    }
-   else
-      return 0.0;
+   return 0.0;
 }
 
 

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -3,7 +3,7 @@
    <groupId>org.micro-manager.mmcorej</groupId>
    <artifactId>MMCoreJ</artifactId>
    <packaging>jar</packaging>
-   <version>10.4.0</version>
+   <version>10.5.0</version>
    <name>Micro-Manager Java Interface to MMCore</name>
    <description>Micro-Manager is open source software for control of automated/motorized microscopes.  This specific packages provides the Java interface to the device abstractino layer (MMCore) that is written in C++ with a C-interface</description>
    <url>http://micro-manager.org</url>


### PR DESCRIPTION
- Most non-property operations require an initialized device
- Pre-init properties must not be set after initialization
- Device initialiation may only be attempted once per device instance

These rules have been unstated previously, but had to be observed. Now make it an error (throw a `CMMError`).

All `CMMCore` member functions that do _not_ throw `CMMError` were reviewed to make sure newly-thrown exceptions are not left uncaught in SWIG wrappers.

MMCore version bumped 10.4.0 -> 10.5.0.

Closes #366.

Cc: @tlambert03