### PR TITLE
Move `onPropertyChanged("Core"`  calls to their respective setters

### DIFF
--- a/MMCore/CoreProperty.cpp
+++ b/MMCore/CoreProperty.cpp
@@ -166,6 +166,10 @@ void CorePropertyCollection::Execute(const char* propName, const char* value)
       // should never get here...
       assert(!"Unable to execute set property command.\n");
    }
+   
+   // Note to developers. If you add a new propName case here, you must add a corresponding
+   // externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice
+   // call to respective core_->setX method
 }
 
 std::string CorePropertyCollection::Get(const char* propName) const

--- a/MMCore/CoreProperty.cpp
+++ b/MMCore/CoreProperty.cpp
@@ -166,11 +166,6 @@ void CorePropertyCollection::Execute(const char* propName, const char* value)
       // should never get here...
       assert(!"Unable to execute set property command.\n");
    }
-
-   if (core_->externalCallback_)
-   {
-      core_->externalCallback_->onPropertyChanged("Core", propName, value); 
-   }
 }
 
 std::string CorePropertyCollection::Get(const char* propName) const

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -804,6 +804,9 @@ void CMMCore::unloadAllDevices() throw (CMMError)
       logError("MMCore::unloadAllDevices", err.getMsg().c_str());
       throw;
    }
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreInitialize, "0");
+   }
 }
 
 /**
@@ -871,6 +874,9 @@ void CMMCore::initializeAllDevices() throw (CMMError)
    LOG_INFO(coreLogger_) << "Finished initializing " << devices.size() << " devices";
 
    updateCoreProperties();
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreInitialize, "1");
+   }
 }
 
 /**
@@ -2424,6 +2430,9 @@ void CMMCore::setAutoShutter(bool state)
       stateCache_.addSetting(PropertySetting(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreAutoShutter, state ? "1" : "0"));
    }
    LOG_DEBUG(coreLogger_) << "Autoshutter turned " << (state ? "on" : "off");
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreAutoShutter, state ? "1" : "0");
+   }
 }
 
 /**
@@ -3250,6 +3259,9 @@ void CMMCore::setAutoFocusDevice(const char* autofocusLabel) throw (CMMError)
       MMThreadGuard scg(stateCacheLock_);
       stateCache_.addSetting(PropertySetting(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreAutoFocus, newAutofocusLabel.c_str()));
    }
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreAutoFocus, newAutofocusLabel.c_str());
+   }
 }
 
 /**
@@ -3317,6 +3329,9 @@ void CMMCore::setImageProcessorDevice(const char* procLabel) throw (CMMError)
       MMThreadGuard scg(stateCacheLock_);
       stateCache_.addSetting(PropertySetting(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreImageProcessor, newProcLabel.c_str()));
    }
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreImageProcessor, newProcLabel.c_str());
+   }
 }
 
 /**
@@ -3340,6 +3355,9 @@ void CMMCore::setSLMDevice(const char* slmLabel) throw (CMMError)
    {
       MMThreadGuard scg(stateCacheLock_);
       stateCache_.addSetting(PropertySetting(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreSLM, newSLMLabel.c_str()));
+   }
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreSLM, newSLMLabel.c_str());
    }
 }
 
@@ -3365,6 +3383,9 @@ void CMMCore::setGalvoDevice(const char* galvoLabel) throw (CMMError)
    {
       MMThreadGuard scg(stateCacheLock_);
       stateCache_.addSetting(PropertySetting(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreGalvo, newGalvoLabel.c_str()));
+   }
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreGalvo, newGalvoLabel.c_str());
    }
 }
 
@@ -3396,6 +3417,7 @@ void CMMCore::setChannelGroup(const char* chGroup) throw (CMMError)
    if (externalCallback_ != 0) 
    {
       externalCallback_->onChannelGroupChanged(channelGroup_.c_str());
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreChannelGroup, channelGroup_.c_str());
    }
 }
 
@@ -3455,6 +3477,9 @@ void CMMCore::setShutterDevice(const char* shutterLabel) throw (CMMError)
       MMThreadGuard scg(stateCacheLock_);
       stateCache_.addSetting(PropertySetting(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreShutter, newShutterLabel.c_str()));
    }
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreShutter, newShutterLabel.c_str());
+   }
 }
 
 /**
@@ -3480,6 +3505,9 @@ void CMMCore::setFocusDevice(const char* focusLabel) throw (CMMError)
       MMThreadGuard scg(stateCacheLock_);
       stateCache_.addSetting(PropertySetting(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreFocus, newFocusLabel.c_str()));
    }
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreFocus, newFocusLabel.c_str());
+   }
 }
 
 /**
@@ -3502,6 +3530,9 @@ void CMMCore::setXYStageDevice(const char* xyDeviceLabel) throw (CMMError)
    {
       MMThreadGuard scg(stateCacheLock_);
       stateCache_.addSetting(PropertySetting(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreXYStage, newXYStageLabel.c_str()));
+   }
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreXYStage, newXYStageLabel.c_str());
    }
 }
 
@@ -3541,6 +3572,9 @@ void CMMCore::setCameraDevice(const char* cameraLabel) throw (CMMError)
    {
       MMThreadGuard scg(stateCacheLock_);
       stateCache_.addSetting(PropertySetting(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreCamera, newCameraLabel.c_str()));
+   }
+   if (externalCallback_) {
+      externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreCamera, newCameraLabel.c_str());
    }
 }
 
@@ -4223,6 +4257,17 @@ double CMMCore::getExposure(const char* label) throw (CMMError)
   }
   else
      return 0.0;
+}
+
+
+void CMMCore::setTimeoutMs(long timeoutMs)
+{
+   if (timeoutMs > 0) {
+      timeoutMs_ = timeoutMs;
+      if (externalCallback_) {
+         externalCallback_->onPropertyChanged(MM::g_Keyword_CoreDevice, MM::g_Keyword_CoreTimeoutMs, std::to_string(timeoutMs).c_str());
+      }
+   }
 }
 
 /**

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -261,7 +261,7 @@ public:
    void setDeviceDelayMs(const char* label, double delayMs) throw (CMMError);
    bool usesDeviceDelay(const char* label) throw (CMMError);
 
-   void setTimeoutMs(long timeoutMs) {if (timeoutMs > 0) timeoutMs_ = timeoutMs;}
+   void setTimeoutMs(long timeoutMs);
    long getTimeoutMs() { return timeoutMs_;}
 
    void sleep(double intervalMs) const;


### PR DESCRIPTION
currently, if you. call `core.setProperty("Core", ...)` you will get a `onPropertyChanged("Core"` callback.  However, if you directly call the setter method called by `CorePropertyCollection::Execute`, the end result is the same, but you don't get a callback.  This moves the callbacks inside the setter methods.  It's unfortunately more code, but it makes callbacks more consistent with internal state.