### PR TITLE
MMCore: Add getDeviceInitializationState()

### DIFF
--- a/MMCore/Devices/DeviceInstance.h
+++ b/MMCore/Devices/DeviceInstance.h
@@ -90,6 +90,9 @@ public:
    // Callback API
    int LogMessage(const char* msg, bool debugOnly);
 
+   bool IsInitialized() const { return initialized_; }
+   bool HasInitializationBeenAttempted() const { return initializeCalled_; }
+
 protected:
    // The DeviceInstance object owns the raw device pointer (pDevice) as soon
    // as the constructor is called, even if the constructor throws.

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -113,7 +113,7 @@ using namespace std;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 10, MMCore_versionMinor = 6, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 10, MMCore_versionMinor = 7, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -960,6 +960,29 @@ void CMMCore::initializeDevice(const char* label ///< the device to initialize
    LOG_INFO(coreLogger_) << "Did initialize device " << label;
 
    updateCoreProperties();
+}
+
+
+/**
+ * Queries the initialization state of the given device.
+ *
+ * @param label the device label
+ */
+DeviceInitializationState
+CMMCore::getDeviceInitializationState(const char* label) const throw (CMMError)
+{
+   std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
+
+   mm::DeviceModuleLockGuard guard(pDevice);
+   if (pDevice->IsInitialized())
+   {
+      return DeviceInitializationState::InitializedSuccessfully;
+   }
+   if (pDevice->HasInitializationBeenAttempted())
+   {
+      return DeviceInitializationState::InitializationFailed;
+   }
+   return DeviceInitializationState::Uninitialized;
 }
 
 

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -112,6 +112,12 @@ namespace mm {
 
 typedef unsigned int* imgRGB32;
 
+enum DeviceInitializationState {
+   Uninitialized,
+   InitializedSuccessfully,
+   InitializationFailed,
+};
+
 
 /// The Micro-Manager Core.
 /**
@@ -147,6 +153,7 @@ public:
    void unloadAllDevices() throw (CMMError);
    void initializeAllDevices() throw (CMMError);
    void initializeDevice(const char* label) throw (CMMError);
+   DeviceInitializationState getDeviceInitializationState(const char* label) const throw (CMMError);
    void reset() throw (CMMError);
 
    void unloadLibrary(const char* moduleName) throw (CMMError);

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -3,7 +3,7 @@
    <groupId>org.micro-manager.mmcorej</groupId>
    <artifactId>MMCoreJ</artifactId>
    <packaging>jar</packaging>
-   <version>10.6.0</version>
+   <version>10.7.0</version>
    <name>Micro-Manager Java Interface to MMCore</name>
    <description>Micro-Manager is open source software for control of automated/motorized microscopes.  This specific packages provides the Java interface to the device abstractino layer (MMCore) that is written in C++ with a C-interface</description>
    <url>http://micro-manager.org</url>


### PR DESCRIPTION
Closes #378.

Using `enum` rather than C++11 `enum class` for SWIG 3.x compatibility.

MMCore(J) version 10.7.0.