### PR TITLE
Nidaq: adds property indicating whether sequences transitions happen at the beginning or end of exposure

### DIFF
--- a/DeviceAdapters/NIDAQ/NIAnalogOutputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIAnalogOutputPort.cpp
@@ -199,6 +199,16 @@ int NIAnalogOutputPort::StartDASequence()
    if (task_)
       StopTask();
 
+   // probably beneficial in all cases to move to the first position,
+   // essential if we are transitioning post-exposure
+   double volt0 = sentSequence_[0];
+   SetSignal(volt0);
+
+   if (transitionPostExposure_) {
+      for (int i = 0; i < sentSequence_.size() - 1; i++) {
+         sentSequence_[i] = sentSequence_[i + 1];
+      }
+   }
    sequenceRunning_ = true;
 
    int err = GetHub()->StartAOSequenceForPort(niPort_, sentSequence_);

--- a/DeviceAdapters/NIDAQ/NIDAQ.cpp
+++ b/DeviceAdapters/NIDAQ/NIDAQ.cpp
@@ -37,9 +37,10 @@ const char* g_On = "On";
 const char* g_Off = "Off";
 const char* g_Low = "Low";
 const char* g_High = "High";
-
 const char* g_Never = "Never";
 const char* g_UseHubSetting = "Use hub setting";
+const char* g_Post = "Post";
+const char* g_Pre = "Pre";
 
 const int ERR_SEQUENCE_RUNNING = 2001;
 const int ERR_SEQUENCE_TOO_LONG = 2002;

--- a/DeviceAdapters/NIDAQ/NIDAQ.h
+++ b/DeviceAdapters/NIDAQ/NIDAQ.h
@@ -39,8 +39,9 @@ extern const char* g_On;
 extern const char* g_Off;
 extern const char* g_Low;
 extern const char* g_High;
-
 extern const char* g_Never;
+extern const char* g_Pre;
+extern const char* g_Post;
 extern const char* g_UseHubSetting;
 
 extern const int ERR_SEQUENCE_RUNNING;
@@ -286,6 +287,7 @@ private:
    int OnMinVolts(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnMaxVolts(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnSequenceable(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnSequenceTransition(MM::PropertyBase* pProp, MM::ActionType eAct);
 
    // Post-init property action handlers
    int OnVoltage(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -309,6 +311,8 @@ private:
    double minVolts_; // User-selected for this port
    double maxVolts_; // User-selected for this port
    bool neverSequenceable_;
+   bool transitionPostExposure_; // when to transition in a sequence, not that we always transition on a rising flank
+      // it can be advantaguous to transition post exposure, in which case we have to modify our sequence 
 
    TaskHandle task_;
 


### PR DESCRIPTION
Also puts the analog output always at the first position when starting a sequence. When the property indicates the transition happens at the end of exposure, we move the first position of the sequence to the end (i.e. move everything else forward by one position).  Works in practice. Default is the old behavior.