### PR TITLE
Spinnaker device: Adding the Mirroring X and Y functions

### DIFF
--- a/DeviceAdapters/Spinnaker/SpinnakerCamera.cpp
+++ b/DeviceAdapters/Spinnaker/SpinnakerCamera.cpp
@@ -403,6 +403,8 @@ int SpinnakerCamera::Initialize()
    CreatePropertyFromFloat("Gamma", m_cam->Gamma, &SpinnakerCamera::OnGamma);
    CreatePropertyFromFloat("Black Level", m_cam->BlackLevel, &SpinnakerCamera::OnBlackLevel);
    CreatePropertyFromEnum("Black Level Auto", m_cam->BlackLevelAuto, &SpinnakerCamera::OnBlackLevelAuto);
+   CreatePropertyFromBool("Reverse X", m_cam->ReverseX, &SpinnakerCamera::OnReverseX);
+   CreatePropertyFromBool("Reverse Y", m_cam->ReverseY, &SpinnakerCamera::OnReverseY);
 
    try
    {


### PR DESCRIPTION
Minor add on:
The FLIR cameras have the methods for `ReverseX` and  `ReverseY`, but these were not exposed as properties. One could take care of this through post processing, but for getting proper `live_view` it's useful. 

This was tested on Blackfly and Oryx cameras. 