### PR TITLE
CI: use macos-12 for the experimental Meson build

### DIFF
--- a/.github/workflows/ci-mmdevice-mmcore.yml
+++ b/.github/workflows/ci-mmdevice-mmcore.yml
@@ -30,7 +30,7 @@ jobs:
             runner: windows-2019
             cxx: cl
           - os: macos
-            runner: macos-11
+            runner: macos-12
             cxx: clang++
           - os: ubuntu
             runner: ubuntu-22.04


### PR DESCRIPTION
The macos-11 runner is deprecated and has started to fail.