### PR TITLE
Add algorithm include  to CoreCallback.cpp

### DIFF
--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -36,6 +36,7 @@
 #include <chrono>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 
 CoreCallback::CoreCallback(CMMCore* c) :


### PR DESCRIPTION
CoreCallback.cpp uses std::min but doesn't include `<algorithm>`, this can cause compile time errors (though I've only seen those errors on Windows)