### PR TITLE
ASITiger: reduce serial traffic for PLogic

### DIFF
--- a/DeviceAdapters/ASITiger/ASIPLogic.cpp
+++ b/DeviceAdapters/ASITiger/ASIPLogic.cpp
@@ -525,7 +525,7 @@ int CPLogic::OnPLogicOutputState(MM::PropertyBase* pProp, MM::ActionType eAct)
    if (eAct == MM::BeforeGet || eAct == MM::AfterSet)
    {
       // always read
-      command << addressChar_ << "RDADC Z?";
+      command << addressChar_ << "RA Z?";
       RETURN_ON_MM_ERROR ( hub_->QueryCommandVerify(command.str(), ":A") );
       RETURN_ON_MM_ERROR ( hub_->ParseAnswerAfterPosition2(val) );
       if (!pProp->Set((long)val))
@@ -541,7 +541,7 @@ int CPLogic::OnPLogicOutputStateUpper(MM::PropertyBase* pProp, MM::ActionType eA
    if (eAct == MM::BeforeGet || eAct == MM::AfterSet)
    {
       // always read
-      command << addressChar_ << "RDADC F?";
+      command << addressChar_ << "RA F?";
       RETURN_ON_MM_ERROR ( hub_->QueryCommandVerify(command.str(), ":A") );
       RETURN_ON_MM_ERROR ( hub_->ParseAnswerAfterPosition2(val) );
       if (!pProp->Set((long)val))
@@ -557,7 +557,7 @@ int CPLogic::OnFrontpanelOutputState(MM::PropertyBase* pProp, MM::ActionType eAc
    if (eAct == MM::BeforeGet || eAct == MM::AfterSet)
    {
       // always read
-      command << addressChar_ << "RDADC X?";
+      command << addressChar_ << "RA X?";
       RETURN_ON_MM_ERROR ( hub_->QueryCommandVerify(command.str(), ":A") );
       RETURN_ON_MM_ERROR ( hub_->ParseAnswerAfterPosition2(val) );
       if (!pProp->Set((long)val))
@@ -573,7 +573,7 @@ int CPLogic::OnBackplaneOutputState(MM::PropertyBase* pProp, MM::ActionType eAct
    if (eAct == MM::BeforeGet || eAct == MM::AfterSet)
    {
       // always read
-      command << addressChar_ << "RDADC Y?";
+      command << addressChar_ << "RA Y?";
       RETURN_ON_MM_ERROR ( hub_->QueryCommandVerify(command.str(), ":A") );
       RETURN_ON_MM_ERROR ( hub_->ParseAnswerAfterPosition2(val) );
       if (!pProp->Set((long)val))


### PR DESCRIPTION
Use the RA shortcut for the RDADC serial command. These values are always read even when the "RefreshPropertyValues" property is set to "No". This saves 9 bytes sent per serial command on PLOGIC_16 builds and 12 bytes on PLOGIC_24 builds.