### PR TITLE
Galvo projector: adds ability to run polygons to Utilities::DAGalvo device.

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -609,7 +609,11 @@ int CDemoCamera::SnapImage()
    {
       while (exp > (GetCurrentMMTime() - startTime).getMsec())
       {
+#ifdef _WIN32
+         // SleepShort(1);
+#elif
          CDeviceUtils::SleepMs(1);
+#endif
       }		
    }
    else
@@ -2410,17 +2414,17 @@ void CDemoCamera::GenerateSyntheticImage(ImgBuffer& img, double exp)
       // this function.
       for (unsigned int i = 0; i < imgWidth; ++i)
       {
-         for (unsigned j = 0; j < img.Height(); ++j)
+         for (unsigned h = 0; h < img.Height(); ++h)
          {
             bool shouldKeep = false;
-            for (unsigned int k = 0; k < multiROIXs_.size(); ++k)
+            for (unsigned int mr = 0; mr < multiROIXs_.size(); ++mr)
             {
-               unsigned xOffset = multiROIXs_[k] - roiX_;
-               unsigned yOffset = multiROIYs_[k] - roiY_;
-               unsigned width = multiROIWidths_[k];
-               unsigned height = multiROIHeights_[k];
+               unsigned xOffset = multiROIXs_[mr] - roiX_;
+               unsigned yOffset = multiROIYs_[mr] - roiY_;
+               unsigned width = multiROIWidths_[mr];
+               unsigned height = multiROIHeights_[mr];
                if (i >= xOffset && i < xOffset + width &&
-                        j >= yOffset && j < yOffset + height)
+                        h >= yOffset && h < yOffset + height)
                {
                   // Pixel is inside an ROI.
                   shouldKeep = true;
@@ -2430,7 +2434,7 @@ void CDemoCamera::GenerateSyntheticImage(ImgBuffer& img, double exp)
             if (!shouldKeep)
             {
                // Blank the pixel.
-               long lIndex = imgWidth * j + i;
+               long lIndex = imgWidth * h + i;
                if (pixelType.compare(g_PixelType_8bit) == 0)
                {
                   *((unsigned char*) rawBuf + lIndex) = static_cast<unsigned char>(multiROIFillValue_);
@@ -4221,7 +4225,8 @@ DemoGalvo::DemoGalvo() :
    offsetX_(20),
    vMaxX_(10.0),
    offsetY_(15),
-   vMaxY_(10.0)
+   vMaxY_(10.0),
+   pulseTime_Us_(100000.0)
 {
    // handwritten 5x5 gaussian kernel, no longer used
    /*
@@ -4309,8 +4314,9 @@ int DemoGalvo::PointAndFire(double x, double y, double pulseTime_us)
    return DEVICE_OK;
 }
 
-int DemoGalvo::SetSpotInterval(double /* pulseInterval_us */) 
+int DemoGalvo::SetSpotInterval(double pulseTime_Us) 
 {
+   pulseTime_Us_ = pulseTime_Us;
    return DEVICE_OK;
 }
 
@@ -4368,17 +4374,19 @@ int DemoGalvo::SetPolygonRepetitions(int /* repetitions */)
 
 int DemoGalvo::RunPolygons()
 {
-   /*
    std::ostringstream os;
    os << "# of polygons: " << vertices_.size() << std::endl;
    for (std::map<int, std::vector<PointD> >::iterator it = vertices_.begin();
          it != vertices_.end(); ++it)
    {
       os << "ROI " << it->first << " has " << it->second.size() << " points" << std::endl;
+      // illuminate just the first point
+      this->PointAndFire(it->second.at(0).x, it->second.at(0).y, pulseTime_Us_);
+      CDeviceUtils::SleepMs((long) (pulseTime_Us_ / 1000.0));
    }
    LogMessage(os.str().c_str());
-   */
-   runROIS_ = true;
+
+   //runROIS_ = true;
    return DEVICE_OK;
 }
 

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -1191,4 +1191,5 @@ private:
    double vMaxX_;
    int offsetY_;
    double vMaxY_;
+   double pulseTime_Us_;
 };

--- a/DeviceAdapters/Utilities/DAGalvo.cpp
+++ b/DeviceAdapters/Utilities/DAGalvo.cpp
@@ -34,6 +34,7 @@
 
 #include <chrono>
 #include <thread>
+#include <vector>
 
 
 extern const char* g_NoDevice;
@@ -46,6 +47,7 @@ DAGalvo::DAGalvo() :
    pulseIntervalUs_(100000),
    initialized_(false)
 {
+   polygons_ = new std::vector<DAPolygon*>();
 }
 
 DAGalvo::~DAGalvo()
@@ -236,21 +238,40 @@ double DAGalvo::GetYMinimum()
    return yMin;
 }
 
-int DAGalvo::AddPolygonVertex(int /* polygonIndex */, double /* x */, double /* y */)
+int DAGalvo::AddPolygonVertex(int index, double x, double y)
 {
-   return DEVICE_NOT_YET_IMPLEMENTED;
+   if (index > 0) {
+      size_t nrPolygons = polygons_->size();
+      if (index < nrPolygons) {
+         DAPolygon* polygon = polygons_->at(index);
+         polygon->addVertex(x, y);
+         return true;
+      }
+      else if (index == nrPolygons) {
+         DAPolygon* polygon = new DAPolygon(x, y);
+         polygons_->push_back(polygon);
+         return true;
+      }
+   }
+   return false; // the index is more than nrPolygons and our vector does not accomodate this
 }
+
 int DAGalvo::DeletePolygons()
 {
-   return DEVICE_NOT_YET_IMPLEMENTED;
+   for (int i = 0; i < polygons_->size(); i++) {
+      delete(polygons_->at(i));
+   }
+   return polygons_->empty();
 }
+
 int DAGalvo::RunSequence()
 {
    return DEVICE_NOT_YET_IMPLEMENTED;
 }
+
 int DAGalvo::LoadPolygons()
 {
-   return DEVICE_NOT_YET_IMPLEMENTED;
+   return DEVICE_OK; // Not sure how we can benefit, this is supposed to load the polygons to the device
 }
 
 int DAGalvo::SetPolygonRepetitions(int repetitions)
@@ -262,8 +283,14 @@ int DAGalvo::SetPolygonRepetitions(int repetitions)
 
 int DAGalvo::RunPolygons()
 {
-   return DEVICE_NOT_YET_IMPLEMENTED;
+   for (int i = 0; i < polygons_->size(); i++) {
+      DAPolygon* polygon = polygons_->at(i);
+      std::pair<double, double> xyPair = polygon->getVertex(0);
+      this->PointAndFire(xyPair.first, xyPair.second, pulseIntervalUs_);
+   }
+   return DEVICE_OK;
 }
+
 int DAGalvo::StopSequence()
 {
    return DEVICE_NOT_YET_IMPLEMENTED;

--- a/DeviceAdapters/Utilities/Utilities.h
+++ b/DeviceAdapters/Utilities/Utilities.h
@@ -29,6 +29,7 @@
 #include "ImgBuffer.h"
 #include <string>
 #include <map>
+#include <vector>
 
 //////////////////////////////////////////////////////////////////////////////
 // Error codes
@@ -632,6 +633,37 @@ private:
    MM::MMTime lastChangeTime_;
 };
 
+class DAPolygon
+{
+private:
+   std::vector<std::pair<double, double>> polygon_;
+public:
+   DAPolygon(double x, double y) {
+      polygon_.push_back(std::make_pair(x, y));
+   }
+   void addVertex(double x, double y) {
+      polygon_.push_back(std::make_pair(x, y));
+   }
+
+   boolean hasVertex(size_t index) {
+      return polygon_.size() <= index + 1;
+   }
+
+   std::pair<double, double> getVertex(size_t index) {
+      if (polygon_.size() <= index + 1) {
+         return polygon_[index];
+      }
+      else { 
+         // TODO: throw exception
+      }
+   }
+
+   size_t getNumberOfVertices() {
+      return polygon_.size();
+   }
+};
+
+      
 
 class DAGalvo : public CGalvoBase<DAGalvo>
 {
@@ -673,6 +705,7 @@ private:
    long nrRepetitions_;
    double pulseIntervalUs_;
    std::string shutter_;
+   std::vector<DAPolygon*> *polygons_;
 
 };
 


### PR DESCRIPTION
There is ample ambiguity who controls the shutter and channel config while photo-targetting, the UI code or the device adapter.

We should discuss the best path forward, but in the mean time this works.