### PR TITLE
Add NotificationTester device adapter

### DIFF
--- a/DeviceAdapters/Makefile.am
+++ b/DeviceAdapters/Makefile.am
@@ -155,6 +155,7 @@ SUBDIRS = \
 	NewportSMC \
 	Nikon \
 	NikonTE2000 \
+	NotificationTester \
 	OVP_ECS2 \
 	Omicron \
 	Oxxius \

--- a/DeviceAdapters/NotificationTester/DelayedNotifier.h
+++ b/DeviceAdapters/NotificationTester/DelayedNotifier.h
@@ -1,0 +1,137 @@
+// Mock device adapter for testing of device change notifications
+//
+// Copyright (C) 2024 Board of Regents of the University of Wisconsin System
+//
+// This file is distributed under the BSD license. License text is included
+// with the source distribution.
+//
+// This file is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.
+//
+// IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// Author: Mark A. Tsuchida
+
+#pragma once
+
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+// DelayedNotifier calls scheduled callables after a delay relative to when
+// they are scheduled. The delay is fixed at the time of scheduling, and
+// actions are always called on a background thread, even if the delay is zero.
+// Member functions are thread-safe.
+
+class DelayedNotifier {
+   using Clock = std::chrono::steady_clock;
+   using TimePoint = Clock::time_point;
+
+   struct Item {
+      TimePoint when;
+      std::function<void()> what;
+
+      Item(TimePoint timeout, std::function<void()> action) :
+         when(timeout), what(action) {}
+   };
+
+   // Priority queue with soonest item at top
+   struct LaterItem {
+      bool operator()(const Item& lhs, const Item& rhs) const {
+         return lhs.when > rhs.when;
+      }
+   };
+   using PrioQ = std::priority_queue<Item, std::vector<Item>, LaterItem>;
+
+   mutable std::mutex mut_;
+   std::condition_variable cv_;
+   std::chrono::microseconds delay_{};
+   PrioQ scheduledItems_;
+   bool stopRequested_ = false;
+
+   std::thread notifyThread_;
+   std::once_flag threadStarted_;
+
+   TimePoint NextTimeout() const {
+      if (scheduledItems_.empty()) {
+         return TimePoint::max();
+      }
+      return scheduledItems_.top().when;
+   }
+
+   void IssueNotifications() {
+      std::unique_lock<std::mutex> lock(mut_);
+      for (;;) {
+         const auto timeout = NextTimeout();
+         cv_.wait_until(lock, timeout,
+               [&] { return NextTimeout() < timeout || stopRequested_; });
+         if (stopRequested_) {
+            return;
+         }
+         const auto now = Clock::now();
+         while (NextTimeout() <= now) {
+            std::function<void()> func = scheduledItems_.top().what;
+            scheduledItems_.pop();
+            lock.unlock();
+            func();
+            lock.lock();
+         }
+      }
+   }
+
+public:
+   ~DelayedNotifier() {
+      if (notifyThread_.joinable()) {
+         {
+            std::lock_guard<std::mutex> lock(mut_);
+            stopRequested_ = true;
+         }
+         cv_.notify_one();
+         notifyThread_.join();
+      }
+   }
+
+   std::chrono::microseconds Delay() const {
+      std::lock_guard<std::mutex> lock(mut_);
+      return delay_;
+   }
+
+   // Set the delay; applies to actions scheduled in the future only.
+   void Delay(std::chrono::microseconds delay) {
+      assert(delay.count() >= 0);
+      std::lock_guard<std::mutex> lock(mut_);
+      delay_ = delay;
+   }
+
+   void Schedule(std::function<void()> action) {
+      assert(action);
+      std::call_once(threadStarted_, [this] { // Lazy-start thread
+         notifyThread_ = std::thread([this] { IssueNotifications(); });
+	  });
+      bool needToInterruptWait{};
+      {
+         std::lock_guard<std::mutex> lock(mut_);
+         const auto prevTimeout = NextTimeout();
+         const auto timeout = Clock::now() + delay_;
+         scheduledItems_.emplace(timeout, action);
+         needToInterruptWait = timeout < prevTimeout;
+      }
+      if (needToInterruptWait) {
+         cv_.notify_one();
+      }
+   }
+
+   void CancelAll() {
+      std::lock_guard<std::mutex> lock(mut_);
+      while (!scheduledItems_.empty()) {
+         scheduledItems_.pop();
+      }
+   }
+};

--- a/DeviceAdapters/NotificationTester/Makefile.am
+++ b/DeviceAdapters/NotificationTester/Makefile.am
@@ -1,0 +1,8 @@
+AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS)
+
+deviceadapter_LTLIBRARIES = libmmgr_dal_NotificationTester.la
+
+libmmgr_dal_NotificationTester_la_SOURCES = NotificationTester.cpp
+
+libmmgr_dal_NotificationTester_la_LIBADD = $(MMDEVAPI_LIBADD)
+libmmgr_dal_NotificationTester_la_LDFLAGS = $(MMDEVAPI_LDFLAGS)

--- a/DeviceAdapters/NotificationTester/NotificationTester.cpp
+++ b/DeviceAdapters/NotificationTester/NotificationTester.cpp
@@ -102,6 +102,21 @@ public:
                return DEVICE_OK;
             }));
 
+      this->CreateFloatProperty("ExternallySet", model_.Setpoint(), false,
+            new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                        MM::ActionType eAct) {
+               if (eAct == MM::BeforeGet) {
+                  // Keep last-set value
+               } else if (eAct == MM::AfterSet) {
+                  double value{};
+                  pProp->Get(value);
+                  this->LogMessage(("sp = " + std::to_string(value) +
+                                    " (external)").c_str(), true);
+                  model_.Setpoint(value);
+               }
+               return DEVICE_OK;
+            }));
+
       if (isAsync_) {
          this->CreateFloatProperty("SlewTimePerUnit_s",
                model_.ReciprocalSlewRateSeconds(), false,

--- a/DeviceAdapters/NotificationTester/NotificationTester.cpp
+++ b/DeviceAdapters/NotificationTester/NotificationTester.cpp
@@ -1,0 +1,196 @@
+// Mock device adapter for testing of device change notifications
+//
+// Copyright (C) 2024 Board of Regents of the University of Wisconsin System
+//
+// This file is distributed under the BSD license. License text is included
+// with the source distribution.
+//
+// This file is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.
+//
+// IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// Author: Mark A. Tsuchida
+
+#include "DelayedNotifier.h"
+#include "ProcessModel.h"
+
+#include "DeviceBase.h"
+#include "ModuleInterface.h"
+
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+constexpr char DEVNAME_SYNC_PROPERTY[] = "NTSyncProperty";
+constexpr char DEVNAME_ASYNC_PROPERTY[] = "NTAsyncProperty";
+constexpr char PROPNAME_TEST_PROPERTY[] = "TestProperty";
+
+template <typename ProcModel>
+class NTestProp : public CGenericBase<NTestProp<ProcModel>>
+{
+   static constexpr bool isAsync_ =
+         std::is_same<ProcModel, AsyncProcessModel>::value;
+
+   std::string name_;
+   ProcModel model_;
+   DelayedNotifier delayer_;
+
+   std::mutex notificationMut_;
+   bool notificationsEnabled_ = false;
+
+public:
+   explicit NTestProp(std::string name) :
+      name_(std::move(name)),
+      model_([this](double pv) {
+         this->LogMessage(("PV = " + std::to_string(pv)).c_str(), true);
+         {
+            std::lock_guard<std::mutex> lock(notificationMut_);
+            if (!notificationsEnabled_) {
+               return;
+            }
+         }
+         // Avoid delay scheduling for async zero-delay, for close (though not
+         // quite atomic) sync with busy state. (Atomicity between device state
+         // and notifications is not meaningfully achievable with the MMDevice
+         // API, nor is it what notifications are meant for.)
+         if (isAsync_ && delayer_.Delay().count() > 0) {
+            delayer_.Schedule([this, pv = std::to_string(pv)] {
+               this->OnPropertyChanged(PROPNAME_TEST_PROPERTY, pv.c_str());
+            });
+         } else {
+            this->OnPropertyChanged(PROPNAME_TEST_PROPERTY,
+                                    std::to_string(pv).c_str());
+         }
+      })
+   {}
+
+   int Initialize() final {
+      this->CreateStringProperty("NotificationsEnabled",
+            notificationsEnabled_ ? "Yes" : "No", false,
+            new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                        MM::ActionType eAct) {
+               if (eAct == MM::BeforeGet) {
+                  pProp->Set(notificationsEnabled_ ? "Yes" : "No");
+               } else if (eAct == MM::AfterSet) {
+                  std::string value;
+                  pProp->Get(value);
+                  notificationsEnabled_ = (value == "Yes");
+               }
+               return DEVICE_OK;
+            }));
+      this->AddAllowedValue("NotificationsEnabled", "No");
+      this->AddAllowedValue("NotificationsEnabled", "Yes");
+
+      this->CreateFloatProperty(PROPNAME_TEST_PROPERTY,
+            model_.ProcessVariable(), false,
+            new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                        MM::ActionType eAct) {
+               if (eAct == MM::BeforeGet) {
+                  pProp->Set(model_.ProcessVariable());
+               } else if (eAct == MM::AfterSet) {
+                  double value{};
+                  pProp->Get(value);
+                  this->LogMessage(
+                        ("sp = " + std::to_string(value)).c_str(), true);
+                  model_.Setpoint(value);
+               }
+               return DEVICE_OK;
+            }));
+
+      if (isAsync_) {
+         this->CreateFloatProperty("SlewTimePerUnit_s",
+               model_.ReciprocalSlewRateSeconds(), false,
+               new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                           MM::ActionType eAct) {
+                  if (eAct == MM::BeforeGet) {
+                     pProp->Set(model_.ReciprocalSlewRateSeconds());
+                  } else if (eAct == MM::AfterSet) {
+                     double seconds{};
+                     pProp->Get(seconds);
+                     model_.ReciprocalSlewRateSeconds(seconds);
+                  }
+                  return DEVICE_OK;
+               }));
+         this->SetPropertyLimits("SlewTimePerUnit_s", 0.0001, 10.0);
+
+         this->CreateFloatProperty("UpdateInterval_s",
+               model_.UpdateIntervalSeconds(), false,
+               new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                           MM::ActionType eAct) {
+                  if (eAct == MM::BeforeGet) {
+                     pProp->Set(model_.UpdateIntervalSeconds());
+                  } else if (eAct == MM::AfterSet) {
+                     double seconds{};
+                     pProp->Get(seconds);
+                     model_.UpdateIntervalSeconds(seconds);
+                  }
+                  return DEVICE_OK;
+               }));
+         this->SetPropertyLimits("UpdateInterval_s", 0.0001, 10.0);
+
+         using std::chrono::duration_cast;
+         using std::chrono::microseconds;
+         using FPSeconds = std::chrono::duration<double>;
+         this->CreateFloatProperty("NotificationDelay_s",
+               duration_cast<FPSeconds>(delayer_.Delay()).count(), false,
+               new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                           MM::ActionType eAct) {
+                  if (eAct == MM::BeforeGet) {
+                     pProp->Set(
+                        duration_cast<FPSeconds>(delayer_.Delay()).count());
+                  } else if (eAct == MM::AfterSet) {
+                     double seconds{};
+                     pProp->Get(seconds);
+                     const auto delay = FPSeconds{seconds};
+                     delayer_.Delay(duration_cast<microseconds>(delay));
+                  }
+                  return DEVICE_OK;
+               }));
+         this->SetPropertyLimits("NotificationDelay_s", 0.0, 1.0);
+      }
+
+      return DEVICE_OK;
+   }
+
+   int Shutdown() final {
+      model_.Halt();
+      delayer_.CancelAll();
+      return DEVICE_OK;
+   }
+
+   bool Busy() final {
+      return model_.IsSlewing();
+   }
+
+   void GetName(char *name) const final {
+      CDeviceUtils::CopyLimitedString(name, name_.c_str());
+   }
+};
+
+MODULE_API void InitializeModuleData()
+{
+   RegisterDevice(DEVNAME_SYNC_PROPERTY, MM::GenericDevice,
+                  "Test synchronous property notifications");
+   RegisterDevice(DEVNAME_ASYNC_PROPERTY, MM::GenericDevice,
+                  "Test asynchronous property busy state and notifications");
+}
+
+MODULE_API MM::Device *CreateDevice(const char *deviceName)
+{
+   const std::string name(deviceName);
+   if (name == DEVNAME_SYNC_PROPERTY)
+      return new NTestProp<SyncProcessModel>(name);
+   if (name == DEVNAME_ASYNC_PROPERTY)
+      return new NTestProp<AsyncProcessModel>(name);
+   return nullptr;
+}
+
+MODULE_API void DeleteDevice(MM::Device *pDevice)
+{
+   delete pDevice;
+}

--- a/DeviceAdapters/NotificationTester/NotificationTester.cpp
+++ b/DeviceAdapters/NotificationTester/NotificationTester.cpp
@@ -21,6 +21,7 @@
 #include "ModuleInterface.h"
 
 #include <chrono>
+#include <cmath>
 #include <mutex>
 #include <string>
 #include <type_traits>
@@ -28,6 +29,8 @@
 
 constexpr char DEVNAME_SYNC_PROPERTY[] = "NTSyncProperty";
 constexpr char DEVNAME_ASYNC_PROPERTY[] = "NTAsyncProperty";
+constexpr char DEVNAME_SYNC_STAGE[] = "NTSyncStage";
+constexpr char DEVNAME_ASYNC_STAGE[] = "NTAsyncStage";
 constexpr char PROPNAME_TEST_PROPERTY[] = "TestProperty";
 
 template <typename ProcModel>
@@ -55,6 +58,7 @@ public:
             }
          }
          delayer_.Schedule([this, pv = std::to_string(pv)]{
+            this->LogMessage(("Notifying: PV = " + pv).c_str(), true);
             this->OnPropertyChanged(PROPNAME_TEST_PROPERTY, pv.c_str());
          });
       })
@@ -178,12 +182,212 @@ public:
    }
 };
 
+template <typename ProcModel>
+class NTestStage : public CStageBase<NTestStage<ProcModel>>
+{
+   static constexpr bool isAsync_ =
+         std::is_same<ProcModel, AsyncProcessModel>::value;
+
+   // The process model operates in steps (only set to integers; round upon
+   // readout).
+   static constexpr double umPerStep_ = 0.1;
+
+   std::string name_;
+   ProcModel model_;
+   DelayedNotifier delayer_;
+
+   std::mutex notificationMut_;
+   bool notificationsEnabled_ = false;
+
+public:
+   explicit NTestStage(std::string name) :
+      name_(std::move(name)),
+      model_([this](double pv) {
+         long ipv = std::lround(pv);
+         this->LogMessage(("PV = " + std::to_string(ipv)).c_str(), true);
+         {
+            std::lock_guard<std::mutex> lock(notificationMut_);
+            if (!notificationsEnabled_) {
+               return;
+            }
+         }
+         delayer_.Schedule([this, ipv] {
+            this->LogMessage(("Notifying: PV = " +
+                              std::to_string(ipv)).c_str(), true);
+            this->OnStagePositionChanged(umPerStep_ * ipv);
+         });
+      })
+   {
+      // Adjust default for stage-like velocity (100 um/s).
+      model_.ReciprocalSlewRateSeconds(0.01 * umPerStep_);
+   }
+
+   int Initialize() final {
+      this->CreateFloatProperty("UmPerStep", umPerStep_, true);
+
+      this->CreateStringProperty("NotificationsEnabled",
+            notificationsEnabled_ ? "Yes" : "No", false,
+            new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                        MM::ActionType eAct) {
+               if (eAct == MM::BeforeGet) {
+                  pProp->Set(notificationsEnabled_ ? "Yes" : "No");
+               } else if (eAct == MM::AfterSet) {
+                  std::string value;
+                  pProp->Get(value);
+                  notificationsEnabled_ = (value == "Yes");
+               }
+               return DEVICE_OK;
+            }));
+      this->AddAllowedValue("NotificationsEnabled", "No");
+      this->AddAllowedValue("NotificationsEnabled", "Yes");
+
+      this->CreateIntegerProperty("ExternallySetSteps",
+            static_cast<long>(model_.Setpoint()), false,
+            new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                        MM::ActionType eAct) {
+               if (eAct == MM::BeforeGet) {
+                  // Keep last-set value
+               } else if (eAct == MM::AfterSet) {
+                  long value{};
+                  pProp->Get(value);
+                  this->LogMessage(("sp = " + std::to_string(value) +
+                                    " (external)").c_str(), true);
+                  model_.Setpoint(value);
+               }
+               return DEVICE_OK;
+            }));
+
+      if (isAsync_) {
+         this->CreateFloatProperty("SlewTimePerStep_s",
+               model_.ReciprocalSlewRateSeconds(), false,
+               new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                           MM::ActionType eAct) {
+                  if (eAct == MM::BeforeGet) {
+                     pProp->Set(model_.ReciprocalSlewRateSeconds());
+                  } else if (eAct == MM::AfterSet) {
+                     double seconds{};
+                     pProp->Get(seconds);
+                     model_.ReciprocalSlewRateSeconds(seconds);
+                  }
+                  return DEVICE_OK;
+               }));
+         this->SetPropertyLimits("SlewTimePerStep_s", 0.0001, 10.0);
+
+         this->CreateFloatProperty("UpdateInterval_s",
+               model_.UpdateIntervalSeconds(), false,
+               new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                           MM::ActionType eAct) {
+                  if (eAct == MM::BeforeGet) {
+                     pProp->Set(model_.UpdateIntervalSeconds());
+                  } else if (eAct == MM::AfterSet) {
+                     double seconds{};
+                     pProp->Get(seconds);
+                     model_.UpdateIntervalSeconds(seconds);
+                  }
+                  return DEVICE_OK;
+               }));
+         this->SetPropertyLimits("UpdateInterval_s", 0.0001, 10.0);
+
+         using std::chrono::duration_cast;
+         using std::chrono::microseconds;
+         using FPSeconds = std::chrono::duration<double>;
+         this->CreateFloatProperty("NotificationDelay_s",
+               duration_cast<FPSeconds>(delayer_.Delay()).count(), false,
+               new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                           MM::ActionType eAct) {
+                  if (eAct == MM::BeforeGet) {
+                     pProp->Set(duration_cast<FPSeconds>(delayer_.Delay()).count());
+                  } else if (eAct == MM::AfterSet) {
+                     double seconds{};
+                     pProp->Get(seconds);
+                     const auto delay = FPSeconds{seconds};
+                     delayer_.Delay(duration_cast<microseconds>(delay));
+                  }
+                  return DEVICE_OK;
+               }));
+         this->SetPropertyLimits("NotificationDelay_s", 0.0, 1.0);
+      }
+
+      return DEVICE_OK;
+   }
+
+   int Shutdown() final {
+      model_.Halt();
+      delayer_.CancelAll();
+      return DEVICE_OK;
+   }
+
+   bool Busy() final {
+      return model_.IsSlewing();
+   }
+
+   void GetName(char* name) const final {
+      CDeviceUtils::CopyLimitedString(name, name_.c_str());
+   }
+
+   int SetPositionUm(double um) final {
+      const long steps = std::lround(um / umPerStep_);
+      return SetPositionSteps(steps);
+   }
+
+   int Stop() final {
+      model_.Halt();
+      return DEVICE_OK;
+   }
+
+   int GetPositionUm(double& um) final {
+      long steps{};
+      int ret = GetPositionSteps(steps);
+      if (ret != DEVICE_OK) {
+         return ret;
+      }
+      um = umPerStep_ * steps;
+      return DEVICE_OK;
+   }
+
+   int SetPositionSteps(long steps) final {
+      this->LogMessage(("sp = " + std::to_string(steps)).c_str(), true);
+      model_.Setpoint(steps);
+      return DEVICE_OK;
+   }
+
+   int GetPositionSteps(long& steps) final {
+      steps = std::lround(model_.ProcessVariable());
+      return DEVICE_OK;
+   }
+
+   int SetOrigin() final {
+      return DEVICE_UNSUPPORTED_COMMAND;
+   }
+
+   int GetLimits(double& lo, double& hi) final {
+      // Conservatively keep steps within 32-bit range (we want exact integer
+      // steps to be preserved by the double-based process model).
+      lo = -2147483648 * umPerStep_;
+      hi = +2147483647 * umPerStep_;
+      return DEVICE_OK;
+   }
+
+   int IsStageSequenceable(bool& flag) const final {
+      flag = false;
+      return DEVICE_OK;
+   }
+
+   bool IsContinuousFocusDrive() const final {
+      return false;
+   }
+};
+
 MODULE_API void InitializeModuleData()
 {
    RegisterDevice(DEVNAME_SYNC_PROPERTY, MM::GenericDevice,
                   "Test synchronous property notifications");
    RegisterDevice(DEVNAME_ASYNC_PROPERTY, MM::GenericDevice,
                   "Test asynchronous property busy state and notifications");
+   RegisterDevice(DEVNAME_SYNC_STAGE, MM::StageDevice,
+                  "Test synchronous stage position notifications");
+   RegisterDevice(DEVNAME_ASYNC_STAGE, MM::StageDevice,
+                  "Test asynchronous stage busy state and position notifications");
 }
 
 MODULE_API MM::Device *CreateDevice(const char *deviceName)
@@ -193,6 +397,10 @@ MODULE_API MM::Device *CreateDevice(const char *deviceName)
       return new NTestProp<SyncProcessModel>(name);
    if (name == DEVNAME_ASYNC_PROPERTY)
       return new NTestProp<AsyncProcessModel>(name);
+   if (name == DEVNAME_SYNC_STAGE)
+      return new NTestStage<SyncProcessModel>(name);
+   if (name == DEVNAME_ASYNC_STAGE)
+      return new NTestStage<AsyncProcessModel>(name);
    return nullptr;
 }
 

--- a/DeviceAdapters/NotificationTester/NotificationTester.cpp
+++ b/DeviceAdapters/NotificationTester/NotificationTester.cpp
@@ -30,7 +30,33 @@ constexpr char DEVNAME_SYNC_PROPERTY[] = "NTSyncProperty";
 constexpr char DEVNAME_ASYNC_PROPERTY[] = "NTAsyncProperty";
 constexpr char DEVNAME_SYNC_STAGE[] = "NTSyncStage";
 constexpr char DEVNAME_ASYNC_STAGE[] = "NTAsyncStage";
+constexpr char DEVNAME_SYNC_XY_STAGE[] = "NTSyncXYStage";
+constexpr char DEVNAME_ASYNC_XY_STAGE[] = "NTAsyncXYStage";
 constexpr char PROPNAME_TEST_PROPERTY[] = "TestProperty";
+
+std::pair<bool, std::array<long, 2>> ParseIntegerPair(const std::string& s) {
+   // Strings like " 100 ; -200  ", all spaces optional.
+   // (Not using ',' as delimiter as it is not allowed in property values.)
+   static constexpr char delimiter = ';';
+   static constexpr auto invalid = std::make_pair(false,
+                                                  std::array<long, 2>{});
+   try {
+      std::size_t index{};
+      const long x = std::stol(s, &index);
+      const auto delimPos = s.find_first_not_of(' ', index);
+      if (delimPos >= s.size() || s[delimPos] != delimiter) {
+         return invalid;
+      }
+      const std::string afterDelim = s.substr(delimPos + 1);
+      const long y = std::stol(afterDelim, &index);
+      if (afterDelim.find_first_not_of(' ', index) != std::string::npos) {
+         return invalid;
+      }
+      return {true, {x, y}};
+   } catch (const std::exception&) {
+      return invalid;
+   }
+}
 
 template <typename ProcModel>
 class NTestProp : public CGenericBase<NTestProp<ProcModel>>
@@ -371,6 +397,221 @@ public:
    }
 };
 
+template <typename ProcModel>
+class NTestXYStage : public CXYStageBase<NTestXYStage<ProcModel>>
+{
+   // The process model operates in steps (only set to integers; round upon
+   // readout). X and Y use the same step size.
+   static constexpr double umPerStep_ = 0.1;
+   std::string name_;
+   ProcModel model_;
+   DelayedNotifier delayer_;
+
+   std::mutex notificationMut_;
+   bool notificationsEnabled_ = false;
+
+public:
+   explicit NTestXYStage(std::string name) :
+      name_(std::move(name)),
+      model_([this](std::array<double, 2> pv) {
+         const long ix = std::lround(pv[0]);
+         const long iy = std::lround(pv[1]);
+         this->LogMessage(("PV = " + std::to_string(ix) + ", " +
+                           std::to_string(iy)).c_str(), true);
+         {
+            std::lock_guard<std::mutex> lock(notificationMut_);
+            if (!notificationsEnabled_) {
+               return;
+            }
+         }
+         delayer_.Schedule([this, ix, iy] {
+            this->LogMessage(("Notifying: PV = " + std::to_string(ix) + ", " +
+                              std::to_string(iy)).c_str(), true);
+            this->OnXYStagePositionChanged(umPerStep_* ix, umPerStep_* iy);
+         });
+      })
+   {
+      // Adjust default for stage-like velocity (100 um/s).
+      model_.ReciprocalSlewRateSeconds(0.01 * umPerStep_);
+   }
+
+   int Initialize() final {
+      this->CreateFloatProperty("UmPerStep", umPerStep_, true);
+
+      this->CreateStringProperty("NotificationsEnabled",
+            notificationsEnabled_ ? "Yes" : "No", false,
+            new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                        MM::ActionType eAct) {
+               if (eAct == MM::BeforeGet) {
+                  pProp->Set(notificationsEnabled_ ? "Yes" : "No");
+               } else if (eAct == MM::AfterSet) {
+                  std::string value;
+                  pProp->Get(value);
+                  notificationsEnabled_ = (value == "Yes");
+               }
+               return DEVICE_OK;
+            }));
+      this->AddAllowedValue("NotificationsEnabled", "No");
+      this->AddAllowedValue("NotificationsEnabled", "Yes");
+
+      this->CreateStringProperty("ExternallySetSteps", "0; 0", false,
+         new MM::ActionLambda([this](MM::PropertyBase* pProp,
+            MM::ActionType eAct) {
+               if (eAct == MM::BeforeGet) {
+                  // Keep last-set value
+               } else if (eAct == MM::AfterSet) {
+                  std::string commaSeparated;
+                  pProp->Get(commaSeparated);
+                  const auto okAndPair = ParseIntegerPair(commaSeparated);
+                  if (!okAndPair.first) {
+                     // Snap to current setpoint for next get
+                     const auto sp = model_.Setpoint();
+                     pProp->Set((std::to_string(std::lround(sp[0])) + "; " +
+                                 std::to_string(std::lround(sp[1]))).c_str());
+                     return DEVICE_INVALID_PROPERTY_VALUE;
+                  }
+                  const auto sp = okAndPair.second;
+                  this->LogMessage(("sp = " + std::to_string(sp[0]) + ", " +
+                                    std::to_string(sp[1])).c_str(), true);
+                  model_.Setpoint({double(sp[0]), double(sp[1])});
+               }
+               return DEVICE_OK;
+            }));
+
+      if (ProcModel::isAsync) {
+         this->CreateFloatProperty("SlewTimePerStep_s",
+               model_.ReciprocalSlewRateSeconds(), false,
+               new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                           MM::ActionType eAct) {
+                  if (eAct == MM::BeforeGet) {
+                     pProp->Set(model_.ReciprocalSlewRateSeconds());
+                  } else if (eAct == MM::AfterSet) {
+                     double seconds{};
+                     pProp->Get(seconds);
+                     model_.ReciprocalSlewRateSeconds(seconds);
+                  }
+                  return DEVICE_OK;
+               }));
+         this->SetPropertyLimits("SlewTimePerStep_s", 0.0001, 10.0);
+
+         this->CreateFloatProperty("UpdateInterval_s",
+               model_.UpdateIntervalSeconds(), false,
+               new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                           MM::ActionType eAct) {
+                  if (eAct == MM::BeforeGet) {
+                     pProp->Set(model_.UpdateIntervalSeconds());
+                  } else if (eAct == MM::AfterSet) {
+                     double seconds{};
+                     pProp->Get(seconds);
+                     model_.UpdateIntervalSeconds(seconds);
+                  }
+                  return DEVICE_OK;
+               }));
+         this->SetPropertyLimits("UpdateInterval_s", 0.0001, 10.0);
+
+         using std::chrono::duration_cast;
+         using std::chrono::microseconds;
+         using FPSeconds = std::chrono::duration<double>;
+         this->CreateFloatProperty("NotificationDelay_s",
+               duration_cast<FPSeconds>(delayer_.Delay()).count(), false,
+               new MM::ActionLambda([this](MM::PropertyBase* pProp,
+                                           MM::ActionType eAct) {
+                  if (eAct == MM::BeforeGet) {
+                     pProp->Set(duration_cast<FPSeconds>(delayer_.Delay()).count());
+                  } else if (eAct == MM::AfterSet) {
+                     double seconds{};
+                     pProp->Get(seconds);
+                     const auto delay = FPSeconds{seconds};
+                     delayer_.Delay(duration_cast<microseconds>(delay));
+                  }
+                  return DEVICE_OK;
+               }));
+         this->SetPropertyLimits("NotificationDelay_s", 0.0, 1.0);
+      }
+
+      return DEVICE_OK;
+   }
+
+   int Shutdown() final {
+      model_.Halt();
+      delayer_.CancelAll();
+      return DEVICE_OK;
+   }
+
+   bool Busy() final {
+      return model_.IsSlewing();
+   }
+
+   void GetName(char* name) const final {
+      CDeviceUtils::CopyLimitedString(name, name_.c_str());
+   }
+
+   int GetLimitsUm(double& xMin, double& xMax, double& yMin, double& yMax) final {
+      long xLo, xHi, yLo, yHi;
+      int ret = GetStepLimits(xLo, xHi, yLo, yHi);
+      if (ret != DEVICE_OK) {
+         return ret;
+      }
+      xMin = xLo * umPerStep_;
+      xMax = xHi * umPerStep_;
+      yMin = yLo * umPerStep_;
+      yMax = yHi * umPerStep_;
+      return DEVICE_OK;
+   }
+
+   int SetPositionSteps(long x, long y) final {
+      this->LogMessage(("sp = " + std::to_string(x) + ", " +
+                        std::to_string(y)).c_str(), true);
+      model_.Setpoint({double(x), double(y)});
+      return DEVICE_OK;
+   }
+
+   int GetPositionSteps(long& x, long& y) final {
+      const auto pv = model_.ProcessVariable();
+      x = std::lround(pv[0]);
+      y = std::lround(pv[1]);
+      return DEVICE_OK;
+   }
+
+   int Home() final {
+      // We could simulate homing, but it is not currently clear what
+      // notifications mean during a home (application code should explicitly
+      // read the position after a home). For now, pretend that the stage
+      // doesn't support homing.
+      return DEVICE_UNSUPPORTED_COMMAND;
+   }
+
+   int Stop() final {
+      model_.Halt();
+      return DEVICE_OK;
+   }
+
+   int SetOrigin() final {
+      return DEVICE_UNSUPPORTED_COMMAND;
+   }
+
+   int GetStepLimits(long& xMin, long& xMax, long& yMin, long& yMax) final {
+      // Conservatively keep steps within 32-bit range (we want exact integer
+      // steps to be preserved by the double-based process model).
+      xMin = yMin = -2147483648;
+      xMax = yMax = +2147483647;
+      return DEVICE_OK;
+   }
+
+   double GetStepSizeXUm() final {
+      return umPerStep_;
+   }
+
+   double GetStepSizeYUm() final {
+      return umPerStep_;
+   }
+
+   int IsXYStageSequenceable(bool& flag) const final {
+      flag = false;
+      return DEVICE_OK;
+   }
+};
+
 MODULE_API void InitializeModuleData()
 {
    RegisterDevice(DEVNAME_SYNC_PROPERTY, MM::GenericDevice,
@@ -381,6 +622,10 @@ MODULE_API void InitializeModuleData()
                   "Test synchronous stage position notifications");
    RegisterDevice(DEVNAME_ASYNC_STAGE, MM::StageDevice,
                   "Test asynchronous stage busy state and position notifications");
+   RegisterDevice(DEVNAME_SYNC_XY_STAGE, MM::XYStageDevice,
+                  "Test synchronous XY stage position notifications");
+   RegisterDevice(DEVNAME_ASYNC_XY_STAGE, MM::XYStageDevice,
+                  "Test asynchronous XY stage busy state and position notifications");
 }
 
 MODULE_API MM::Device *CreateDevice(const char *deviceName)
@@ -394,6 +639,10 @@ MODULE_API MM::Device *CreateDevice(const char *deviceName)
       return new NTestStage<SyncProcessModel<1>>(name);
    if (name == DEVNAME_ASYNC_STAGE)
       return new NTestStage<AsyncProcessModel<1>>(name);
+   if (name == DEVNAME_SYNC_XY_STAGE)
+      return new NTestXYStage<SyncProcessModel<2>>(name);
+   if (name == DEVNAME_ASYNC_XY_STAGE)
+      return new NTestXYStage<AsyncProcessModel<2>>(name);
    return nullptr;
 }
 

--- a/DeviceAdapters/NotificationTester/NotificationTester.cpp
+++ b/DeviceAdapters/NotificationTester/NotificationTester.cpp
@@ -54,18 +54,9 @@ public:
                return;
             }
          }
-         // Avoid delay scheduling for async zero-delay, for close (though not
-         // quite atomic) sync with busy state. (Atomicity between device state
-         // and notifications is not meaningfully achievable with the MMDevice
-         // API, nor is it what notifications are meant for.)
-         if (isAsync_ && delayer_.Delay().count() > 0) {
-            delayer_.Schedule([this, pv = std::to_string(pv)] {
-               this->OnPropertyChanged(PROPNAME_TEST_PROPERTY, pv.c_str());
-            });
-         } else {
-            this->OnPropertyChanged(PROPNAME_TEST_PROPERTY,
-                                    std::to_string(pv).c_str());
-         }
+         delayer_.Schedule([this, pv = std::to_string(pv)]{
+            this->OnPropertyChanged(PROPNAME_TEST_PROPERTY, pv.c_str());
+         });
       })
    {}
 

--- a/DeviceAdapters/NotificationTester/NotificationTester.vcxproj
+++ b/DeviceAdapters/NotificationTester/NotificationTester.vcxproj
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="DelayedNotifier.h" />
+    <ClInclude Include="ProcessModel.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="NotificationTester.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\MMDevice\MMDevice-SharedRuntime.vcxproj">
+      <Project>{b8c95f39-54bf-40a9-807b-598df2821d55}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{7c8c60fa-92e3-4102-80ab-a4468c4fcd2f}</ProjectGuid>
+    <RootNamespace>NotificationTester</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;NOTIFICATIONTESTERVS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;NOTIFICATIONTESTERVS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DeviceAdapters/NotificationTester/NotificationTester.vcxproj.filters
+++ b/DeviceAdapters/NotificationTester/NotificationTester.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="DelayedNotifier.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ProcessModel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="NotificationTester.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/DeviceAdapters/NotificationTester/ProcessModel.h
+++ b/DeviceAdapters/NotificationTester/ProcessModel.h
@@ -1,0 +1,242 @@
+// Mock device adapter for testing of device change notifications
+//
+// Copyright (C) 2024 Board of Regents of the University of Wisconsin System
+//
+// This file is distributed under the BSD license. License text is included
+// with the source distribution.
+//
+// This file is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.
+//
+// IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// Author: Mark A. Tsuchida
+
+#pragma once
+
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+// Models of physical device state. SyncProcessModel and AsyncProcessModel have
+// the same compile-time interface. Member functions are not thread-safe: they
+// must be called with external synchronization.
+//
+// SyncProcessModel issues change notifications synchronously (i.e., from the
+// thread setting the value) and never becomes busy.
+//
+// AsyncProcessModel separates setpoint from process variable; the latter is
+// slewed so that it reaches the setpoint over time (so the model is "busy"
+// while still slewing). Change notifications are periodically issued from a
+// background thread during the slewing, with the last notification always
+// occuring when the PV reaches the SP.
+
+class SyncProcessModel {
+   // Setpoint and process variable are always equal.
+   double value_ = 0.0;
+
+   std::function<void(double)> update_;
+   double lastUpdatedPV_ = 0.0;
+
+   void Update() {
+      if (value_ == lastUpdatedPV_) {
+         return;
+      }
+      update_(value_);
+      lastUpdatedPV_ = value_;
+   }
+
+public:
+   explicit SyncProcessModel(std::function<void(double)> updateFunc) :
+         update_(std::move(updateFunc)) {
+      assert(update_);
+   }
+
+   void ReciprocalSlewRateSeconds(double rRate_s) {
+      (void)rRate_s;
+      assert(false);
+   }
+
+   double ReciprocalSlewRateSeconds() const {
+      assert(false);
+      return 1.0;
+   }
+
+   void UpdateIntervalSeconds(double interval_s) {
+      (void)interval_s;
+      assert(false);
+   }
+
+   double UpdateIntervalSeconds() const {
+      assert(false);
+      return 0.1;
+   }
+
+   bool IsSlewing() const { return false; }
+
+   double ProcessVariable() const { return value_; }
+
+   double Setpoint() const { return value_; }
+
+   void Halt() { /* no-op */ }
+
+   void Setpoint(double setpoint) {
+      assert(std::isfinite(setpoint));
+      value_ = setpoint;
+      Update();
+   }
+};
+
+class AsyncProcessModel {
+   std::chrono::duration<double> rRate_{1.0}; // Reciprocal rate, per PV unit
+   std::chrono::duration<double> updateInterval_{0.1};
+
+   // PV and SP protected by mut_ unless slewThread_ known not to be running
+   mutable std::mutex mut_;
+   double procVar_ = 0.0;
+   double setpoint_ = 0.0;
+
+   std::thread slewThread_;
+   std::mutex stopMut_;
+   std::condition_variable stopCv_;
+   bool stopRequested_ = false;
+
+   std::mutex updateMut_;
+   std::function<void(double)> update_;
+   double lastUpdatedPV_ = 0.0;
+
+   // Only call from slew thread; cancel triggered by Halt()
+   template <typename TimePoint>
+   bool CancelableWaitUntil(TimePoint timeout) {
+      std::unique_lock<std::mutex> lock(stopMut_);
+      stopCv_.wait_until(lock, timeout, [&] { return stopRequested_; });
+      return stopRequested_;
+   }
+
+   // Only call from slew thread
+   void Update() {
+      std::lock_guard<std::mutex> lock(updateMut_);
+      if (procVar_ == lastUpdatedPV_) {
+         return;
+      }
+      update_(procVar_);
+      lastUpdatedPV_ = procVar_;
+   }
+
+public:
+   explicit AsyncProcessModel(std::function<void(double)> updateFunc) :
+         update_(std::move(updateFunc)) {
+      assert(update_);
+   }
+
+   ~AsyncProcessModel() {
+      // Avoid sending updates upon halting
+      {
+         std::lock_guard<std::mutex> lock(updateMut_);
+         update_ = [](auto) {};
+      }
+      Halt();
+   }
+
+   // Set slew rate (as reciprocal slew rate); applies to next setpoint
+   void ReciprocalSlewRateSeconds(double rRate_s) {
+      assert(rRate_s > 0.0);
+      rRate_ = std::chrono::duration<double>{rRate_s};
+   }
+
+   double ReciprocalSlewRateSeconds() const {
+      return rRate_.count();
+   }
+
+   // Set update interval; applies to next setpoint
+   void UpdateIntervalSeconds(double interval_s) {
+      assert(interval_s > 0.0);
+      updateInterval_ = std::chrono::duration<double>{interval_s};
+   }
+
+   double UpdateIntervalSeconds() const {
+      return updateInterval_.count();
+   }
+
+   bool IsSlewing() const { // Aka "busy", "in motion"
+      std::lock_guard<std::mutex> lock(mut_);
+      return procVar_ != setpoint_;
+   }
+
+   double ProcessVariable() const {
+      std::lock_guard<std::mutex> lock(mut_);
+      return procVar_;
+   }
+
+   double Setpoint() const {
+      std::lock_guard<std::mutex> lock(mut_);
+      return setpoint_;
+   }
+
+   void Halt() {
+      if (!slewThread_.joinable()) {
+         return;
+      }
+
+      {
+         std::lock_guard<std::mutex> lock(stopMut_);
+         stopRequested_ = true;
+      }
+      stopCv_.notify_one();
+      slewThread_.join();
+
+      setpoint_ = procVar_;
+   }
+
+   void Setpoint(double setpoint) {
+      assert(std::isfinite(setpoint));
+      Halt(); // Cancel previous slew, if any, updating last PV
+      setpoint_ = setpoint;
+      if (procVar_ == setpoint_) {
+         return;
+      }
+
+      const auto orig = procVar_;
+      stopRequested_ = false;
+      slewThread_ = std::thread(
+            [this, orig, setpoint, absRRate = rRate_,
+                  updateInterval = updateInterval_] {
+         const auto displacement = setpoint - orig;
+         const auto rRate = displacement < 0.0 ? -absRRate : absRRate;
+         const auto duration = displacement * rRate;
+         const auto startTime = std::chrono::steady_clock::now();
+         const auto finishTime = startTime + duration;
+         auto updateTime = startTime + updateInterval;
+         for (;;) {
+            if (finishTime <= updateTime) {
+               if (!CancelableWaitUntil(finishTime)) {
+                  std::lock_guard<std::mutex> lock(mut_);
+                  procVar_ = setpoint;
+               }
+               Update();
+               return;
+            }
+
+            if (CancelableWaitUntil(updateTime)) {
+               Update();
+               return;
+            }
+            const auto elapsed = updateTime - startTime;
+            const double pv = orig + elapsed / rRate;
+            {
+               std::lock_guard<std::mutex> lock(mut_);
+               procVar_ = pv;
+            }
+            Update();
+            updateTime += updateInterval;
+         }
+      });
+   }
+};

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -586,6 +586,7 @@ m4_define([device_adapter_dirs], [m4_strip([
    NewportSMC
    Nikon
    NikonTE2000
+   NotificationTester
    OVP_ECS2
    Omicron
    OpenCVgrabber

--- a/micromanager.sln
+++ b/micromanager.sln
@@ -481,6 +481,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "IDSPeak", "DeviceAdapters\IDSPeak\IDSPeak.vcxproj", "{823CF77E-8120-41B1-9B25-823A79C93198}"
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "QSI", "DeviceAdapters\QSI\QSI.vcxproj", "{320AF64E-C4FC-4A97-A7D1-F8233A8A44C7}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NotificationTester", "DeviceAdapters\NotificationTester\NotificationTester.vcxproj", "{7C8C60FA-92E3-4102-80AB-A4468C4FCD2F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -1447,6 +1449,10 @@ Global
 		{320AF64E-C4FC-4A97-A7D1-F8233A8A44C7}.Debug|x64.Build.0 = Debug|x64
 		{320AF64E-C4FC-4A97-A7D1-F8233A8A44C7}.Release|x64.ActiveCfg = Release|x64
 		{320AF64E-C4FC-4A97-A7D1-F8233A8A44C7}.Release|x64.Build.0 = Release|x64
+		{7C8C60FA-92E3-4102-80AB-A4468C4FCD2F}.Debug|x64.ActiveCfg = Debug|x64
+		{7C8C60FA-92E3-4102-80AB-A4468C4FCD2F}.Debug|x64.Build.0 = Debug|x64
+		{7C8C60FA-92E3-4102-80AB-A4468C4FCD2F}.Release|x64.ActiveCfg = Release|x64
+		{7C8C60FA-92E3-4102-80AB-A4468C4FCD2F}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Pure-software device adapter intended for automated (and interactive) testing of application handling of change notifications.

Initial implementation with property simulator only. Simulation of Z/XY stages, etc., will follow soon.

Draft of docs (to be put on device page once merged):

Device `NTSyncProperty` has `TestProperty` (float) that is never busy (immediately reflects set value). If `NotificationsEnabled` is set to `Yes`, `OnPropertyChanged()` is called from within the property `AfterSet` handler, on the same thread that called into the device adapter.

Device `NTAsyncProperty` has `TestProperty` (float) which distinguishes the target value from the current value, and the current value is slewed toward the target at a constant rate (`SlewTimePerUnit_s`), updating periodically (`UpdateInterval_s`). The last update is guaranteed to match the target value (even if that happens mid-update-interval). `Busy()` returns true when the current value differs from the target value. Reading the property always returns the last-updated current value (as opposed to the target). If the property is set before the previous slewing completed, the previous target is forgotten and a slew toward the new target is begun. When `NotificationsEnabled` is `Yes`, `OnPropertyChanged()` is called on every update, after an optional, independent delay (`NotificationDelay_s`), always from a thread owned by the device adapter. A device that only notifies once per change can be simulated by setting the update interval to be longer than the total slew time.

It is hard to know how well this captures the behavior of every existing device adapter, although the intent is to capture most possibilities that have some degree of coherence. I'm sure there are devices that have other quirks that cannot be simulated with this scheme (some of those may be bugs, but perhaps not all).