### PR TITLE
Fix GCC and Clang warnings in MMDevice, MMCore

### DIFF
--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -36,6 +36,14 @@
 #include <memory>
 #include <string>
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4290) // 'C++ exception specification ignored'
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
 
 const long long bytesInMB = 1 << 20;
 const long adjustThreshold = LONG_MAX / 2;

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -40,6 +40,11 @@
 #pragma warning(disable: 4290) // 'C++ exception specification ignored'
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
 
 class ThreadPool;
 class TaskSet_CopyMemory;
@@ -100,6 +105,10 @@ private:
    std::shared_ptr<ThreadPool> threadPool_;
    std::shared_ptr<TaskSet_CopyMemory> tasksMemCopy_;
 };
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/MMCore/ConfigGroup.h
+++ b/MMCore/ConfigGroup.h
@@ -22,6 +22,17 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4290) // 'C++ exception specification ignored'
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+
 #include "Configuration.h"
 #include "Error.h"
 #include <string>
@@ -436,3 +447,11 @@ public:
       }
    }
 };
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/MMCore/Configuration.cpp
+++ b/MMCore/Configuration.cpp
@@ -27,6 +27,15 @@
 #include <sstream>
 #include <string>
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4290) // 'C++ exception specification ignored'
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+
 std::string PropertySetting::generateKey(const char* device, const char* prop)
 {
    std::string key(device);

--- a/MMCore/Configuration.h
+++ b/MMCore/Configuration.h
@@ -25,6 +25,12 @@
 #pragma warning(disable: 4290) // 'C++ exception specification ignored'
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+
 #include <string>
 #include <vector>
 #include <map>
@@ -118,6 +124,10 @@ private:
    std::vector<PropertySetting> settings_;
    std::map<std::string, int> index_;
 };
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -37,7 +37,6 @@
 //                because all public methods will most likely appear in other
 //                programming environments (Java or Python).
 
-
 #include "../MMDevice/DeviceThreads.h"
 #include "../MMDevice/DeviceUtils.h"
 #include "../MMDevice/ImageMetadata.h"
@@ -64,6 +63,15 @@
 #include <set>
 #include <sstream>
 #include <vector>
+
+#ifdef _MSC_VER
+#pragma warning(disable: 4290) // 'C++ exception specification ignored'
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
 
 /*
  * Important! Read this before changing this file:

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -4458,23 +4458,10 @@ void CMMCore::setMultiROI(std::vector<unsigned> xs, std::vector<unsigned> ys,
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
    }
    mm::DeviceModuleLockGuard guard(camera);
-   unsigned numROI = (unsigned) xs.size();
-   unsigned* xsArr = new unsigned[numROI];
-   unsigned* ysArr = new unsigned[numROI];
-   unsigned* widthsArr = new unsigned[numROI];
-   unsigned* heightsArr = new unsigned[numROI];
-   for (unsigned i = 0; i < numROI; ++i)
-   {
-      xsArr[i] = xs[i];
-      ysArr[i] = ys[i];
-      widthsArr[i] = widths[i];
-      heightsArr[i] = heights[i];
-   }
-   int nRet = camera->SetMultiROI(xsArr, ysArr, widthsArr, heightsArr, numROI);
-   free(xsArr);
-   free(ysArr);
-   free(widthsArr);
-   free(heightsArr);
+   const unsigned numROI = (unsigned) xs.size();
+   int nRet = camera->SetMultiROI(xs.data(), ys.data(),
+                                  widths.data(), heights.data(),
+                                  numROI);
    if (nRet != DEVICE_OK)
    {
       throw CMMError(getDeviceErrorText(nRet, camera).c_str(), MMERR_DEVICE_GENERIC);
@@ -4507,18 +4494,16 @@ void CMMCore::getMultiROI(std::vector<unsigned>& xs, std::vector<unsigned>& ys,
       throw CMMError(getDeviceErrorText(nRet, camera).c_str(), MMERR_DEVICE_GENERIC);
    }
 
-   unsigned* xsArr = new unsigned[numROI];
-   unsigned* ysArr = new unsigned[numROI];
-   unsigned* widthsArr = new unsigned[numROI];
-   unsigned* heightsArr = new unsigned[numROI];
+   std::vector<unsigned> xsTmp(numROI);
+   std::vector<unsigned> ysTmp(numROI);
+   std::vector<unsigned> widthsTmp(numROI);
+   std::vector<unsigned> heightsTmp(numROI);
    unsigned newNum = numROI;
-   nRet = camera->GetMultiROI(xsArr, ysArr, widthsArr, heightsArr, &newNum);
+   nRet = camera->GetMultiROI(xsTmp.data(), ysTmp.data(),
+                              widthsTmp.data(), heightsTmp.data(),
+                              &newNum);
    if (nRet != DEVICE_OK)
    {
-      free(xsArr);
-      free(ysArr);
-      free(widthsArr);
-      free(heightsArr);
       throw CMMError(getDeviceErrorText(nRet, camera).c_str(), MMERR_DEVICE_GENERIC);
    }
    if (newNum > numROI)
@@ -4527,21 +4512,10 @@ void CMMCore::getMultiROI(std::vector<unsigned>& xs, std::vector<unsigned>& ys,
       throw CMMError("Camera returned too many ROIs");
    }
 
-   xs.clear();
-   ys.clear();
-   widths.clear();
-   heights.clear();
-   for (unsigned i = 0; i < newNum; ++i)
-   {
-      xs.push_back(xsArr[i]);
-      ys.push_back(ysArr[i]);
-      widths.push_back(widthsArr[i]);
-      heights.push_back(heightsArr[i]);
-   }
-   free(xsArr);
-   free(ysArr);
-   free(widthsArr);
-   free(heightsArr);
+   xs.swap(xsTmp);
+   ys.swap(ysTmp);
+   widths.swap(widthsTmp);
+   heights.swap(heightsTmp);
 }
 
 /**

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -52,6 +52,12 @@
 #pragma warning(disable: 4290) // 'C++ exception specification ignored'
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+
 #include "../MMDevice/DeviceThreads.h"
 #include "../MMDevice/MMDevice.h"
 #include "../MMDevice/MMDeviceConstants.h"
@@ -692,6 +698,10 @@ private:
    void updateCoreProperty(const char* propName, MM::DeviceType devType) throw (CMMError);
    void loadSystemConfigurationImpl(const char* fileName) throw (CMMError);
 };
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/MMCore/MMCore.vcxproj
+++ b/MMCore/MMCore.vcxproj
@@ -55,7 +55,6 @@
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Lib>
       <OutputFile>$(OutDir)MMCore.lib</OutputFile>
@@ -70,7 +69,6 @@
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Lib>
       <OutputFile>$(OutDir)MMCore.lib</OutputFile>

--- a/MMCore/meson.build
+++ b/MMCore/meson.build
@@ -15,7 +15,6 @@ cxx = meson.get_compiler('cpp')
 
 if cxx.get_id() in ['msvc', 'clang-cl']
     add_project_arguments('-DNOMINMAX', language: 'cpp')
-    add_project_arguments('/wd4290', language: 'cpp')
 endif
 
 # MMDevice must be copied into subprojects/ for this experimental build to work

--- a/MMDevice/ImageMetadata.h
+++ b/MMDevice/ImageMetadata.h
@@ -101,7 +101,7 @@ public:
       str.append(name_);
       return str;
    }
-   const bool IsReadOnly() const  {return readOnly_;}
+   bool IsReadOnly() const  {return readOnly_;}
 
    void SetDevice(const char* device) {deviceLabel_ = device;}
    void SetName(const char* name) {name_ = name;}

--- a/MMDevice/ImageMetadata.h
+++ b/MMDevice/ImageMetadata.h
@@ -27,6 +27,12 @@
 #pragma warning(disable: 4290) // 'C++ exception specification ignored'
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+
 #include "MMDeviceConstants.h"
 
 #include <string>
@@ -319,7 +325,7 @@ public:
       else
          return false;
    }
-   
+
    MetadataSingleTag GetSingleTag(const char* key) const throw (MetadataKeyError)
    {
       MetadataTag* tag = FindTag(key);
@@ -493,6 +499,10 @@ private:
    typedef std::map<std::string, MetadataTag*>::iterator TagIter;
    typedef std::map<std::string, MetadataTag*>::const_iterator TagConstIter;
 };
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/MMDevice/Property.cpp
+++ b/MMDevice/Property.cpp
@@ -191,7 +191,7 @@ bool MM::FloatProperty::Get(std::string& strVal) const
 {
    char fmtStr[20];
    char buf[BUFSIZE];
-   std::sprintf(fmtStr, "%%.%df", decimalPlaces_);
+   std::snprintf(fmtStr, sizeof(fmtStr), "%%.%df", decimalPlaces_);
    std::snprintf(buf, BUFSIZE, fmtStr, value_);
    strVal = buf;
    return true;


### PR DESCRIPTION
So far removes warnings on macOS/Clang. Keeping as draft until I add commits for Linux/GCC.