### PR TITLE
Enable parallel build for each VS project

### DIFF
--- a/buildscripts/VisualStudio/MMCommon.props
+++ b/buildscripts/VisualStudio/MMCommon.props
@@ -26,6 +26,7 @@
       <DisableSpecificWarnings>4127;4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <ExceptionHandling>Sync</ExceptionHandling>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
(As opposed to, and in addition to, parallel building of projects.)

For human developers, this means:

- When building a single project in Visual Studio (e.g. by right-clicking), compilation is parallelized (this being the motivation for the change).
- When building the whole solution (presumably not very common), both files within each project and projects in the solution are parallelized, both up to the CPU count, which is not ideal but doesn't appear to affect the total build time appreciably.
    - It may make the computer a little less responsive.
    - The project-level parallelism can be adjusted under Tools > Options... > Projects and Solutions > Build And Run.

For the automated build, this means:

- There will be a similar excess parallelization, hopefully with no negative consequences. If there are problems, I might roll this back or come up with some tweak.