### PR TITLE
NIDAQ: set more logical internal limit for sequence buffer size.

### DIFF
--- a/DeviceAdapters/NIDAQ/NIAnalogOutputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIAnalogOutputPort.cpp
@@ -199,6 +199,12 @@ int NIAnalogOutputPort::StartDASequence()
    if (task_)
       StopTask();
 
+   // not checkint the size of the array will lead to a crash in the next line
+   if (sentSequence_.size() < 1) {
+      // Do we neet to return an error code?  Probably...
+      return DEVICE_OK;
+   }
+
    // probably beneficial in all cases to move to the first position,
    // essential if we are transitioning post-exposure
    double volt0 = sentSequence_[0];

--- a/DeviceAdapters/NIDAQ/NIDAQ.cpp
+++ b/DeviceAdapters/NIDAQ/NIDAQ.cpp
@@ -529,9 +529,7 @@ std::string NIDAQHub::GetPhysicalChannelListForSequencing(std::vector<std::strin
 template<typename T>
 inline int NIDAQHub::GetLCMSamplesPerChannel(size_t& seqLen, std::vector<std::vector<T>> channelSequences) const
 {
-   // Use an arbitrary but reasonable limit to prevent
-   // overflow or excessive memory consumption.
-   const uint64_t factorLimit = 2 << 14;
+   const uint64_t factorLimit = channelSequences.size() * maxSequenceLength_;
 
    uint64_t len = 1;
    for (unsigned int i = 0; i < channelSequences.size(); ++i)


### PR DESCRIPTION
Also avoids crash when starting a DA sequence of size 0.