### PR TITLE
MMCore: Revert strict initialization checks

### DIFF
--- a/MMCore/Devices/AutoFocusInstance.cpp
+++ b/MMCore/Devices/AutoFocusInstance.cpp
@@ -22,13 +22,13 @@
 #include "AutoFocusInstance.h"
 
 
-int AutoFocusInstance::SetContinuousFocusing(bool state) { RequireInitialized(); return GetImpl()->SetContinuousFocusing(state); }
-int AutoFocusInstance::GetContinuousFocusing(bool& state) { RequireInitialized(); return GetImpl()->GetContinuousFocusing(state); }
-bool AutoFocusInstance::IsContinuousFocusLocked() { RequireInitialized(); return GetImpl()->IsContinuousFocusLocked(); }
-int AutoFocusInstance::FullFocus() { RequireInitialized(); return GetImpl()->FullFocus(); }
-int AutoFocusInstance::IncrementalFocus() { RequireInitialized(); return GetImpl()->IncrementalFocus(); }
-int AutoFocusInstance::GetLastFocusScore(double& score) { RequireInitialized(); return GetImpl()->GetLastFocusScore(score); }
-int AutoFocusInstance::GetCurrentFocusScore(double& score) { RequireInitialized(); return GetImpl()->GetCurrentFocusScore(score); }
-int AutoFocusInstance::AutoSetParameters() { RequireInitialized(); return GetImpl()->AutoSetParameters(); }
-int AutoFocusInstance::GetOffset(double &offset) { RequireInitialized(); return GetImpl()->GetOffset(offset); }
-int AutoFocusInstance::SetOffset(double offset) { RequireInitialized(); return GetImpl()->SetOffset(offset); }
+int AutoFocusInstance::SetContinuousFocusing(bool state) { RequireInitialized(__func__); return GetImpl()->SetContinuousFocusing(state); }
+int AutoFocusInstance::GetContinuousFocusing(bool& state) { RequireInitialized(__func__); return GetImpl()->GetContinuousFocusing(state); }
+bool AutoFocusInstance::IsContinuousFocusLocked() { RequireInitialized(__func__); return GetImpl()->IsContinuousFocusLocked(); }
+int AutoFocusInstance::FullFocus() { RequireInitialized(__func__); return GetImpl()->FullFocus(); }
+int AutoFocusInstance::IncrementalFocus() { RequireInitialized(__func__); return GetImpl()->IncrementalFocus(); }
+int AutoFocusInstance::GetLastFocusScore(double& score) { RequireInitialized(__func__); return GetImpl()->GetLastFocusScore(score); }
+int AutoFocusInstance::GetCurrentFocusScore(double& score) { RequireInitialized(__func__); return GetImpl()->GetCurrentFocusScore(score); }
+int AutoFocusInstance::AutoSetParameters() { RequireInitialized(__func__); return GetImpl()->AutoSetParameters(); }
+int AutoFocusInstance::GetOffset(double &offset) { RequireInitialized(__func__); return GetImpl()->GetOffset(offset); }
+int AutoFocusInstance::SetOffset(double offset) { RequireInitialized(__func__); return GetImpl()->SetOffset(offset); }

--- a/MMCore/Devices/CameraInstance.cpp
+++ b/MMCore/Devices/CameraInstance.cpp
@@ -22,15 +22,15 @@
 #include "CameraInstance.h"
 
 
-int CameraInstance::SnapImage() { RequireInitialized(); return GetImpl()->SnapImage(); }
-const unsigned char* CameraInstance::GetImageBuffer() { RequireInitialized(); return GetImpl()->GetImageBuffer(); }
-const unsigned char* CameraInstance::GetImageBuffer(unsigned channelNr) { RequireInitialized(); return GetImpl()->GetImageBuffer(channelNr); }
-const unsigned int* CameraInstance::GetImageBufferAsRGB32() { RequireInitialized(); return GetImpl()->GetImageBufferAsRGB32(); }
-unsigned CameraInstance::GetNumberOfComponents() const { RequireInitialized(); return GetImpl()->GetNumberOfComponents(); }
+int CameraInstance::SnapImage() { RequireInitialized(__func__); return GetImpl()->SnapImage(); }
+const unsigned char* CameraInstance::GetImageBuffer() { RequireInitialized(__func__); return GetImpl()->GetImageBuffer(); }
+const unsigned char* CameraInstance::GetImageBuffer(unsigned channelNr) { RequireInitialized(__func__); return GetImpl()->GetImageBuffer(channelNr); }
+const unsigned int* CameraInstance::GetImageBufferAsRGB32() { RequireInitialized(__func__); return GetImpl()->GetImageBufferAsRGB32(); }
+unsigned CameraInstance::GetNumberOfComponents() const { RequireInitialized(__func__); return GetImpl()->GetNumberOfComponents(); }
 
 std::string CameraInstance::GetComponentName(unsigned component)
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    DeviceStringBuffer nameBuf(this, "GetComponentName");
    int err = GetImpl()->GetComponentName(component, nameBuf.GetBuffer());
    ThrowIfError(err, "Cannot get component name at index " +
@@ -38,37 +38,37 @@ std::string CameraInstance::GetComponentName(unsigned component)
    return nameBuf.Get();
 }
 
-int unsigned CameraInstance::GetNumberOfChannels() const { RequireInitialized(); return GetImpl()->GetNumberOfChannels(); }
+int unsigned CameraInstance::GetNumberOfChannels() const { RequireInitialized(__func__); return GetImpl()->GetNumberOfChannels(); }
 
 std::string CameraInstance::GetChannelName(unsigned channel)
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    DeviceStringBuffer nameBuf(this, "GetChannelName");
    int err = GetImpl()->GetChannelName(channel, nameBuf.GetBuffer());
    ThrowIfError(err, "Cannot get channel name at index " + ToString(channel));
    return nameBuf.Get();
 }
 
-long CameraInstance::GetImageBufferSize() const { RequireInitialized(); return GetImpl()->GetImageBufferSize(); }
-unsigned CameraInstance::GetImageWidth() const { RequireInitialized(); return GetImpl()->GetImageWidth(); }
-unsigned CameraInstance::GetImageHeight() const { RequireInitialized(); return GetImpl()->GetImageHeight(); }
-unsigned CameraInstance::GetImageBytesPerPixel() const { RequireInitialized(); return GetImpl()->GetImageBytesPerPixel(); }
-unsigned CameraInstance::GetBitDepth() const { RequireInitialized(); return GetImpl()->GetBitDepth(); }
-double CameraInstance::GetPixelSizeUm() const { RequireInitialized(); return GetImpl()->GetPixelSizeUm(); }
-int CameraInstance::GetBinning() const { RequireInitialized(); return GetImpl()->GetBinning(); }
-int CameraInstance::SetBinning(int binSize) { RequireInitialized(); return GetImpl()->SetBinning(binSize); }
-void CameraInstance::SetExposure(double exp_ms) { RequireInitialized(); return GetImpl()->SetExposure(exp_ms); }
-double CameraInstance::GetExposure() const { RequireInitialized(); return GetImpl()->GetExposure(); }
-int CameraInstance::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize) { RequireInitialized(); return GetImpl()->SetROI(x, y, xSize, ySize); }
-int CameraInstance::GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize) { RequireInitialized(); return GetImpl()->GetROI(x, y, xSize, ySize); }
-int CameraInstance::ClearROI() { RequireInitialized(); return GetImpl()->ClearROI(); }
+long CameraInstance::GetImageBufferSize() const { RequireInitialized(__func__); return GetImpl()->GetImageBufferSize(); }
+unsigned CameraInstance::GetImageWidth() const { RequireInitialized(__func__); return GetImpl()->GetImageWidth(); }
+unsigned CameraInstance::GetImageHeight() const { RequireInitialized(__func__); return GetImpl()->GetImageHeight(); }
+unsigned CameraInstance::GetImageBytesPerPixel() const { RequireInitialized(__func__); return GetImpl()->GetImageBytesPerPixel(); }
+unsigned CameraInstance::GetBitDepth() const { RequireInitialized(__func__); return GetImpl()->GetBitDepth(); }
+double CameraInstance::GetPixelSizeUm() const { RequireInitialized(__func__); return GetImpl()->GetPixelSizeUm(); }
+int CameraInstance::GetBinning() const { RequireInitialized(__func__); return GetImpl()->GetBinning(); }
+int CameraInstance::SetBinning(int binSize) { RequireInitialized(__func__); return GetImpl()->SetBinning(binSize); }
+void CameraInstance::SetExposure(double exp_ms) { RequireInitialized(__func__); return GetImpl()->SetExposure(exp_ms); }
+double CameraInstance::GetExposure() const { RequireInitialized(__func__); return GetImpl()->GetExposure(); }
+int CameraInstance::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize) { RequireInitialized(__func__); return GetImpl()->SetROI(x, y, xSize, ySize); }
+int CameraInstance::GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize) { RequireInitialized(__func__); return GetImpl()->GetROI(x, y, xSize, ySize); }
+int CameraInstance::ClearROI() { RequireInitialized(__func__); return GetImpl()->ClearROI(); }
 
 /**
  * Queries if the camera supports multiple simultaneous ROIs.
  */
 bool CameraInstance::SupportsMultiROI()
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    return GetImpl()->SupportsMultiROI();
 }
 
@@ -79,7 +79,7 @@ bool CameraInstance::SupportsMultiROI()
  */
 bool CameraInstance::IsMultiROISet()
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    return GetImpl()->IsMultiROISet();
 }
 
@@ -89,7 +89,7 @@ bool CameraInstance::IsMultiROISet()
  */
 int CameraInstance::GetMultiROICount(unsigned int& count)
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    return GetImpl()->GetMultiROICount(count);
 }
 
@@ -106,7 +106,7 @@ int CameraInstance::SetMultiROI(const unsigned int* xs, const unsigned int* ys,
       const unsigned* widths, const unsigned int* heights,
       unsigned numROIs)
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    return GetImpl()->SetMultiROI(xs, ys, widths, heights, numROIs);
 }
 
@@ -123,19 +123,19 @@ int CameraInstance::SetMultiROI(const unsigned int* xs, const unsigned int* ys,
 int CameraInstance::GetMultiROI(unsigned* xs, unsigned* ys, unsigned* widths,
       unsigned* heights, unsigned* length)
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    return GetImpl()->GetMultiROI(xs, ys, widths, heights, length);
 }
 
-int CameraInstance::StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow) { RequireInitialized(); return GetImpl()->StartSequenceAcquisition(numImages, interval_ms, stopOnOverflow); }
-int CameraInstance::StartSequenceAcquisition(double interval_ms) { RequireInitialized(); return GetImpl()->StartSequenceAcquisition(interval_ms); }
-int CameraInstance::StopSequenceAcquisition() { RequireInitialized(); return GetImpl()->StopSequenceAcquisition(); }
-int CameraInstance::PrepareSequenceAcqusition() { RequireInitialized(); return GetImpl()->PrepareSequenceAcqusition(); }
-bool CameraInstance::IsCapturing() { RequireInitialized(); return GetImpl()->IsCapturing(); }
+int CameraInstance::StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow) { RequireInitialized(__func__); return GetImpl()->StartSequenceAcquisition(numImages, interval_ms, stopOnOverflow); }
+int CameraInstance::StartSequenceAcquisition(double interval_ms) { RequireInitialized(__func__); return GetImpl()->StartSequenceAcquisition(interval_ms); }
+int CameraInstance::StopSequenceAcquisition() { RequireInitialized(__func__); return GetImpl()->StopSequenceAcquisition(); }
+int CameraInstance::PrepareSequenceAcqusition() { RequireInitialized(__func__); return GetImpl()->PrepareSequenceAcqusition(); }
+bool CameraInstance::IsCapturing() { RequireInitialized(__func__); return GetImpl()->IsCapturing(); }
 
 std::string CameraInstance::GetTags()
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    // TODO Probably makes sense to deserialize here.
    // Also note the danger of limiting serialized metadata to MM::MaxStrLength
    // (CCameraBase takes no precaution to limit string length; it is an
@@ -145,12 +145,12 @@ std::string CameraInstance::GetTags()
    return serializedMetadataBuf.Get();
 }
 
-void CameraInstance::AddTag(const char* key, const char* deviceLabel, const char* value) { RequireInitialized(); return GetImpl()->AddTag(key, deviceLabel, value); }
-void CameraInstance::RemoveTag(const char* key) { RequireInitialized(); return GetImpl()->RemoveTag(key); }
-int CameraInstance::IsExposureSequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsExposureSequenceable(isSequenceable); }
-int CameraInstance::GetExposureSequenceMaxLength(long& nrEvents) const { RequireInitialized(); return GetImpl()->GetExposureSequenceMaxLength(nrEvents); }
-int CameraInstance::StartExposureSequence() { RequireInitialized(); return GetImpl()->StartExposureSequence(); }
-int CameraInstance::StopExposureSequence() { RequireInitialized(); return GetImpl()->StopExposureSequence(); }
-int CameraInstance::ClearExposureSequence() { RequireInitialized(); return GetImpl()->ClearExposureSequence(); }
-int CameraInstance::AddToExposureSequence(double exposureTime_ms) { RequireInitialized(); return GetImpl()->AddToExposureSequence(exposureTime_ms); }
-int CameraInstance::SendExposureSequence() const { RequireInitialized(); return GetImpl()->SendExposureSequence(); }
+void CameraInstance::AddTag(const char* key, const char* deviceLabel, const char* value) { RequireInitialized(__func__); return GetImpl()->AddTag(key, deviceLabel, value); }
+void CameraInstance::RemoveTag(const char* key) { RequireInitialized(__func__); return GetImpl()->RemoveTag(key); }
+int CameraInstance::IsExposureSequenceable(bool& isSequenceable) const { RequireInitialized(__func__); return GetImpl()->IsExposureSequenceable(isSequenceable); }
+int CameraInstance::GetExposureSequenceMaxLength(long& nrEvents) const { RequireInitialized(__func__); return GetImpl()->GetExposureSequenceMaxLength(nrEvents); }
+int CameraInstance::StartExposureSequence() { RequireInitialized(__func__); return GetImpl()->StartExposureSequence(); }
+int CameraInstance::StopExposureSequence() { RequireInitialized(__func__); return GetImpl()->StopExposureSequence(); }
+int CameraInstance::ClearExposureSequence() { RequireInitialized(__func__); return GetImpl()->ClearExposureSequence(); }
+int CameraInstance::AddToExposureSequence(double exposureTime_ms) { RequireInitialized(__func__); return GetImpl()->AddToExposureSequence(exposureTime_ms); }
+int CameraInstance::SendExposureSequence() const { RequireInitialized(__func__); return GetImpl()->SendExposureSequence(); }

--- a/MMCore/Devices/DeviceInstance.cpp
+++ b/MMCore/Devices/DeviceInstance.cpp
@@ -122,10 +122,17 @@ DeviceInstance::ThrowIfError(int code, const std::string& message) const
 }
 
 void
-DeviceInstance::RequireInitialized() const
+DeviceInstance::RequireInitialized(const char *operation) const
 {
-   if (!initialized_)
-      ThrowError("Operation not permitted on uninitialized device");
+   if (!initialized_) {
+      // This is an error, but existing application code (in particular,
+      // the Hardware Configuration Wizard) breaks if we enforce it strictly.
+      // Until such code is fixed, we only log.
+      LOG_WARNING(Logger()) << "Operation (" << operation <<
+         ") not permitted on uninitialized device (this will be an error in a future version of MMCore; for now we continue with the operation anyway, even though it might not be safe)";
+      // Eventually to be replaced with:
+      // ThrowError("Operation not permitted on uninitialized device");
+   }
 }
 
 void
@@ -326,7 +333,7 @@ DeviceInstance::GetErrorText(int code) const
 bool
 DeviceInstance::Busy()
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    return pImpl_->Busy();
 }
 

--- a/MMCore/Devices/DeviceInstance.h
+++ b/MMCore/Devices/DeviceInstance.h
@@ -114,7 +114,7 @@ protected:
    void ThrowError(const std::string& message) const;
    void ThrowIfError(int code) const;
    void ThrowIfError(int code, const std::string& message) const;
-   void RequireInitialized() const;
+   void RequireInitialized(const char *) const;
 
    /// Utility class for getting fixed-length strings from the device interface.
    /**

--- a/MMCore/Devices/GalvoInstance.cpp
+++ b/MMCore/Devices/GalvoInstance.cpp
@@ -22,26 +22,26 @@
 #include "GalvoInstance.h"
 
 
-int GalvoInstance::PointAndFire(double x, double y, double time_us) { RequireInitialized(); return GetImpl()->PointAndFire(x, y, time_us); }
-int GalvoInstance::SetSpotInterval(double pulseInterval_us) { RequireInitialized(); return GetImpl()->SetSpotInterval(pulseInterval_us); }
-int GalvoInstance::SetPosition(double x, double y) { RequireInitialized(); return GetImpl()->SetPosition(x, y); }
-int GalvoInstance::GetPosition(double& x, double& y) { RequireInitialized(); return GetImpl()->GetPosition(x, y); }
-int GalvoInstance::SetIlluminationState(bool on) { RequireInitialized(); return GetImpl()->SetIlluminationState(on); }
-double GalvoInstance::GetXRange() { RequireInitialized(); return GetImpl()->GetXRange(); }
-double GalvoInstance::GetXMinimum() { RequireInitialized(); return GetImpl()->GetXMinimum(); }
-double GalvoInstance::GetYRange() { RequireInitialized(); return GetImpl()->GetYRange(); }
-double GalvoInstance::GetYMinimum() { RequireInitialized(); return GetImpl()->GetYMinimum(); }
-int GalvoInstance::AddPolygonVertex(int polygonIndex, double x, double y) { RequireInitialized(); return GetImpl()->AddPolygonVertex(polygonIndex, x, y); }
-int GalvoInstance::DeletePolygons() { RequireInitialized(); return GetImpl()->DeletePolygons(); }
-int GalvoInstance::RunSequence() { RequireInitialized(); return GetImpl()->RunSequence(); }
-int GalvoInstance::LoadPolygons() { RequireInitialized(); return GetImpl()->LoadPolygons(); }
-int GalvoInstance::SetPolygonRepetitions(int repetitions) { RequireInitialized(); return GetImpl()->SetPolygonRepetitions(repetitions); }
-int GalvoInstance::RunPolygons() { RequireInitialized(); return GetImpl()->RunPolygons(); }
-int GalvoInstance::StopSequence() { RequireInitialized(); return GetImpl()->StopSequence(); }
+int GalvoInstance::PointAndFire(double x, double y, double time_us) { RequireInitialized(__func__); return GetImpl()->PointAndFire(x, y, time_us); }
+int GalvoInstance::SetSpotInterval(double pulseInterval_us) { RequireInitialized(__func__); return GetImpl()->SetSpotInterval(pulseInterval_us); }
+int GalvoInstance::SetPosition(double x, double y) { RequireInitialized(__func__); return GetImpl()->SetPosition(x, y); }
+int GalvoInstance::GetPosition(double& x, double& y) { RequireInitialized(__func__); return GetImpl()->GetPosition(x, y); }
+int GalvoInstance::SetIlluminationState(bool on) { RequireInitialized(__func__); return GetImpl()->SetIlluminationState(on); }
+double GalvoInstance::GetXRange() { RequireInitialized(__func__); return GetImpl()->GetXRange(); }
+double GalvoInstance::GetXMinimum() { RequireInitialized(__func__); return GetImpl()->GetXMinimum(); }
+double GalvoInstance::GetYRange() { RequireInitialized(__func__); return GetImpl()->GetYRange(); }
+double GalvoInstance::GetYMinimum() { RequireInitialized(__func__); return GetImpl()->GetYMinimum(); }
+int GalvoInstance::AddPolygonVertex(int polygonIndex, double x, double y) { RequireInitialized(__func__); return GetImpl()->AddPolygonVertex(polygonIndex, x, y); }
+int GalvoInstance::DeletePolygons() { RequireInitialized(__func__); return GetImpl()->DeletePolygons(); }
+int GalvoInstance::RunSequence() { RequireInitialized(__func__); return GetImpl()->RunSequence(); }
+int GalvoInstance::LoadPolygons() { RequireInitialized(__func__); return GetImpl()->LoadPolygons(); }
+int GalvoInstance::SetPolygonRepetitions(int repetitions) { RequireInitialized(__func__); return GetImpl()->SetPolygonRepetitions(repetitions); }
+int GalvoInstance::RunPolygons() { RequireInitialized(__func__); return GetImpl()->RunPolygons(); }
+int GalvoInstance::StopSequence() { RequireInitialized(__func__); return GetImpl()->StopSequence(); }
 
 std::string GalvoInstance::GetChannel()
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    DeviceStringBuffer nameBuf(this, "GetChannel");
    int err = GetImpl()->GetChannel(nameBuf.GetBuffer());
    ThrowIfError(err, "Cannot get current channel name");

--- a/MMCore/Devices/HubInstance.cpp
+++ b/MMCore/Devices/HubInstance.cpp
@@ -33,7 +33,7 @@
 std::vector<std::string>
 HubInstance::GetInstalledPeripheralNames()
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
 
    std::vector<MM::Device*> peripherals = GetInstalledPeripherals();
 
@@ -61,7 +61,7 @@ HubInstance::GetInstalledPeripheralNames()
 std::string
 HubInstance::GetInstalledPeripheralDescription(const std::string& peripheralName)
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
 
    std::vector<MM::Device*> peripherals = GetInstalledPeripherals();
    for (std::vector<MM::Device*>::iterator it = peripherals.begin(), end = peripherals.end();

--- a/MMCore/Devices/ImageProcessorInstance.cpp
+++ b/MMCore/Devices/ImageProcessorInstance.cpp
@@ -22,4 +22,4 @@
 #include "ImageProcessorInstance.h"
 
 
-int ImageProcessorInstance::Process(unsigned char* buffer, unsigned width, unsigned height, unsigned byteDepth) { RequireInitialized(); return GetImpl()->Process(buffer, width, height, byteDepth); }
+int ImageProcessorInstance::Process(unsigned char* buffer, unsigned width, unsigned height, unsigned byteDepth) { RequireInitialized(__func__); return GetImpl()->Process(buffer, width, height, byteDepth); }

--- a/MMCore/Devices/MagnifierInstance.cpp
+++ b/MMCore/Devices/MagnifierInstance.cpp
@@ -22,4 +22,4 @@
 #include "MagnifierInstance.h"
 
 
-double MagnifierInstance::GetMagnification() { RequireInitialized(); return GetImpl()->GetMagnification(); }
+double MagnifierInstance::GetMagnification() { RequireInitialized(__func__); return GetImpl()->GetMagnification(); }

--- a/MMCore/Devices/SLMInstance.cpp
+++ b/MMCore/Devices/SLMInstance.cpp
@@ -22,26 +22,26 @@
 #include "SLMInstance.h"
 
 
-int SLMInstance::SetImage(unsigned char* pixels) { RequireInitialized(); return GetImpl()->SetImage(pixels); }
-int SLMInstance::SetImage(unsigned int* pixels) { RequireInitialized(); return GetImpl()->SetImage(pixels); }
-int SLMInstance::DisplayImage() { RequireInitialized(); return GetImpl()->DisplayImage(); }
-int SLMInstance::SetPixelsTo(unsigned char intensity) { RequireInitialized(); return GetImpl()->SetPixelsTo(intensity); }
-int SLMInstance::SetPixelsTo(unsigned char red, unsigned char green, unsigned char blue) { RequireInitialized(); return GetImpl()->SetPixelsTo(red, green, blue); }
-int SLMInstance::SetExposure(double interval_ms) { RequireInitialized(); return GetImpl()->SetExposure(interval_ms); }
-double SLMInstance::GetExposure() { RequireInitialized(); return GetImpl()->GetExposure(); }
-unsigned SLMInstance::GetWidth() { RequireInitialized(); return GetImpl()->GetWidth(); }
-unsigned SLMInstance::GetHeight() { RequireInitialized(); return GetImpl()->GetHeight(); }
-unsigned SLMInstance::GetNumberOfComponents() { RequireInitialized(); return GetImpl()->GetNumberOfComponents(); }
-unsigned SLMInstance::GetBytesPerPixel() { RequireInitialized(); return GetImpl()->GetBytesPerPixel(); }
+int SLMInstance::SetImage(unsigned char* pixels) { RequireInitialized(__func__); return GetImpl()->SetImage(pixels); }
+int SLMInstance::SetImage(unsigned int* pixels) { RequireInitialized(__func__); return GetImpl()->SetImage(pixels); }
+int SLMInstance::DisplayImage() { RequireInitialized(__func__); return GetImpl()->DisplayImage(); }
+int SLMInstance::SetPixelsTo(unsigned char intensity) { RequireInitialized(__func__); return GetImpl()->SetPixelsTo(intensity); }
+int SLMInstance::SetPixelsTo(unsigned char red, unsigned char green, unsigned char blue) { RequireInitialized(__func__); return GetImpl()->SetPixelsTo(red, green, blue); }
+int SLMInstance::SetExposure(double interval_ms) { RequireInitialized(__func__); return GetImpl()->SetExposure(interval_ms); }
+double SLMInstance::GetExposure() { RequireInitialized(__func__); return GetImpl()->GetExposure(); }
+unsigned SLMInstance::GetWidth() { RequireInitialized(__func__); return GetImpl()->GetWidth(); }
+unsigned SLMInstance::GetHeight() { RequireInitialized(__func__); return GetImpl()->GetHeight(); }
+unsigned SLMInstance::GetNumberOfComponents() { RequireInitialized(__func__); return GetImpl()->GetNumberOfComponents(); }
+unsigned SLMInstance::GetBytesPerPixel() { RequireInitialized(__func__); return GetImpl()->GetBytesPerPixel(); }
 int SLMInstance::IsSLMSequenceable(bool& isSequenceable)
-{ RequireInitialized(); return GetImpl()->IsSLMSequenceable(isSequenceable); }
+{ RequireInitialized(__func__); return GetImpl()->IsSLMSequenceable(isSequenceable); }
 int SLMInstance::GetSLMSequenceMaxLength(long& nrEvents)
-{ RequireInitialized(); return GetImpl()->GetSLMSequenceMaxLength(nrEvents); }
-int SLMInstance::StartSLMSequence() { RequireInitialized(); return GetImpl()->StartSLMSequence(); }
-int SLMInstance::StopSLMSequence() { RequireInitialized(); return GetImpl()->StopSLMSequence(); }
-int SLMInstance::ClearSLMSequence() { RequireInitialized(); return GetImpl()->ClearSLMSequence(); }
+{ RequireInitialized(__func__); return GetImpl()->GetSLMSequenceMaxLength(nrEvents); }
+int SLMInstance::StartSLMSequence() { RequireInitialized(__func__); return GetImpl()->StartSLMSequence(); }
+int SLMInstance::StopSLMSequence() { RequireInitialized(__func__); return GetImpl()->StopSLMSequence(); }
+int SLMInstance::ClearSLMSequence() { RequireInitialized(__func__); return GetImpl()->ClearSLMSequence(); }
 int SLMInstance::AddToSLMSequence(const unsigned char * pixels)
-{ RequireInitialized(); return GetImpl()->AddToSLMSequence(pixels); }
+{ RequireInitialized(__func__); return GetImpl()->AddToSLMSequence(pixels); }
 int SLMInstance::AddToSLMSequence(const unsigned int * pixels)
-{ RequireInitialized(); return GetImpl()->AddToSLMSequence(pixels); }
-int SLMInstance::SendSLMSequence() { RequireInitialized(); return GetImpl()->SendSLMSequence(); }
+{ RequireInitialized(__func__); return GetImpl()->AddToSLMSequence(pixels); }
+int SLMInstance::SendSLMSequence() { RequireInitialized(__func__); return GetImpl()->SendSLMSequence(); }

--- a/MMCore/Devices/SerialInstance.cpp
+++ b/MMCore/Devices/SerialInstance.cpp
@@ -22,9 +22,9 @@
 #include "SerialInstance.h"
 
 
-MM::PortType SerialInstance::GetPortType() const { RequireInitialized(); return GetImpl()->GetPortType(); }
-int SerialInstance::SetCommand(const char* command, const char* term) { RequireInitialized(); return GetImpl()->SetCommand(command, term); }
-int SerialInstance::GetAnswer(char* txt, unsigned maxChars, const char* term) { RequireInitialized(); return GetImpl()->GetAnswer(txt, maxChars, term); }
-int SerialInstance::Write(const unsigned char* buf, unsigned long bufLen) { RequireInitialized(); return GetImpl()->Write(buf, bufLen); }
-int SerialInstance::Read(unsigned char* buf, unsigned long bufLen, unsigned long& charsRead) { RequireInitialized(); return GetImpl()->Read(buf, bufLen, charsRead); }
-int SerialInstance::Purge() { RequireInitialized(); return GetImpl()->Purge(); }
+MM::PortType SerialInstance::GetPortType() const { RequireInitialized(__func__); return GetImpl()->GetPortType(); }
+int SerialInstance::SetCommand(const char* command, const char* term) { RequireInitialized(__func__); return GetImpl()->SetCommand(command, term); }
+int SerialInstance::GetAnswer(char* txt, unsigned maxChars, const char* term) { RequireInitialized(__func__); return GetImpl()->GetAnswer(txt, maxChars, term); }
+int SerialInstance::Write(const unsigned char* buf, unsigned long bufLen) { RequireInitialized(__func__); return GetImpl()->Write(buf, bufLen); }
+int SerialInstance::Read(unsigned char* buf, unsigned long bufLen, unsigned long& charsRead) { RequireInitialized(__func__); return GetImpl()->Read(buf, bufLen, charsRead); }
+int SerialInstance::Purge() { RequireInitialized(__func__); return GetImpl()->Purge(); }

--- a/MMCore/Devices/ShutterInstance.cpp
+++ b/MMCore/Devices/ShutterInstance.cpp
@@ -22,6 +22,6 @@
 #include "ShutterInstance.h"
 
 
-int ShutterInstance::SetOpen(bool open) { RequireInitialized(); return GetImpl()->SetOpen(open); }
-int ShutterInstance::GetOpen(bool& open) { RequireInitialized(); return GetImpl()->GetOpen(open); }
-int ShutterInstance::Fire(double deltaT) { RequireInitialized(); return GetImpl()->Fire(deltaT); }
+int ShutterInstance::SetOpen(bool open) { RequireInitialized(__func__); return GetImpl()->SetOpen(open); }
+int ShutterInstance::GetOpen(bool& open) { RequireInitialized(__func__); return GetImpl()->GetOpen(open); }
+int ShutterInstance::Fire(double deltaT) { RequireInitialized(__func__); return GetImpl()->Fire(deltaT); }

--- a/MMCore/Devices/SignalIOInstance.cpp
+++ b/MMCore/Devices/SignalIOInstance.cpp
@@ -22,15 +22,15 @@
 #include "SignalIOInstance.h"
 
 
-int SignalIOInstance::SetGateOpen(bool open) { RequireInitialized(); return GetImpl()->SetGateOpen(open); }
-int SignalIOInstance::GetGateOpen(bool& open) { RequireInitialized(); return GetImpl()->GetGateOpen(open); }
-int SignalIOInstance::SetSignal(double volts) { RequireInitialized(); return GetImpl()->SetSignal(volts); }
-int SignalIOInstance::GetSignal(double& volts) { RequireInitialized(); return GetImpl()->GetSignal(volts); }
-int SignalIOInstance::GetLimits(double& minVolts, double& maxVolts) { RequireInitialized(); return GetImpl()->GetLimits(minVolts, maxVolts); }
-int SignalIOInstance::IsDASequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsDASequenceable(isSequenceable); }
-int SignalIOInstance::GetDASequenceMaxLength(long& nrEvents) const { RequireInitialized(); return GetImpl()->GetDASequenceMaxLength(nrEvents); }
-int SignalIOInstance::StartDASequence() { RequireInitialized(); return GetImpl()->StartDASequence(); }
-int SignalIOInstance::StopDASequence() { RequireInitialized(); return GetImpl()->StopDASequence(); }
-int SignalIOInstance::ClearDASequence() { RequireInitialized(); return GetImpl()->ClearDASequence(); }
-int SignalIOInstance::AddToDASequence(double voltage) { RequireInitialized(); return GetImpl()->AddToDASequence(voltage); }
-int SignalIOInstance::SendDASequence() { RequireInitialized(); return GetImpl()->SendDASequence(); }
+int SignalIOInstance::SetGateOpen(bool open) { RequireInitialized(__func__); return GetImpl()->SetGateOpen(open); }
+int SignalIOInstance::GetGateOpen(bool& open) { RequireInitialized(__func__); return GetImpl()->GetGateOpen(open); }
+int SignalIOInstance::SetSignal(double volts) { RequireInitialized(__func__); return GetImpl()->SetSignal(volts); }
+int SignalIOInstance::GetSignal(double& volts) { RequireInitialized(__func__); return GetImpl()->GetSignal(volts); }
+int SignalIOInstance::GetLimits(double& minVolts, double& maxVolts) { RequireInitialized(__func__); return GetImpl()->GetLimits(minVolts, maxVolts); }
+int SignalIOInstance::IsDASequenceable(bool& isSequenceable) const { RequireInitialized(__func__); return GetImpl()->IsDASequenceable(isSequenceable); }
+int SignalIOInstance::GetDASequenceMaxLength(long& nrEvents) const { RequireInitialized(__func__); return GetImpl()->GetDASequenceMaxLength(nrEvents); }
+int SignalIOInstance::StartDASequence() { RequireInitialized(__func__); return GetImpl()->StartDASequence(); }
+int SignalIOInstance::StopDASequence() { RequireInitialized(__func__); return GetImpl()->StopDASequence(); }
+int SignalIOInstance::ClearDASequence() { RequireInitialized(__func__); return GetImpl()->ClearDASequence(); }
+int SignalIOInstance::AddToDASequence(double voltage) { RequireInitialized(__func__); return GetImpl()->AddToDASequence(voltage); }
+int SignalIOInstance::SendDASequence() { RequireInitialized(__func__); return GetImpl()->SendDASequence(); }

--- a/MMCore/Devices/StageInstance.cpp
+++ b/MMCore/Devices/StageInstance.cpp
@@ -22,17 +22,17 @@
 #include "StageInstance.h"
 
 
-int StageInstance::SetPositionUm(double pos) { RequireInitialized(); return GetImpl()->SetPositionUm(pos); }
-int StageInstance::SetRelativePositionUm(double d) { RequireInitialized(); return GetImpl()->SetRelativePositionUm(d); }
-int StageInstance::Move(double velocity) { RequireInitialized(); return GetImpl()->Move(velocity); }
-int StageInstance::Stop() { RequireInitialized(); return GetImpl()->Stop(); }
-int StageInstance::Home() { RequireInitialized(); return GetImpl()->Home(); }
-int StageInstance::SetAdapterOriginUm(double d) { RequireInitialized(); return GetImpl()->SetAdapterOriginUm(d); }
-int StageInstance::GetPositionUm(double& pos) { RequireInitialized(); return GetImpl()->GetPositionUm(pos); }
-int StageInstance::SetPositionSteps(long steps) { RequireInitialized(); return GetImpl()->SetPositionSteps(steps); }
-int StageInstance::GetPositionSteps(long& steps) { RequireInitialized(); return GetImpl()->GetPositionSteps(steps); }
-int StageInstance::SetOrigin() { RequireInitialized(); return GetImpl()->SetOrigin(); }
-int StageInstance::GetLimits(double& lower, double& upper) { RequireInitialized(); return GetImpl()->GetLimits(lower, upper); }
+int StageInstance::SetPositionUm(double pos) { RequireInitialized(__func__); return GetImpl()->SetPositionUm(pos); }
+int StageInstance::SetRelativePositionUm(double d) { RequireInitialized(__func__); return GetImpl()->SetRelativePositionUm(d); }
+int StageInstance::Move(double velocity) { RequireInitialized(__func__); return GetImpl()->Move(velocity); }
+int StageInstance::Stop() { RequireInitialized(__func__); return GetImpl()->Stop(); }
+int StageInstance::Home() { RequireInitialized(__func__); return GetImpl()->Home(); }
+int StageInstance::SetAdapterOriginUm(double d) { RequireInitialized(__func__); return GetImpl()->SetAdapterOriginUm(d); }
+int StageInstance::GetPositionUm(double& pos) { RequireInitialized(__func__); return GetImpl()->GetPositionUm(pos); }
+int StageInstance::SetPositionSteps(long steps) { RequireInitialized(__func__); return GetImpl()->SetPositionSteps(steps); }
+int StageInstance::GetPositionSteps(long& steps) { RequireInitialized(__func__); return GetImpl()->GetPositionSteps(steps); }
+int StageInstance::SetOrigin() { RequireInitialized(__func__); return GetImpl()->SetOrigin(); }
+int StageInstance::GetLimits(double& lower, double& upper) { RequireInitialized(__func__); return GetImpl()->GetLimits(lower, upper); }
 
 MM::FocusDirection
 StageInstance::GetFocusDirection()
@@ -57,14 +57,14 @@ StageInstance::SetFocusDirection(MM::FocusDirection direction)
    focusDirectionHasBeenSet_ = true;
 }
 
-int StageInstance::IsStageSequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsStageSequenceable(isSequenceable); }
-int StageInstance::IsStageLinearSequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsStageLinearSequenceable(isSequenceable); }
-bool StageInstance::IsContinuousFocusDrive() const { RequireInitialized(); return GetImpl()->IsContinuousFocusDrive(); }
-int StageInstance::GetStageSequenceMaxLength(long& nrEvents) const { RequireInitialized(); return GetImpl()->GetStageSequenceMaxLength(nrEvents); }
-int StageInstance::StartStageSequence() { RequireInitialized(); return GetImpl()->StartStageSequence(); }
-int StageInstance::StopStageSequence() { RequireInitialized(); return GetImpl()->StopStageSequence(); }
-int StageInstance::ClearStageSequence() { RequireInitialized(); return GetImpl()->ClearStageSequence(); }
-int StageInstance::AddToStageSequence(double position) { RequireInitialized(); return GetImpl()->AddToStageSequence(position); }
-int StageInstance::SendStageSequence() { RequireInitialized(); return GetImpl()->SendStageSequence(); }
+int StageInstance::IsStageSequenceable(bool& isSequenceable) const { RequireInitialized(__func__); return GetImpl()->IsStageSequenceable(isSequenceable); }
+int StageInstance::IsStageLinearSequenceable(bool& isSequenceable) const { RequireInitialized(__func__); return GetImpl()->IsStageLinearSequenceable(isSequenceable); }
+bool StageInstance::IsContinuousFocusDrive() const { RequireInitialized(__func__); return GetImpl()->IsContinuousFocusDrive(); }
+int StageInstance::GetStageSequenceMaxLength(long& nrEvents) const { RequireInitialized(__func__); return GetImpl()->GetStageSequenceMaxLength(nrEvents); }
+int StageInstance::StartStageSequence() { RequireInitialized(__func__); return GetImpl()->StartStageSequence(); }
+int StageInstance::StopStageSequence() { RequireInitialized(__func__); return GetImpl()->StopStageSequence(); }
+int StageInstance::ClearStageSequence() { RequireInitialized(__func__); return GetImpl()->ClearStageSequence(); }
+int StageInstance::AddToStageSequence(double position) { RequireInitialized(__func__); return GetImpl()->AddToStageSequence(position); }
+int StageInstance::SendStageSequence() { RequireInitialized(__func__); return GetImpl()->SendStageSequence(); }
 int StageInstance::SetStageLinearSequence(double dZ_um, long nSlices)
-{ RequireInitialized(); return GetImpl()->SetStageLinearSequence(dZ_um, nSlices); }
+{ RequireInitialized(__func__); return GetImpl()->SetStageLinearSequence(dZ_um, nSlices); }

--- a/MMCore/Devices/StateInstance.cpp
+++ b/MMCore/Devices/StateInstance.cpp
@@ -22,13 +22,13 @@
 #include "StateInstance.h"
 
 
-int StateInstance::SetPosition(long pos) { RequireInitialized(); return GetImpl()->SetPosition(pos); }
-int StateInstance::SetPosition(const char* label) { RequireInitialized(); return GetImpl()->SetPosition(label); }
-int StateInstance::GetPosition(long& pos) const { RequireInitialized(); return GetImpl()->GetPosition(pos); }
+int StateInstance::SetPosition(long pos) { RequireInitialized(__func__); return GetImpl()->SetPosition(pos); }
+int StateInstance::SetPosition(const char* label) { RequireInitialized(__func__); return GetImpl()->SetPosition(label); }
+int StateInstance::GetPosition(long& pos) const { RequireInitialized(__func__); return GetImpl()->GetPosition(pos); }
 
 std::string StateInstance::GetPositionLabel() const
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    DeviceStringBuffer labelBuf(this, "GetPosition");
    int err = GetImpl()->GetPosition(labelBuf.GetBuffer());
    ThrowIfError(err, "Cannot get current position label");
@@ -37,15 +37,15 @@ std::string StateInstance::GetPositionLabel() const
 
 std::string StateInstance::GetPositionLabel(long pos) const
 {
-   RequireInitialized();
+   RequireInitialized(__func__);
    DeviceStringBuffer labelBuf(this, "GetPositionLabel");
    int err = GetImpl()->GetPositionLabel(pos, labelBuf.GetBuffer());
    ThrowIfError(err, "Cannot get position label at index " + ToString(pos));
    return labelBuf.Get();
 }
 
-int StateInstance::GetLabelPosition(const char* label, long& pos) const { RequireInitialized(); return GetImpl()->GetLabelPosition(label, pos); }
-int StateInstance::SetPositionLabel(long pos, const char* label) { RequireInitialized(); return GetImpl()->SetPositionLabel(pos, label); }
-unsigned long StateInstance::GetNumberOfPositions() const { RequireInitialized(); return GetImpl()->GetNumberOfPositions(); }
-int StateInstance::SetGateOpen(bool open) { RequireInitialized(); return GetImpl()->SetGateOpen(open); }
-int StateInstance::GetGateOpen(bool& open) { RequireInitialized(); return GetImpl()->GetGateOpen(open); }
+int StateInstance::GetLabelPosition(const char* label, long& pos) const { RequireInitialized(__func__); return GetImpl()->GetLabelPosition(label, pos); }
+int StateInstance::SetPositionLabel(long pos, const char* label) { RequireInitialized(__func__); return GetImpl()->SetPositionLabel(pos, label); }
+unsigned long StateInstance::GetNumberOfPositions() const { RequireInitialized(__func__); return GetImpl()->GetNumberOfPositions(); }
+int StateInstance::SetGateOpen(bool open) { RequireInitialized(__func__); return GetImpl()->SetGateOpen(open); }
+int StateInstance::GetGateOpen(bool& open) { RequireInitialized(__func__); return GetImpl()->GetGateOpen(open); }

--- a/MMCore/Devices/XYStageInstance.cpp
+++ b/MMCore/Devices/XYStageInstance.cpp
@@ -22,27 +22,27 @@
 #include "XYStageInstance.h"
 
 
-int XYStageInstance::SetPositionUm(double x, double y) { RequireInitialized(); return GetImpl()->SetPositionUm(x, y); }
-int XYStageInstance::SetRelativePositionUm(double dx, double dy) { RequireInitialized(); return GetImpl()->SetRelativePositionUm(dx, dy); }
-int XYStageInstance::SetAdapterOriginUm(double x, double y) { RequireInitialized(); return GetImpl()->SetAdapterOriginUm(x, y); }
-int XYStageInstance::GetPositionUm(double& x, double& y) { RequireInitialized(); return GetImpl()->GetPositionUm(x, y); }
-int XYStageInstance::GetLimitsUm(double& xMin, double& xMax, double& yMin, double& yMax) { RequireInitialized(); return GetImpl()->GetLimitsUm(xMin, xMax, yMin, yMax); }
-int XYStageInstance::Move(double vx, double vy) { RequireInitialized(); return GetImpl()->Move(vx, vy); }
-int XYStageInstance::SetPositionSteps(long x, long y) { RequireInitialized(); return GetImpl()->SetPositionSteps(x, y); }
-int XYStageInstance::GetPositionSteps(long& x, long& y) { RequireInitialized(); return GetImpl()->GetPositionSteps(x, y); }
-int XYStageInstance::SetRelativePositionSteps(long x, long y) { RequireInitialized(); return GetImpl()->SetRelativePositionSteps(x, y); }
-int XYStageInstance::Home() { RequireInitialized(); return GetImpl()->Home(); }
-int XYStageInstance::Stop() { RequireInitialized(); return GetImpl()->Stop(); }
-int XYStageInstance::SetOrigin() { RequireInitialized(); return GetImpl()->SetOrigin(); }
-int XYStageInstance::SetXOrigin() { RequireInitialized(); return GetImpl()->SetXOrigin(); }
-int XYStageInstance::SetYOrigin() { RequireInitialized(); return GetImpl()->SetYOrigin(); }
-int XYStageInstance::GetStepLimits(long& xMin, long& xMax, long& yMin, long& yMax) { RequireInitialized(); return GetImpl()->GetStepLimits(xMin, xMax, yMin, yMax); }
-double XYStageInstance::GetStepSizeXUm() { RequireInitialized(); return GetImpl()->GetStepSizeXUm(); }
-double XYStageInstance::GetStepSizeYUm() { RequireInitialized(); return GetImpl()->GetStepSizeYUm(); }
-int XYStageInstance::IsXYStageSequenceable(bool& isSequenceable) const { RequireInitialized(); return GetImpl()->IsXYStageSequenceable(isSequenceable); }
-int XYStageInstance::GetXYStageSequenceMaxLength(long& nrEvents) const { RequireInitialized(); return GetImpl()->GetXYStageSequenceMaxLength(nrEvents); }
-int XYStageInstance::StartXYStageSequence() { RequireInitialized(); return GetImpl()->StartXYStageSequence(); }
-int XYStageInstance::StopXYStageSequence() { RequireInitialized(); return GetImpl()->StopXYStageSequence(); }
-int XYStageInstance::ClearXYStageSequence() { RequireInitialized(); return GetImpl()->ClearXYStageSequence(); }
-int XYStageInstance::AddToXYStageSequence(double positionX, double positionY) { RequireInitialized(); return GetImpl()->AddToXYStageSequence(positionX, positionY); }
-int XYStageInstance::SendXYStageSequence() { RequireInitialized(); return GetImpl()->SendXYStageSequence(); }
+int XYStageInstance::SetPositionUm(double x, double y) { RequireInitialized(__func__); return GetImpl()->SetPositionUm(x, y); }
+int XYStageInstance::SetRelativePositionUm(double dx, double dy) { RequireInitialized(__func__); return GetImpl()->SetRelativePositionUm(dx, dy); }
+int XYStageInstance::SetAdapterOriginUm(double x, double y) { RequireInitialized(__func__); return GetImpl()->SetAdapterOriginUm(x, y); }
+int XYStageInstance::GetPositionUm(double& x, double& y) { RequireInitialized(__func__); return GetImpl()->GetPositionUm(x, y); }
+int XYStageInstance::GetLimitsUm(double& xMin, double& xMax, double& yMin, double& yMax) { RequireInitialized(__func__); return GetImpl()->GetLimitsUm(xMin, xMax, yMin, yMax); }
+int XYStageInstance::Move(double vx, double vy) { RequireInitialized(__func__); return GetImpl()->Move(vx, vy); }
+int XYStageInstance::SetPositionSteps(long x, long y) { RequireInitialized(__func__); return GetImpl()->SetPositionSteps(x, y); }
+int XYStageInstance::GetPositionSteps(long& x, long& y) { RequireInitialized(__func__); return GetImpl()->GetPositionSteps(x, y); }
+int XYStageInstance::SetRelativePositionSteps(long x, long y) { RequireInitialized(__func__); return GetImpl()->SetRelativePositionSteps(x, y); }
+int XYStageInstance::Home() { RequireInitialized(__func__); return GetImpl()->Home(); }
+int XYStageInstance::Stop() { RequireInitialized(__func__); return GetImpl()->Stop(); }
+int XYStageInstance::SetOrigin() { RequireInitialized(__func__); return GetImpl()->SetOrigin(); }
+int XYStageInstance::SetXOrigin() { RequireInitialized(__func__); return GetImpl()->SetXOrigin(); }
+int XYStageInstance::SetYOrigin() { RequireInitialized(__func__); return GetImpl()->SetYOrigin(); }
+int XYStageInstance::GetStepLimits(long& xMin, long& xMax, long& yMin, long& yMax) { RequireInitialized(__func__); return GetImpl()->GetStepLimits(xMin, xMax, yMin, yMax); }
+double XYStageInstance::GetStepSizeXUm() { RequireInitialized(__func__); return GetImpl()->GetStepSizeXUm(); }
+double XYStageInstance::GetStepSizeYUm() { RequireInitialized(__func__); return GetImpl()->GetStepSizeYUm(); }
+int XYStageInstance::IsXYStageSequenceable(bool& isSequenceable) const { RequireInitialized(__func__); return GetImpl()->IsXYStageSequenceable(isSequenceable); }
+int XYStageInstance::GetXYStageSequenceMaxLength(long& nrEvents) const { RequireInitialized(__func__); return GetImpl()->GetXYStageSequenceMaxLength(nrEvents); }
+int XYStageInstance::StartXYStageSequence() { RequireInitialized(__func__); return GetImpl()->StartXYStageSequence(); }
+int XYStageInstance::StopXYStageSequence() { RequireInitialized(__func__); return GetImpl()->StopXYStageSequence(); }
+int XYStageInstance::ClearXYStageSequence() { RequireInitialized(__func__); return GetImpl()->ClearXYStageSequence(); }
+int XYStageInstance::AddToXYStageSequence(double positionX, double positionY) { RequireInitialized(__func__); return GetImpl()->AddToXYStageSequence(positionX, positionY); }
+int XYStageInstance::SendXYStageSequence() { RequireInitialized(__func__); return GetImpl()->SendXYStageSequence(); }

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -113,7 +113,7 @@ using namespace std;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 10, MMCore_versionMinor = 5, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 10, MMCore_versionMinor = 6, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -3,7 +3,7 @@
    <groupId>org.micro-manager.mmcorej</groupId>
    <artifactId>MMCoreJ</artifactId>
    <packaging>jar</packaging>
-   <version>10.5.0</version>
+   <version>10.6.0</version>
    <name>Micro-Manager Java Interface to MMCore</name>
    <description>Micro-Manager is open source software for control of automated/motorized microscopes.  This specific packages provides the Java interface to the device abstractino layer (MMCore) that is written in C++ with a C-interface</description>
    <url>http://micro-manager.org</url>


### PR DESCRIPTION
When an operation that requires an initialized device is attempted on an uninitalized device, log a warning message instead of throwing an exception. This reverts part of #376; see #384 for some background.

It turns out that the Hardware Configuration Wizard currently relies (mostly incorrectly) on some operations that are not actually correct, but fixing it is complicated enough that we need to revert the exception throwing for now.

In addition, MMCore itself needs some fixes so that functions like waitForSystem() do not cause issues in the presence of uninitialized devices. This may also apply to other bulk actions such as unloadAllDevices() and the system state cache.

The goal is still to enable exceptions for these checks, but only once we've had a chance to fix these issues.

This does not revert the checks against multiple initialization attempts and against setting a pre-init property after initialization (also added in #376). These are not known to cause any issues so far.

Also add the name of the operation to the logged warning message to assist with the necessary fixes. The log messages have log level `WRN`, which should stand out since we have never used it before. This is to prevent people from thinking that the "normal" operation of the Hardware Configuration Wizard is causing errors.

Sample log message:
```text
2023-09-29T17:04:35.377065 tid18444 [WRN,Core:dev:UserDefinedStateDevice] Operation (GetNumberOfPositions) not permitted on uninitialized device (this will be an error in a future version of MMCore; for now we continue with the operation anyway, even though it might not be safe)
```

Bump MMCore version to 10.6.0.