### PR TITLE
Relax check against setting a pre-init property after initialization

### DIFF
--- a/MMCore/Devices/DeviceInstance.cpp
+++ b/MMCore/Devices/DeviceInstance.cpp
@@ -180,8 +180,20 @@ void
 DeviceInstance::SetProperty(const std::string& name,
       const std::string& value) const
 {
-   if (initialized_ && GetPropertyInitStatus(name.c_str()))
-      ThrowError("Cannot set pre-init property after initialization");
+   if (initialized_ && GetPropertyInitStatus(name.c_str())) {
+      // Note: Some features (port scanning) may depend on setting serial port
+      // properties post-init. We may want to exclude SerialManager from this
+      // check (regardless of whether strictInitializationChecks is enabled).
+      if (mm::features::flags().strictInitializationChecks)
+      {
+         ThrowError("Cannot set pre-init property after initialization");
+      }
+      else
+      {
+         LOG_WARNING(Logger()) << "Setting of pre-init property (" << name <<
+            ") not permitted on initialized device (this will be an error in a future version of MMCore; for now we continue with the operation anyway, even though it might not be safe)";
+      }
+   }
 
    LOG_DEBUG(Logger()) << "Will set property \"" << name << "\" to \"" <<
       value << "\"";

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -102,7 +102,7 @@ using namespace std;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 11, MMCore_versionMinor = 1, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 11, MMCore_versionMinor = 1, MMCore_versionPatch = 1;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -3,7 +3,7 @@
    <groupId>org.micro-manager.mmcorej</groupId>
    <artifactId>MMCoreJ</artifactId>
    <packaging>jar</packaging>
-   <version>11.1.0</version>
+   <version>11.1.1</version>
    <name>Micro-Manager Java Interface to MMCore</name>
    <description>Micro-Manager is open source software for control of automated/motorized microscopes.  This specific packages provides the Java interface to the device abstractino layer (MMCore) that is written in C++ with a C-interface</description>
    <url>http://micro-manager.org</url>


### PR DESCRIPTION
Before this change: Setting a pre-init property after initialization is an error.

After this change: Setting a pre-init property after initialization is an error if Core feature StrictInitializationChecks is enabled. Otherwise it is a warning.

Bump MMCore version to 11.1.1.

(We probably need to special case SerialManager ports, to allow port scanning to work. But for now remove the error for all devices to give us time to decide what exactly needs to be allowed.)

Related to: https://github.com/micro-manager/mmCoreAndDevices/issues/384#issuecomment-1796571576