### PR TITLE
MMDevice: Allow compilation with C++17

### DIFF
--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1562,7 +1562,7 @@ protected:
    virtual long GetNumberOfImages() {return thd_->GetNumberOfImages();}
 
    // called from the thread function before exit
-   virtual void OnThreadExiting() throw()
+   virtual void OnThreadExiting()
    {
       try
       {
@@ -1668,7 +1668,7 @@ protected:
       void UpdateActualDuration() {actualDuration_ = camera_->GetCurrentMMTime() - startTime_;}
 
    private:
-      virtual int svc(void) throw()
+      virtual int svc()
       {
          int ret=DEVICE_ERR;
          try

--- a/MMDevice/ImageMetadata.h
+++ b/MMDevice/ImageMetadata.h
@@ -22,17 +22,6 @@
 
 #pragma once
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4290) // 'C++ exception specification ignored'
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#endif
-
 #include "MMDeviceConstants.h"
 
 #include <string>
@@ -41,6 +30,12 @@
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
+
+#ifdef SWIG
+#define MMDEVICE_LEGACY_THROW(ex) throw (ex)
+#else
+#define MMDEVICE_LEGACY_THROW(ex)
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // MetadataError
@@ -326,14 +321,14 @@ public:
          return false;
    }
 
-   MetadataSingleTag GetSingleTag(const char* key) const throw (MetadataKeyError)
+   MetadataSingleTag GetSingleTag(const char* key) const MMDEVICE_LEGACY_THROW(MetadataKeyError)
    {
       MetadataTag* tag = FindTag(key);
       const MetadataSingleTag* stag = tag->ToSingleTag();
       return *stag;
    }
 
-   MetadataArrayTag GetArrayTag(const char* key) const throw (MetadataKeyError)
+   MetadataArrayTag GetArrayTag(const char* key) const MMDEVICE_LEGACY_THROW(MetadataKeyError)
    {
       MetadataTag* tag = FindTag(key);
       const MetadataArrayTag* atag = tag->ToArrayTag();
@@ -499,11 +494,3 @@ private:
    typedef std::map<std::string, MetadataTag*>::iterator TagIter;
    typedef std::map<std::string, MetadataTag*>::const_iterator TagConstIter;
 };
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif


### PR DESCRIPTION
This allows individual device adapters to be compiled with C++17 (as opposed to our current default of C++14) without encountering warnings or errors due to obsolete [dynamic exception specifications](https://en.cppreference.com/w/cpp/language/except_spec) (which we still keep for use by our SWIG Java bindings).

See #159 for more on C++17 support status.

- Remove pointless `throw ()` from two functions.

- Wrap remaining dynamic exception specifications (2 occurrences) in macro, which expands to nothing unless read by SWIG.

- Removed the warning suppressions related to dynamic exception specifications.

- Confirmed, using japicmp, that the MMCoreJ API did not change (tested with SWIG 3, Linux).

- There is no C++ MMDevice ABI change because dynamic exception specifications are not part of the ABI (so no increment of device interface version).