### PR TITLE
Revert pull request #476

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -7526,19 +7526,11 @@ MM::DeviceDetectionStatus CMMCore::detectDevice(const char* label)
  * device. Doing otherwise results in undefined behavior. This function was
  * intended for use during initial configuration, not routine loading of
  * devices. These restrictions may be relaxed in the future if possible.
- * 
- * Throws an exception if the hub device is not initialized.
  *
  * @param hubDeviceLabel    the label for the device of type Hub
  */
 std::vector<std::string> CMMCore::getInstalledDevices(const char* hubDeviceLabel) throw (CMMError)
 {
-   if (isFeatureEnabled("StrictInitializationChecks")) {
-      if (getDeviceInitializationState(hubDeviceLabel) == DeviceInitializationState::Uninitialized) {
-         throw CMMError("Device " + ToQuotedString(hubDeviceLabel) + " is not yet initialized.");
-      }
-   }
-
    std::shared_ptr<HubInstance> pHub =
       deviceManager_->GetDeviceOfType<HubInstance>(hubDeviceLabel);
 


### PR DESCRIPTION
The check for an initialized hub was already in HubInstance.

@tlambert03 Sorry I missed this while reviewing #476. See
https://github.com/micro-manager/mmCoreAndDevices/blob/36c45e604a6a58dd08427c542881e029d419c5a1/MMCore/Devices/HubInstance.cpp#L36
which is in the code path of `getInstalledDevices()`.

Is it possible that the above check is not functioning (with the `StrictInitializationChecks` feature enabled)? If so, let me know how to reproduce. It should also log a warning with the feature disabled.