### PR TITLE
Aravis (camera) adapter

### DIFF
--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -473,8 +473,6 @@ int AravisCamera::OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct)
   pProp->Get(pixelType);
   
   printf("OnPixelType '%s'\n", pixelType.c_str());
-  //arv_camera_set_pixel_format_from_string(arv_cam, pixelType.c_str(), NULL);
-  /* Checking for an error causes a crash, IDK why. */
   arv_camera_set_pixel_format_from_string(arv_cam, pixelType.c_str(), &gerror);
   arvCheckError(gerror);
 

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -565,7 +565,6 @@ int AravisCamera::Initialize()
 
   initialized = true;
     
-  printf("ArvInitializeEnd %s\n", arv_cam_name);
   return DEVICE_OK;
 }
 

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -1070,22 +1070,26 @@ int AravisCamera::SnapImage()
 
 int AravisCamera::StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow)
 {
-  if (!ArvStartSequenceAcquisition()){    
+  if (!ArvStartSequenceAcquisition()){
+    int ret = GetCoreCallback()->PrepareForAcq(this);
+    if (ret != DEVICE_OK) {
+      return ret;
+    }
     return DEVICE_OK;
   }
-  else{
-    return ARV_ERROR;
-  }
+  return ARV_ERROR;
 }
 
 
 int AravisCamera::StartSequenceAcquisition(double interval_ms) {
   if (!ArvStartSequenceAcquisition()){
+    int ret = GetCoreCallback()->PrepareForAcq(this);
+    if (ret != DEVICE_OK) {
+      return ret;
+    }    
     return DEVICE_OK;
   }
-  else{
-    return ARV_ERROR;
-  }
+  return ARV_ERROR;
 }
 
 

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -1,6 +1,31 @@
-// #pragma warning(push)
-// #pragma warning(disable : 4482)
-// #pragma warning(disable : 4251) // Note: need to have a C++ interface, i.e., compiler versions need to match!
+/*
+  Copyright 2024 Hazen Babcock
+  
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice, this 
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice, this 
+     list of conditions and the following disclaimer in the documentation and/or 
+     other materials provided with the distribution.
+
+  3. Neither the name of the copyright holder nor the names of its contributors may 
+     be used to endorse or promote products derived from this software without 
+     specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
+  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
+  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
+  DAMAGE.
+*/
 
 #include "AravisCamera.h"
 
@@ -218,7 +243,6 @@ int AravisCamera::ArvCheckError(GError *gerror) const
     std::stringstream msg;
     msg << "Aravis Error: " << gerror->message;
     LogMessage(msg.str(), false);
-    //printf("Aravis Error: %s\n", gerror->message);
     g_clear_error(&gerror);
     return 1;
   }

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -14,15 +14,27 @@
  */
 MODULE_API void InitializeModuleData()
 {
+  uint64_t nDevices=0;
+
+  // Update and get number of aravis compatible cameras.
+  arv_update_device_list();
+  nDevices = arv_get_n_devices();
+  printf("AAAAA: Aravis Found %d\n", (int)nDevices);
+  
+  for (int i = 0; i < nDevices; i++)
+  {
+    RegisterDevice(arv_get_device_id(i), MM::CameraDevice, "Aravis Camera");
+  }
 }
 
-MODULE_API MM::Device* CreateDevice(const char* deviceName)
+MODULE_API MM::Device* CreateDevice(const char* deviceId)
 {
-  return new AravisCamera(deviceName);
+  return new AravisCamera(deviceId);
 }
 
 MODULE_API void DeleteDevice(MM::Device* pDevice)
 {
+  delete pDevice;
 }
 
 
@@ -32,10 +44,266 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 
 AravisCamera::AravisCamera(const char *name) : CCameraBase<AravisCamera>()
 {
+  a_cam_name = name;
 }
 
 AravisCamera::~AravisCamera()
 {
+  g_clear_object(&a_cam);
+}
+
+// These supposed to be in alphabetical order.
+
+int AravisCamera::ClearROI()
+{
+  return DEVICE_OK;
+}
+
+int AravisCamera::GetBinning() const
+{
+  gint dx;
+  gint dy;
+  GError *error = NULL;
+  
+  arv_camera_get_binning(a_cam, &dx, &dy, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }
+  
+  // dx is always dy for MM? Add check?  
+  return (int)dx;
+}
+
+unsigned AravisCamera::GetBitDepth() const
+{
+  guint32 arvPixelFormat;
+  GError *error = NULL;
+  
+  arvPixelFormat = arv_camera_get_pixel_format(a_cam, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }
+  
+  switch (arvPixelFormat){
+  case ARV_PIXEL_FORMAT_MONO_8: {
+    return 8;
+  }
+  case ARV_PIXEL_FORMAT_MONO_10: {
+    return 10;
+  }
+  case ARV_PIXEL_FORMAT_MONO_12: {
+    return 12;
+  }
+  case ARV_PIXEL_FORMAT_MONO_14: {
+    return 14;
+  }
+  case ARV_PIXEL_FORMAT_MONO_16: {
+    return 16;
+  }
+  default:{
+    printf ("Aravis Error: Pixel Format %d is not implemented\n", (int)arvPixelFormat);
+  }    
+  }
+  return 0;
+}
+
+double AravisCamera::GetExposure() const
+{
+  GError *error = NULL;
+  
+  return arv_camera_get_exposure_time(a_cam, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }
+}
+
+const unsigned char* AravisCamera::GetImageBuffer()
+{
+  int i;
+  gint w,h;
+  size_t size;
+  unsigned char *mm_buffer;
+  unsigned char *cam_data;
+
+  printf("get image buffer\n");
+  if (ARV_IS_BUFFER (a_buffer)) {
+    w = arv_buffer_get_image_width(a_buffer);
+    h = arv_buffer_get_image_height(a_buffer);
+    cam_data = (unsigned char *)arv_buffer_get_data(a_buffer, &size);
+    printf("buffer is %ld, %d x %d\n", (long)size, (int)w, (int)h); 
+
+    for(i=0;i<(w*h);i++){
+      mm_buffer[i] = cam_data[i];
+    }
+    g_clear_object(&a_buffer);
+    return mm_buffer;
+  }
+  return NULL;
+}
+
+long AravisCamera::GetImageBufferSize() const
+{
+  gint gx,gy,gwidth,gheight;
+  GError *error = NULL;
+  arv_camera_get_region(a_cam, &gx, &gy, &gwidth, &gheight, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }  
+  return (long) gwidth * gheight * this->GetImageBytesPerPixel(); 
+}
+
+unsigned AravisCamera::GetImageBytesPerPixel() const
+{
+  return 1;
+}
+
+unsigned AravisCamera::GetImageWidth() const
+{
+  gint w;
+  gint h;
+  GError *error = NULL;
+  
+  arv_camera_get_sensor_size(a_cam, &w, &h, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }  
+  return (unsigned)w;
+}
+
+unsigned AravisCamera::GetImageHeight() const
+{
+  gint w;
+  gint h;
+  GError *error = NULL;
+  
+  arv_camera_get_sensor_size(a_cam, &w, &h, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }
+  return (unsigned)h;
+}
+
+void AravisCamera::GetName(char *name) const
+{
+  CDeviceUtils::CopyLimitedString(name, a_cam_name); 
+}
+
+unsigned AravisCamera::GetNumberOfComponents() const
+{
+  // Add support for RGB cameras.
+  return 1;
+}
+
+int AravisCamera::GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize)
+{
+  gint gx,gy,gwidth,gheight;
+  GError *error = NULL;
+  
+  arv_camera_get_region(a_cam, &gx, &gy, &gwidth, &gheight, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }
+  x = (unsigned)gx;
+  y = (unsigned)gx;
+  xSize = (unsigned)xSize;
+  ySize = (unsigned)ySize;
+
+  return DEVICE_OK;
+}
+
+int AravisCamera::Initialize()
+{
+  GError *error = NULL;
+  a_cam = arv_camera_new(a_cam_name, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+    return ARV_ERROR;
+  }
+
+  arv_camera_set_exposure_time_auto(a_cam, ARV_AUTO_OFF, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }
+  return DEVICE_OK;
+}
+
+int AravisCamera::IsExposureSequenceable(bool &isSequencable) const
+{
+  isSequencable = false;
+  return DEVICE_OK;
+}
+
+int AravisCamera::SetBinning(int binSize)
+{
+  GError *error;
+  
+  arv_camera_set_binning(a_cam, (gint)binSize, (gint)binSize, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }  
+  return DEVICE_OK;
+}
+
+void AravisCamera::SetExposure(double exp)
+{
+  double expUs = 1.0e6*exp;
+  double frameRate = 1.0/exp;
+  GError *error;
+
+  // Range checking?
+  // Frame rate should be slightly slower than exposure time?
+  arv_camera_set_frame_rate(a_cam, frameRate, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }  
+  arv_camera_set_exposure_time(a_cam, expUs, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }  
+}
+
+int AravisCamera::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize)
+{
+  GError *error;
+  arv_camera_set_region(a_cam, (gint)x, (gint)y, (gint)xSize, (gint)ySize, &error);
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+  }    
+  return DEVICE_OK;
+}
+
+int AravisCamera::Shutdown()
+{
+  return DEVICE_OK;
+}
+
+int AravisCamera::SnapImage()
+{
+  GError *error = NULL;
+  // arv_camera_set_acquisition_mode(a_cam, ARV_ACQUISITION_MODE_SINGLE_FRAME);
+  
+  AravisCamera::a_buffer = arv_camera_acquisition(a_cam, 0, &error);
+
+  if (error != NULL) {
+    printf ("Aravis Error: %s\n", error->message);
+    g_clear_error(&error);
+    return ARV_ERROR;
+  }
+
+  return DEVICE_OK;
 }
 
 

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -1,0 +1,53 @@
+// #pragma warning(push)
+// #pragma warning(disable : 4482)
+// #pragma warning(disable : 4251) // Note: need to have a C++ interface, i.e., compiler versions need to match!
+
+#include "AravisCamera.h"
+#include "ModuleInterface.h"
+#include <vector>
+#include <string>
+#include <algorithm>
+
+
+/*
+ * Module functions.
+ */
+MODULE_API void InitializeModuleData()
+{
+}
+
+MODULE_API MM::Device* CreateDevice(const char* deviceName)
+{
+  return new AravisCamera(deviceName);
+}
+
+MODULE_API void DeleteDevice(MM::Device* pDevice)
+{
+}
+
+
+/*
+ * Camera class and methods.
+ */
+
+AravisCamera::AravisCamera(const char *name) : CCameraBase<AravisCamera>()
+{
+}
+
+AravisCamera::~AravisCamera()
+{
+}
+
+
+/*
+ * Acquistion thread class and methods.
+ */
+AravisAcquisitionThread::AravisAcquisitionThread(AravisCamera * aCam)
+{
+}
+
+AravisAcquisitionThread::~AravisAcquisitionThread()
+{
+}
+
+// #pragma warning(pop)

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -48,7 +48,6 @@ MODULE_API void InitializeModuleData()
 
 MODULE_API MM::Device* CreateDevice(const char* deviceName)
 {
-  printf("ArvCreateDevice %s\n", deviceName);
   return new AravisCamera(deviceName);
 }
 
@@ -118,7 +117,6 @@ AravisCamera::AravisCamera(const char *name) :
   img_buffer(nullptr),
   pixel_type(nullptr)
 {
-  printf("ArvCamera %s\n", name);
   arv_cam_name = (char *)malloc(sizeof(char) * strlen(name));
   CDeviceUtils::CopyLimitedString(arv_cam_name, name);
 }
@@ -555,7 +553,6 @@ int AravisCamera::Initialize()
 
     binc = arv_camera_get_x_binning_increment(arv_cam, &gerror);
     arvCheckError(gerror);
-    printf("Binning %d %d %d\n", bmin, bmax, binc);
 
     SetPropertyLimits(MM::g_Keyword_Binning, bmin, bmax);
 

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -158,7 +158,7 @@ void AravisCamera::AcquisitionCallback(ArvStreamCallbackType type, ArvBuffer *cb
 void AravisCamera::ArvGetExposure()
 {
   double expTimeUs;
-  GError *gerror = NULL;
+  GError *gerror = nullptr;
 
   expTimeUs = arv_camera_get_exposure_time(arv_cam, &gerror);
   if(!arvCheckError(gerror)){
@@ -170,7 +170,7 @@ void AravisCamera::ArvGetExposure()
 void AravisCamera::ArvGetBitDepth()
 {
   guint32 arvPixelFormat;
-  GError *gerror = NULL;
+  GError *gerror = nullptr;
 
   printf("ArvGetBitDepth\n");
   arvPixelFormat = arv_camera_get_pixel_format(arv_cam, &gerror);
@@ -212,7 +212,7 @@ int AravisCamera::ArvStartSequenceAcquisition()
 {
   int i;
   size_t payload;
-  GError *gerror = NULL;
+  GError *gerror = nullptr;
 
   ArvGetBitDepth();   
   counter = 0;
@@ -258,7 +258,7 @@ int AravisCamera::GetBinning() const
 {
   gint dx;
   gint dy;
-  GError *gerror = NULL;
+  GError *gerror = nullptr;
 
   printf("ArvGetBinning\n");
   arv_camera_get_binning(arv_cam, &dx, &dy, &gerror);
@@ -310,7 +310,7 @@ const unsigned char* AravisCamera::GetImageBuffer()
 long AravisCamera::GetImageBufferSize() const
 {
   gint gx,gy,gwidth,gheight;
-  GError *gerror = NULL;
+  GError *gerror = nullptr;
 
   printf("ArvGetImageBufferSize\n");
   arv_camera_get_region(arv_cam, &gx, &gy, &gwidth, &gheight, &gerror);
@@ -357,7 +357,7 @@ unsigned AravisCamera::GetNumberOfComponents() const
 int AravisCamera::GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize)
 {
   gint gx,gy,gwidth,gheight;
-  GError *gerror = NULL;
+  GError *gerror = nullptr;
 
   printf("ArvGetROI\n");
   arv_camera_get_region(arv_cam, &gx, &gy, &gwidth, &gheight, &gerror);
@@ -376,7 +376,7 @@ int AravisCamera::Initialize()
 {
   int i,ret;
   gint tmp;
-  GError *gerror = NULL;
+  GError *gerror = nullptr;
 
   if(initialized){
     return DEVICE_OK;
@@ -468,16 +468,15 @@ bool AravisCamera::IsCapturing()
 int AravisCamera::OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
   std::string pixelType;
-  GError *gerror;
+  GError *gerror = nullptr;
   
   pProp->Get(pixelType);
   
   printf("OnPixelType '%s'\n", pixelType.c_str());
-  arv_camera_set_pixel_format_from_string(arv_cam, pixelType.c_str(), NULL);
-  /* Checking for an error causes a crash, IDK why.
-     arv_camera_set_pixel_format_from_string(arv_cam, pixelType.c_str(), &gerror);
-     arvCheckError(gerror);
-  */
+  //arv_camera_set_pixel_format_from_string(arv_cam, pixelType.c_str(), NULL);
+  /* Checking for an error causes a crash, IDK why. */
+  arv_camera_set_pixel_format_from_string(arv_cam, pixelType.c_str(), &gerror);
+  arvCheckError(gerror);
 
   return DEVICE_OK;
 }
@@ -491,7 +490,7 @@ int AravisCamera::PrepareSequenceAcqusition()
 
 int AravisCamera::SetBinning(int binSize)
 {
-  GError *gerror;
+  GError *gerror = nullptr;
 
   printf("ArvSetBinning\n");
   arv_camera_set_binning(arv_cam, (gint)binSize, (gint)binSize, &gerror);
@@ -501,28 +500,31 @@ int AravisCamera::SetBinning(int binSize)
 }
 
 
-void AravisCamera::SetExposure(double exp)
+void AravisCamera::SetExposure(double expMs)
 {
-  double expUs = 1000.0*exp;
-  double frameRate = 1.0/exp;
-  GError *gerror;
-
-  printf("ArvSetExposure\n");
-  // Range checking?
-  // Frame rate should be slightly slower than exposure time?
-  arv_camera_set_frame_rate(arv_cam, frameRate, &gerror);
-  arvCheckError(gerror);
-
+  double expUs = 1000.0*expMs;
+  double min, max;
+  GError *gerror = nullptr;
+  
+  printf("ArvSetExposure %f\n", expMs);
   arv_camera_set_exposure_time(arv_cam, expUs, &gerror);
   arvCheckError(gerror);
 
+  // This always returns the same bounds, independent of exposure time..
+  arv_camera_get_frame_rate_bounds(arv_cam, &min, &max, &gerror);
+  arvCheckError(gerror);
+    
+  arv_camera_set_frame_rate(arv_cam, max, &gerror);
+  arvCheckError(gerror);
+
+  printf("%f %f\n", min, max);
   ArvGetExposure();
 }
 
 
 int AravisCamera::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize)
 {
-  GError *gerror;
+  GError *gerror = nullptr;
 
   printf("ArvSetROI %d %d %d %d\n", x, y, xSize, ySize);
   arv_camera_set_region(arv_cam, (gint)x, (gint)y, (gint)xSize, (gint)ySize, &gerror);
@@ -543,7 +545,7 @@ int AravisCamera::Shutdown()
 // This should wait until the image is acquired? Maybe it does?
 int AravisCamera::SnapImage()
 {
-  GError *gerror = NULL;
+  GError *gerror = nullptr;
 
   printf("ArvSnapImage\n");
   ArvGetBitDepth();
@@ -581,7 +583,7 @@ int AravisCamera::StartSequenceAcquisition(double interval_ms) {
 
 int AravisCamera::StopSequenceAcquisition()
 {
-  GError *gerror = NULL;
+  GError *gerror = nullptr;
 
   printf("StopSequenceAcquisition\n");
   if (capturing){

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -58,6 +58,7 @@ public:
 
   // Internal.
   void ArvGetExposure();
+  void ArvSetBytesPerPixel(size_t size);
 
 private:
   bool capturing;

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -1,6 +1,7 @@
 #ifndef _ARAVIS_CAMERA_H_
 #define _ARAVIS_CAMERA_H_
 
+#include <iostream>
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -21,10 +22,15 @@ class AravisAcquisitionThread;
 class AravisCamera : public CCameraBase<AravisCamera>
 {
 public:
-  AravisCamera(const char *serialNumber);
+  AravisCamera(const char *);
   ~AravisCamera();
 
-  // MM required functions.
+  // MMDevice API.
+  void GetName(char* name) const;  
+  int Initialize();
+  int Shutdown();
+  
+  // MMCamera API.
   int ClearROI();
   int GetBinning() const;
   unsigned GetBitDepth() const;
@@ -34,22 +40,22 @@ public:
   unsigned GetImageBytesPerPixel() const;
   unsigned GetImageWidth() const;
   unsigned GetImageHeight() const;
-  void GetName(char* name) const;
   unsigned GetNumberOfComponents() const;
   int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
-  int Initialize();
   int IsExposureSequenceable(bool& isSequenceable) const;  
   int SetBinning(int binSize);
   void SetExposure(double exp);
   int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
-  int Shutdown();
   int SnapImage();
 
-  // Variables.
-  ArvBuffer *a_buffer;
-  ArvCamera *a_cam;
-  const char *a_cam_name;  
-
+private:
+  bool initialized_;
+  long img_buffer_size;
+  
+  ArvBuffer *arv_buffer;
+  ArvCamera *arv_cam;
+  char *arv_cam_name;
+  unsigned char *img_buffer;
 };
 
 

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -63,7 +63,10 @@ public:
   int OnBlackLevel(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnGain(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
-  
+  int OnTriggerMode(MM::PropertyBase* pProp, MM::ActionType eAct);
+  int OnTriggerSelector(MM::PropertyBase* pProp, MM::ActionType eAct);
+  int OnTriggerSource(MM::PropertyBase* pProp, MM::ActionType eAct);
+
   // Internal.
   void AcquisitionCallback(ArvStreamCallbackType, ArvBuffer *);
   void ArvBufferUpdate(ArvBuffer *aBuffer);
@@ -88,9 +91,11 @@ private:
   ArvBuffer *arv_buffer;
   ArvCamera *arv_cam;
   char *arv_cam_name;
+  ArvDevice *arv_device;
   ArvStream *arv_stream;
   unsigned char *img_buffer;
   const char *pixel_type;
+  const char *trigger;
 };
 
 #endif // !_ARAVIS_CAMERA_H_

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -48,16 +48,27 @@ public:
   int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
   int SnapImage();
 
-private:
-  bool initialized_;
+  // Continuous acquisition.
+  bool IsCapturing();
+  int PrepareSequenceAcqusition();
+  int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
+  int StartSequenceAcquisition(double interval_ms);
+  int StopSequenceAcquisition();
+
+  bool capturing_;
   int img_buffer_height;
   int img_buffer_width;
+
+private:
+  bool initialized_;
   long img_buffer_size;
   
-  ArvBuffer *arv_buffer;
-  ArvCamera *arv_cam;
   char *arv_cam_name;
   unsigned char *img_buffer;
+
+  ArvBuffer *arv_buffer;
+  ArvCamera *arv_cam;
+  ArvStream *arv_stream;
 };
 
 

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -1,10 +1,11 @@
 #ifndef _ARAVIS_CAMERA_H_
 #define _ARAVIS_CAMERA_H_
 
+/*
 #include <iostream>
 #include <stdlib.h>
 #include <stdio.h>
-
+*/
 
 #include "DeviceBase.h"
 #include "ImgBuffer.h"
@@ -56,6 +57,9 @@ public:
   int StartSequenceAcquisition(double interval_ms);
   int StopSequenceAcquisition();
 
+  // Properties.
+  int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
+  
   // Internal.
   void ArvGetExposure();
   void ArvGetBitDepth();

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -1,0 +1,29 @@
+#ifndef _ARAVIS_CAMERA_H_
+#define _ARAVIS_CAMERA_H_
+
+#include "DeviceBase.h"
+#include "ImgBuffer.h"
+#include "DeviceThreads.h"
+#include "arv.h"
+
+
+class AravisAcquisitionThread;
+
+
+class AravisCamera : public CCameraBase<AravisCamera>
+{
+public:
+   AravisCamera(const char *serialNumber);
+   ~AravisCamera();
+};
+
+
+class AravisAcquisitionThread : public MMDeviceThreadBase
+{
+public:
+   AravisAcquisitionThread(AravisCamera *aCam);
+   ~AravisAcquisitionThread();
+};
+
+#endif // !_ARAVIS_CAMERA_H_
+

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -57,7 +57,9 @@ public:
   int StopSequenceAcquisition();
 
   // Properties.
+  int OnAutoGain(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
+  int OnGain(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
   
   // Internal.

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -58,7 +58,9 @@ public:
   bool capturing_;
   int img_buffer_height;
   int img_buffer_width;
-
+  long counter_;
+  ArvStream *arv_stream;
+  
 private:
   bool initialized_;
   long img_buffer_size;
@@ -68,15 +70,6 @@ private:
 
   ArvBuffer *arv_buffer;
   ArvCamera *arv_cam;
-  ArvStream *arv_stream;
-};
-
-
-class AravisAcquisitionThread : public MMDeviceThreadBase
-{
-public:
-   AravisAcquisitionThread(AravisCamera *aCam);
-   ~AravisAcquisitionThread();
 };
 
 #endif // !_ARAVIS_CAMERA_H_

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -1,10 +1,18 @@
 #ifndef _ARAVIS_CAMERA_H_
 #define _ARAVIS_CAMERA_H_
 
+#include <stdlib.h>
+#include <stdio.h>
+
+
 #include "DeviceBase.h"
 #include "ImgBuffer.h"
 #include "DeviceThreads.h"
 #include "arv.h"
+#include "glib.h"
+
+
+#define ARV_ERROR 3141  // Should this be something specific?
 
 
 class AravisAcquisitionThread;
@@ -13,8 +21,35 @@ class AravisAcquisitionThread;
 class AravisCamera : public CCameraBase<AravisCamera>
 {
 public:
-   AravisCamera(const char *serialNumber);
-   ~AravisCamera();
+  AravisCamera(const char *serialNumber);
+  ~AravisCamera();
+
+  // MM required functions.
+  int ClearROI();
+  int GetBinning() const;
+  unsigned GetBitDepth() const;
+  double GetExposure() const;
+  const unsigned char* GetImageBuffer();
+  long GetImageBufferSize() const;
+  unsigned GetImageBytesPerPixel() const;
+  unsigned GetImageWidth() const;
+  unsigned GetImageHeight() const;
+  void GetName(char* name) const;
+  unsigned GetNumberOfComponents() const;
+  int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
+  int Initialize();
+  int IsExposureSequenceable(bool& isSequenceable) const;  
+  int SetBinning(int binSize);
+  void SetExposure(double exp);
+  int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
+  int Shutdown();
+  int SnapImage();
+
+  // Variables.
+  ArvBuffer *a_buffer;
+  ArvCamera *a_cam;
+  const char *a_cam_name;  
+
 };
 
 

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -1,3 +1,32 @@
+/*
+  Copyright 2024 Hazen Babcock
+  
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice, this 
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice, this 
+     list of conditions and the following disclaimer in the documentation and/or 
+     other materials provided with the distribution.
+
+  3. Neither the name of the copyright holder nor the names of its contributors may 
+     be used to endorse or promote products derived from this software without 
+     specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
+  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
+  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
+  DAMAGE.
+*/
+
 #ifndef _ARAVIS_CAMERA_H_
 #define _ARAVIS_CAMERA_H_
 

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -64,7 +64,7 @@ public:
   // Internal.
   void ArvGetExposure();
   void ArvGetBitDepth();
-  void ArvSetBytesPerPixel(size_t size);
+  //void ArvSetBytesPerPixel(size_t size);
   int ArvStartSequenceAcquisition();
 
 private:
@@ -76,6 +76,7 @@ private:
   int img_buffer_height;
   size_t img_buffer_size;
   int img_buffer_width;
+  unsigned img_number_components;
   bool initialized;
 
   ArvBuffer *arv_buffer;
@@ -83,6 +84,7 @@ private:
   char *arv_cam_name;
   ArvStream *arv_stream;
   unsigned char *img_buffer;
+  const char *pixel_type;
 };
 
 #endif // !_ARAVIS_CAMERA_H_

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -50,6 +50,8 @@ public:
 
 private:
   bool initialized_;
+  int img_buffer_height;
+  int img_buffer_width;
   long img_buffer_size;
   
   ArvBuffer *arv_buffer;

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -58,12 +58,15 @@ public:
 
   // Internal.
   void ArvGetExposure();
+  void ArvGetBitDepth();
   void ArvSetBytesPerPixel(size_t size);
+  int ArvStartSequenceAcquisition();
 
 private:
   bool capturing;
   long counter;
   double exposure_time;
+  unsigned img_bit_depth;
   int img_buffer_bytes_per_pixel;
   int img_buffer_height;
   size_t img_buffer_size;

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -57,8 +57,10 @@ public:
   int StopSequenceAcquisition();
 
   // Properties.
+  int OnAutoBlackLevel(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnAutoGain(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
+  int OnBlackLevel(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnGain(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
   

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -49,27 +49,31 @@ public:
   int SnapImage();
 
   // Continuous acquisition.
+  void AcquisitionCallback(ArvStreamCallbackType, ArvBuffer *);
   bool IsCapturing();
   int PrepareSequenceAcqusition();
   int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
   int StartSequenceAcquisition(double interval_ms);
   int StopSequenceAcquisition();
 
-  bool capturing_;
-  int img_buffer_height;
-  int img_buffer_width;
-  long counter_;
-  ArvStream *arv_stream;
-  
+  // Internal.
+  void ArvGetExposure();
+
 private:
-  bool initialized_;
-  long img_buffer_size;
-  
-  char *arv_cam_name;
-  unsigned char *img_buffer;
+  bool capturing;
+  long counter;
+  double exposure_time;
+  int img_buffer_bytes_per_pixel;
+  int img_buffer_height;
+  size_t img_buffer_size;
+  int img_buffer_width;
+  bool initialized;
 
   ArvBuffer *arv_buffer;
   ArvCamera *arv_cam;
+  char *arv_cam_name;
+  ArvStream *arv_stream;
+  unsigned char *img_buffer;
 };
 
 #endif // !_ARAVIS_CAMERA_H_

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -58,6 +58,7 @@ public:
   int StopSequenceAcquisition();
 
   // Properties.
+  int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
   
   // Internal.

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -50,7 +50,6 @@ public:
   int SnapImage();
 
   // Continuous acquisition.
-  void AcquisitionCallback(ArvStreamCallbackType, ArvBuffer *);
   bool IsCapturing();
   int PrepareSequenceAcqusition();
   int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
@@ -62,21 +61,24 @@ public:
   int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
   
   // Internal.
+  void AcquisitionCallback(ArvStreamCallbackType, ArvBuffer *);
+  void ArvBufferUpdate(ArvBuffer *aBuffer);
   void ArvGetExposure();
-  void ArvGetBitDepth();
-  //void ArvSetBytesPerPixel(size_t size);
+  void ArvPixelFormatUpdate(guint32 arvPixelFormat);
   int ArvStartSequenceAcquisition();
 
+  
 private:
   bool capturing;
   long counter;
   double exposure_time;
-  unsigned img_bit_depth;
+  unsigned img_buffer_bit_depth;
   int img_buffer_bytes_per_pixel;
   int img_buffer_height;
+  unsigned img_buffer_number_components;
+  size_t img_buffer_number_pixels;
   size_t img_buffer_size;
   int img_buffer_width;
-  unsigned img_number_components;
   bool initialized;
 
   ArvBuffer *arv_buffer;

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -62,6 +62,8 @@ public:
   int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnBlackLevel(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnGain(MM::PropertyBase* pProp, MM::ActionType eAct);
+  int OnGamma(MM::PropertyBase* pProp, MM::ActionType eAct);
+  int OnGammaEnable(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnTriggerMode(MM::PropertyBase* pProp, MM::ActionType eAct);
   int OnTriggerSelector(MM::PropertyBase* pProp, MM::ActionType eAct);

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -6,10 +6,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 */
-
 #include "DeviceBase.h"
-#include "ImgBuffer.h"
-#include "DeviceThreads.h"
 #include "arv.h"
 #include "glib.h"
 
@@ -72,6 +69,7 @@ public:
   // Internal.
   void AcquisitionCallback(ArvStreamCallbackType, ArvBuffer *);
   void ArvBufferUpdate(ArvBuffer *aBuffer);
+  int ArvCheckError(GError *gerror) const;
   void ArvGetExposure();
   void ArvPixelFormatUpdate(guint32 arvPixelFormat);
   int ArvStartSequenceAcquisition();

--- a/DeviceAdapters/Aravis/Makefile.am
+++ b/DeviceAdapters/Aravis/Makefile.am
@@ -1,0 +1,14 @@
+
+AM_CXXFLAGS=$(MMDEVAPI_CXXFLAGS)
+
+# Linux, use output from from pkg-config (aravis-0.10).
+ARAVISCPPFLAGS = -I/usr/local/include/aravis-0.10 -I/usr/include/libxml2 -I/usr/include/libusb-1.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include
+ARAVISLDFLAGS = -Wl,--enable-new-dtags -Wl,-rpath,/usr/local/lib/x86_64-linux-gnu,-L/usr/local/lib/x86_64-linux-gnu
+ARAVISLDLIBS = -laravis-0.10 -lgio-2.0 -lgobject-2.0 -lglib-2.0
+
+deviceadapter_LTLIBRARIES=libmmgr_dal_AravisCamera.la
+libmmgr_dal_AravisCamera_la_SOURCES=AravisCamera.cpp AravisCamera.h
+libmmgr_dal_AravisCamera_la_CPPFLAGS=$(ARAVISCPPFLAGS)
+libmmgr_dal_AravisCamera_la_LIBADD=$(MMDEVAPI_LIBADD) $(ARAVISLDLIBS)
+libmmgr_dal_AravisCamera_la_LDFLAGS=$(MMDEVAPI_LDFLAGS) $(ARAVISLDLIBS) $(ARAVISLDFLAGS)
+

--- a/DeviceAdapters/Aravis/README.md
+++ b/DeviceAdapters/Aravis/README.md
@@ -2,3 +2,6 @@
 
 These device adapters add support for the [Aravis Project](https://github.com/AravisProject). The adapters have been developed and tested on 64-bit Linux with Aravis-0.10.
 
+### Note
+
+For the cameras used to test this driver there were two choices for the same camera at hardware configuration, and only one of the two choices worked as expected.

--- a/DeviceAdapters/Aravis/README.md
+++ b/DeviceAdapters/Aravis/README.md
@@ -1,0 +1,6 @@
+# MicroManager Device Adapter for the Aravis genicam based cameras vision library.
+
+## About
+
+These device adapters add support for the [Aravis Project](https://github.com/AravisProject). The adapters have been developed and tested on 64-bit Linux with Aravis-0.10.
+

--- a/DeviceAdapters/Aravis/README.md
+++ b/DeviceAdapters/Aravis/README.md
@@ -1,5 +1,3 @@
-# MicroManager Device Adapter for the Aravis genicam based cameras vision library.
-
 ## About
 
 These device adapters add support for the [Aravis Project](https://github.com/AravisProject). The adapters have been developed and tested on 64-bit Linux with Aravis-0.10.

--- a/DeviceAdapters/Makefile.am
+++ b/DeviceAdapters/Makefile.am
@@ -13,6 +13,9 @@ endif
 if BUILD_ANDORSDK3
    ANDORSDK3 = AndorSDK3
 endif
+if BUILD_ARAVIS_LINUX
+   ARAVIS = Aravis
+endif
 if BUILD_BASLER_LINUX
    BASLER = Basler
 endif
@@ -81,6 +84,7 @@ SUBDIRS = \
 	$(ANDOR) \
 	$(ANDORLASERCOMBINER) \
 	$(ANDORSDK3) \
+        $(ARAVIS) \
 	$(BASLER) \
 	$(DC1394) \
 	$(FAKECAMERA) \

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -306,6 +306,15 @@ else
    AC_MSG_RESULT([not found])
 fi
 
+# Aravis (v0.10).
+AC_MSG_CHECKING(for Aravis_Linux)
+AM_CONDITIONAL([BUILD_ARAVIS_LINUX],[test -f "/usr/local/include/aravis-0.10/arv.h"])
+if test -f "/usr/local/include/aravis-0.10/arv.h"; then
+   AC_MSG_RESULT([found])
+else 
+   AC_MSG_RESULT([not found])
+fi
+
 # BaslerPylon
 AC_MSG_CHECKING(for Basler_Linux)
 AM_CONDITIONAL([BUILD_BASLER_LINUX],[test -f "/opt/pylon/include/pylon/PylonIncludes.h"])
@@ -538,6 +547,7 @@ m4_define([device_adapter_dirs], [m4_strip([
    AndorLaserCombiner
    AndorSDK3
    Aquinas
+   Aravis
    Arduino
    Arduino32bitBoards
    Basler


### PR DESCRIPTION
This pull request adds a device adapter for the [Aravis Project](https://github.com/AravisProject) GenICam camera library. 

I'm not sure this pull request is actually ready to go in. I'm opening this pull request now to get some feedback about what else should go into the device adapter and the ways that it does not correctly conform to the MM expected camera behavior.

It has been tested with two different cameras on 64bit linux (a mono FLIR camera and a color Basler camera). It supports mono and RGB images, exposure time and binning.
