### PR TITLE
Fix two typos

### DIFF
--- a/DeviceAdapters/AmScope/AmScope.cpp
+++ b/DeviceAdapters/AmScope/AmScope.cpp
@@ -694,7 +694,7 @@ int AmScope::SetBinning(int binF)
    return SetProperty("Binning-Software", CDeviceUtils::ConvertToString(binF));
 }
 
-//int AmScope::PrepareSequenceAcqusition()
+//int AmScope::PrepareSequenceAcquisition()
 //{
 //   if (IsCapturing())
 //      return DEVICE_CAMERA_BUSY_ACQUIRING;

--- a/DeviceAdapters/AmScope/AmScope.h
+++ b/DeviceAdapters/AmScope/AmScope.h
@@ -54,7 +54,7 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
-   //int PrepareSequenceAcqusition();
+   //int PrepareSequenceAcquisition();
    int StartSequenceAcquisition(double interval);
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();

--- a/DeviceAdapters/Andor/Andor.h
+++ b/DeviceAdapters/Andor/Andor.h
@@ -110,7 +110,7 @@ public:
    void ResizeSRRFImage(long radiality);
 
    // high-speed interface
-   int PrepareSequenceAcqusition()
+   int PrepareSequenceAcquisition()
    { 
       return DEVICE_OK; 
    }

--- a/DeviceAdapters/AndorSDK3/AndorSDK3.h
+++ b/DeviceAdapters/AndorSDK3/AndorSDK3.h
@@ -101,7 +101,7 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
-   int PrepareSequenceAcqusition() {return DEVICE_OK;}
+   int PrepareSequenceAcquisition() {return DEVICE_OK;}
    int StartSequenceAcquisition(double interval);
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -1076,7 +1076,7 @@ int AravisCamera::OnTriggerSource(MM::PropertyBase* pProp, MM::ActionType eAct)
 }
 
 
-int AravisCamera::PrepareSequenceAcqusition()
+int AravisCamera::PrepareSequenceAcquisition()
 {
    return DEVICE_OK;
 }

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -172,7 +172,7 @@ void AravisCamera::AcquisitionCallback(ArvStreamCallbackType type, ArvBuffer *cb
     md.put(MM::g_Keyword_Metadata_ROI_X, CDeviceUtils::ConvertToString((long)img_buffer_width));
     md.put(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString((long)img_buffer_height));
     md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(counter));
-    md.put(MM::g_Keyword_Meatdata_Exposure, exposure_time);
+    md.put(MM::g_Keyword_Metadata_Exposure, exposure_time);
     md.put(MM::g_Keyword_PixelType, pixel_type);
     
     // Pass data to MM.

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -77,7 +77,7 @@ public:
 
   // Continuous acquisition.
   bool IsCapturing();
-  int PrepareSequenceAcqusition();
+  int PrepareSequenceAcquisition();
   int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
   int StartSequenceAcquisition(double interval_ms);
   int StopSequenceAcquisition();

--- a/DeviceAdapters/ArduinoCounter/ArduinoCounter.cpp
+++ b/DeviceAdapters/ArduinoCounter/ArduinoCounter.cpp
@@ -492,7 +492,7 @@ int ArduinoCounterCamera::ClearROI()
    return DEVICE_OK;
 }
 
-int ArduinoCounterCamera::PrepareSequenceAcqusition()
+int ArduinoCounterCamera::PrepareSequenceAcquisition()
 {
    if (nrCamerasInUse_ < 1)
       return ERR_NO_PHYSICAL_CAMERA;
@@ -502,7 +502,7 @@ int ArduinoCounterCamera::PrepareSequenceAcqusition()
       MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
       if (camera != 0)
       {
-         int ret = camera->PrepareSequenceAcqusition();
+         int ret = camera->PrepareSequenceAcquisition();
          if (ret != DEVICE_OK)
             return ret;
       }

--- a/DeviceAdapters/ArduinoCounter/ArduinoCounter.h
+++ b/DeviceAdapters/ArduinoCounter/ArduinoCounter.h
@@ -96,7 +96,7 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
    int ClearROI();
-   int PrepareSequenceAcqusition();
+   int PrepareSequenceAcquisition();
    int StartSequenceAcquisition(double interval);
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();

--- a/DeviceAdapters/Atik/Atik.cpp
+++ b/DeviceAdapters/Atik/Atik.cpp
@@ -823,7 +823,7 @@ int Atik::SetBinning(int binF)
 	return SetProperty(MM::g_Keyword_Binning, CDeviceUtils::ConvertToString(binF));
 }
 
-int Atik::PrepareSequenceAcqusition()
+int Atik::PrepareSequenceAcquisition()
 {
 	//log("");
 	if (IsCapturing())

--- a/DeviceAdapters/Atik/Atik.h
+++ b/DeviceAdapters/Atik/Atik.h
@@ -64,7 +64,7 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
-   int PrepareSequenceAcqusition();
+   int PrepareSequenceAcquisition();
    int StartSequenceAcquisition(double interval);
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();

--- a/DeviceAdapters/Basler/BaslerPylonCamera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylonCamera.cpp
@@ -2131,7 +2131,7 @@ void CircularBufferInserter::OnImageGrabbed(CInstantCamera& /* camera */, const 
 	md.put(MM::g_Keyword_Metadata_ROI_X, CDeviceUtils::ConvertToString((long)ptrGrabResult->GetWidth()));
 	md.put(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString((long)ptrGrabResult->GetHeight()));
 	md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString((long)ptrGrabResult->GetImageNumber()));
-	md.put(MM::g_Keyword_Meatdata_Exposure, dev_->GetExposure());
+	md.put(MM::g_Keyword_Metadata_Exposure, dev_->GetExposure());
 	// Image grabbed successfully?
 	if (ptrGrabResult->GrabSucceeded())
 	{

--- a/DeviceAdapters/Basler/BaslerPylonCamera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylonCamera.cpp
@@ -1237,7 +1237,7 @@ int BaslerCamera::StopSequenceAcquisition()
 	return DEVICE_OK;
 }
 
-int BaslerCamera::PrepareSequenceAcqusition()
+int BaslerCamera::PrepareSequenceAcquisition()
 {
 	// nothing to prepare
 	return DEVICE_OK;

--- a/DeviceAdapters/Basler/BaslerPylonCamera.h
+++ b/DeviceAdapters/Basler/BaslerPylonCamera.h
@@ -115,7 +115,7 @@ public:
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StartSequenceAcquisition(double interval_ms);
 	int StopSequenceAcquisition();
-	int PrepareSequenceAcqusition();
+	int PrepareSequenceAcquisition();
 
 	/**
 	* Flag to indicate whether Sequence Acquisition is currently running.

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
@@ -1863,7 +1863,7 @@ void CircularBufferInserter::DoOnImageCaptured(CImageDataPointer& objImageDataPo
     md.put(MM::g_Keyword_Metadata_ROI_X, CDeviceUtils::ConvertToString((long)objImageDataPointer->GetWidth()));
     md.put(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString((long)objImageDataPointer->GetHeight()));
     md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString((long)objImageDataPointer->GetFrameID()));
-    md.put(MM::g_Keyword_Meatdata_Exposure, dev_->GetExposure());
+    md.put(MM::g_Keyword_Metadata_Exposure, dev_->GetExposure());
     // Image grabbed successfully ?
     if (objImageDataPointer->GetStatus()== GX_FRAME_STATUS_SUCCESS)
     {

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
@@ -852,9 +852,9 @@ int ClassGalaxy::StopSequenceAcquisition()
     return DEVICE_OK;
 }
 
-int ClassGalaxy::PrepareSequenceAcqusition()
+int ClassGalaxy::PrepareSequenceAcquisition()
 {
-    AddToLog("PrepareSequenceAcqusition");
+    AddToLog("PrepareSequenceAcquisition");
     // nothing to prepare
     return DEVICE_OK;
 }

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.h
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.h
@@ -98,7 +98,7 @@ public:
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow) final ;
 	int StartSequenceAcquisition(double interval_ms) final;
 	int StopSequenceAcquisition() final;
-	int PrepareSequenceAcqusition() final;
+	int PrepareSequenceAcquisition() final;
 
 	///**
 	//* Flag to indicate whether Sequence Acquisition is currently running.

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -148,7 +148,7 @@ public:
            unsigned numROIs);
    int GetMultiROI(unsigned* xs, unsigned* ys, unsigned* widths,
            unsigned* heights, unsigned* length);
-   int PrepareSequenceAcqusition() { return DEVICE_OK; }
+   int PrepareSequenceAcquisition() { return DEVICE_OK; }
    int StartSequenceAcquisition(double interval);
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();

--- a/DeviceAdapters/FLICamera/FLICamera.cpp
+++ b/DeviceAdapters/FLICamera/FLICamera.cpp
@@ -716,7 +716,7 @@ int CFLICamera::OnExposure(MM::PropertyBase* pProp, MM::ActionType eAct)
 	return ret; 
 }
 
-int CFLICamera::PrepareSequenceAcqusition()
+int CFLICamera::PrepareSequenceAcquisition()
 {
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/FLICamera/FLICamera.h
+++ b/DeviceAdapters/FLICamera/FLICamera.h
@@ -58,7 +58,7 @@ class CFLICamera : public CCameraBase<CFLICamera>
 		int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
 		int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
 		int ClearROI();
-		int PrepareSequenceAcqusition();
+		int PrepareSequenceAcquisition();
 		double GetNominalPixelSizeUm() const;
 		double GetPixelSizeUm() const;
 		int GetBinning() const;

--- a/DeviceAdapters/GigECamera/GigECamera.h
+++ b/DeviceAdapters/GigECamera/GigECamera.h
@@ -182,7 +182,7 @@ public:
 	int ClearROI();
 
 	// sequence-acquisition-related functions
-	int PrepareSequenceAcqusition() { return DEVICE_OK; }
+	int PrepareSequenceAcquisition() { return DEVICE_OK; }
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StopSequenceAcquisition();
 	bool IsCapturing();

--- a/DeviceAdapters/Hikrobot/HikrobotCamera.cpp
+++ b/DeviceAdapters/Hikrobot/HikrobotCamera.cpp
@@ -1611,7 +1611,7 @@ int HikrobotCamera::StopSequenceAcquisition()
 	return DEVICE_OK;
 }
 
-int HikrobotCamera::PrepareSequenceAcqusition()
+int HikrobotCamera::PrepareSequenceAcquisition()
 {
 	// nothing to prepare
 	return DEVICE_OK;

--- a/DeviceAdapters/Hikrobot/HikrobotCamera.h
+++ b/DeviceAdapters/Hikrobot/HikrobotCamera.h
@@ -119,7 +119,7 @@ public:
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StartSequenceAcquisition(double interval_ms);
 	int StopSequenceAcquisition();
-	int PrepareSequenceAcqusition();
+	int PrepareSequenceAcquisition();
 
 	/**
 	* Flag to indicate whether Sequence Acquisition is currently running.

--- a/DeviceAdapters/IDSPeak/IDSPeak.h
+++ b/DeviceAdapters/IDSPeak/IDSPeak.h
@@ -150,7 +150,7 @@ public:
         unsigned numROIs);
     int GetMultiROI(unsigned* xs, unsigned* ys, unsigned* widths,
         unsigned* heights, unsigned* length);
-    int PrepareSequenceAcqusition() { return DEVICE_OK; }
+    int PrepareSequenceAcquisition() { return DEVICE_OK; }
     int StartSequenceAcquisition(double interval);
     int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
     int StopSequenceAcquisition();

--- a/DeviceAdapters/IDS_uEye/IDS_uEye.h
+++ b/DeviceAdapters/IDS_uEye/IDS_uEye.h
@@ -256,7 +256,7 @@ class CIDS_uEye : public CCameraBase<CIDS_uEye>
   int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
   int ClearROI();
   
-  int PrepareSequenceAcqusition()
+  int PrepareSequenceAcquisition()
   {
     return DEVICE_OK;
   }

--- a/DeviceAdapters/JAI/JAI.cpp
+++ b/DeviceAdapters/JAI/JAI.cpp
@@ -749,7 +749,7 @@ int JAICamera::ClearROI()
 	return ResizeImageBuffer();
 }
 
-int JAICamera::PrepareSequenceAcqusition()
+int JAICamera::PrepareSequenceAcquisition()
 {
    if (IsCapturing())
    {

--- a/DeviceAdapters/JAI/JAI.h
+++ b/DeviceAdapters/JAI/JAI.h
@@ -171,7 +171,7 @@ public:
 
    // overrides the same in the base class
    int InsertImage();
-   int PrepareSequenceAcqusition();
+   int PrepareSequenceAcquisition();
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StartSequenceAcquisition(double interval);
    int StopSequenceAcquisition(); 

--- a/DeviceAdapters/Lumenera/LumeneraCamera.cpp
+++ b/DeviceAdapters/Lumenera/LumeneraCamera.cpp
@@ -1277,7 +1277,7 @@ int LumeneraCamera::StopSequenceAcquisition()
 	return DEVICE_OK;
 }
 
-int LumeneraCamera::PrepareSequenceAcqusition()
+int LumeneraCamera::PrepareSequenceAcquisition()
 {
 	// nothing to prepare
 	return DEVICE_OK;

--- a/DeviceAdapters/Lumenera/LumeneraCamera.h
+++ b/DeviceAdapters/Lumenera/LumeneraCamera.h
@@ -125,7 +125,7 @@ public:
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StartSequenceAcquisition(double interval_ms);
 	int StopSequenceAcquisition();
-	int PrepareSequenceAcqusition();
+	int PrepareSequenceAcquisition();
 	bool IsCapturing();
 
 

--- a/DeviceAdapters/MatrixVision/mvIMPACT_Acquire_Device.h
+++ b/DeviceAdapters/MatrixVision/mvIMPACT_Acquire_Device.h
@@ -96,7 +96,7 @@ public:
       return SetProperty( MM::g_Keyword_Binning, CDeviceUtils::ConvertToString( binSize ) );
    }
 
-   virtual int PrepareSequenceAcqusition( void )
+   virtual int PrepareSequenceAcquisition( void )
    {
       return DEVICE_OK;
    }

--- a/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.h
+++ b/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.h
@@ -84,7 +84,7 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
-   int PrepareSequenceAcqusition()
+   int PrepareSequenceAcquisition()
    {
       return DEVICE_OK;
    }

--- a/DeviceAdapters/Motic/MoticCamera.cpp
+++ b/DeviceAdapters/Motic/MoticCamera.cpp
@@ -739,10 +739,10 @@ int CMoticCamera::SetBinning(int binF)
   return SetProperty(MM::g_Keyword_Binning, CDeviceUtils::ConvertToString(binF));
 }
 
-int CMoticCamera::PrepareSequenceAcqusition()
+int CMoticCamera::PrepareSequenceAcquisition()
 {
 #ifdef _LOG_OUT_
-  OutputDebugString("PrepareSequenceAcqusition");
+  OutputDebugString("PrepareSequenceAcquisition");
 #endif
    if (IsCapturing())
       return DEVICE_CAMERA_BUSY_ACQUIRING;
@@ -751,7 +751,7 @@ int CMoticCamera::PrepareSequenceAcqusition()
    if (ret != DEVICE_OK)
       return ret;
 #ifdef _LOG_OUT_
-   OutputDebugString("PrepareSequenceAcqusition OK");
+   OutputDebugString("PrepareSequenceAcquisition OK");
 #endif
    return DEVICE_OK;
 }

--- a/DeviceAdapters/Motic/MoticCamera.h
+++ b/DeviceAdapters/Motic/MoticCamera.h
@@ -83,7 +83,7 @@ public:
   int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
   int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
   int ClearROI();
-  int PrepareSequenceAcqusition();
+  int PrepareSequenceAcquisition();
   //int StartSequenceAcquisition(double interval);
  // int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
  // int StopSequenceAcquisition();

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.h
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.h
@@ -97,7 +97,7 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
-   int PrepareSequenceAcqusition()
+   int PrepareSequenceAcquisition()
    {
          return DEVICE_OK;
    }

--- a/DeviceAdapters/PCO_Generic/MicroManager.cpp
+++ b/DeviceAdapters/PCO_Generic/MicroManager.cpp
@@ -2227,7 +2227,7 @@ int CPCOCam::ResizeImageBuffer()
   return DEVICE_OK;
 }
 
-int CPCOCam::PrepareSequenceAcqusition()
+int CPCOCam::PrepareSequenceAcquisition()
 {
   return DEVICE_OK;
 }

--- a/DeviceAdapters/PCO_Generic/MicroManager.h
+++ b/DeviceAdapters/PCO_Generic/MicroManager.h
@@ -93,7 +93,7 @@ public:
   int SetROI(unsigned uX, unsigned uY, unsigned uXSize, unsigned uYSize); 
   int GetROI(unsigned& uX, unsigned& uY, unsigned& uXSize, unsigned& uYSize); 
   int ClearROI();
-  int PrepareSequenceAcqusition();
+  int PrepareSequenceAcquisition();
   int StartSequenceAcquisition(long numImages, double /*interval_ms*/, bool stopOnOverflow);
   int StopSequenceAcquisition();
   int StoppedByThread();

--- a/DeviceAdapters/PICAM/PICAMAdapter.h
+++ b/DeviceAdapters/PICAM/PICAMAdapter.h
@@ -235,7 +235,7 @@ class Universal : public CCameraBase<Universal>
 #ifndef linux
       // micromanager calls the "live" acquisition a "sequence"
       //  don't get this confused with a PICAM sequence acquisition, it's actually circular buffer mode
-      int PrepareSequenceAcqusition();
+      int PrepareSequenceAcquisition();
       int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
       int StopSequenceAcquisition();
 #endif

--- a/DeviceAdapters/PICAM/PICAMUniversal.cpp
+++ b/DeviceAdapters/PICAM/PICAMUniversal.cpp
@@ -2325,9 +2325,9 @@ int Universal::ThreadRun(void)
  * Micromanager calls the "live" acquisition a "sequence"
  *  don't get this confused with a PICAM sequence acquisition, it's actually circular buffer mode
  */
-int Universal::PrepareSequenceAcqusition()
+int Universal::PrepareSequenceAcquisition()
 {
-   START_METHOD("Universal::PrepareSequenceAcqusition");
+   START_METHOD("Universal::PrepareSequenceAcquisition");
 
    if (IsCapturing())
    {
@@ -2364,7 +2364,7 @@ int Universal::StartSequenceAcquisition(long numImages, double interval_ms, bool
 {
    START_METHOD("Universal::StartSequenceAcquisition");
 
-   int ret = PrepareSequenceAcqusition();
+   int ret = PrepareSequenceAcquisition();
    if (ret != DEVICE_OK)
       return ret;
 

--- a/DeviceAdapters/PVCAM/PVCAMAdapter.h
+++ b/DeviceAdapters/PVCAM/PVCAMAdapter.h
@@ -223,7 +223,7 @@ public: // MMCamera API
     /**
     * Micro-manager calls the "live" acquisition a "sequence". PVCAM calls this "continuous - circular buffer" mode.
     */
-    int PrepareSequenceAcqusition();
+    int PrepareSequenceAcquisition();
     int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
     int StopSequenceAcquisition();
 

--- a/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
@@ -1990,9 +1990,9 @@ bool Universal::IsCapturing()
     return bCapturing;
 }
 
-int Universal::PrepareSequenceAcqusition()
+int Universal::PrepareSequenceAcquisition()
 {
-    START_METHOD("Universal::PrepareSequenceAcqusition");
+    START_METHOD("Universal::PrepareSequenceAcquisition");
 
     if (isAcquiring_)
         return ERR_BUSY_ACQUIRING;
@@ -2048,7 +2048,7 @@ int Universal::StartSequenceAcquisition(long numImages, double interval_ms, bool
     if (ret != DEVICE_OK)
         return ret;
 
-    ret = PrepareSequenceAcqusition();
+    ret = PrepareSequenceAcquisition();
     if (ret != DEVICE_OK)
         return ret;
 

--- a/DeviceAdapters/Pixelink/Pixelink.h
+++ b/DeviceAdapters/Pixelink/Pixelink.h
@@ -71,7 +71,7 @@ public:
 	int      SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
 	int      GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
 	int      ClearROI();
-	int      PrepareSequenceAcqusition() { return DEVICE_OK; };
+	int      PrepareSequenceAcquisition() { return DEVICE_OK; };
 	int      StartSequenceAcquisition(double interval);
 	int      StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int      StopSequenceAcquisition();

--- a/DeviceAdapters/PlayerOne/POACamera.cpp
+++ b/DeviceAdapters/PlayerOne/POACamera.cpp
@@ -1284,9 +1284,9 @@ int POACamera::SendExposureSequence() const {
 }
 
 
-int POACamera::PrepareSequenceAcqusition()
+int POACamera::PrepareSequenceAcquisition()
 {
-    LOG("PrepareSequenceAcqusition")
+    LOG("PrepareSequenceAcquisition")
     if (IsCapturing())
         return DEVICE_CAMERA_BUSY_ACQUIRING;
 

--- a/DeviceAdapters/PlayerOne/POACamera.h
+++ b/DeviceAdapters/PlayerOne/POACamera.h
@@ -118,7 +118,7 @@ public:
 
     bool SupportsMultiROI();
 
-    int PrepareSequenceAcqusition();
+    int PrepareSequenceAcquisition();
     int StartSequenceAcquisition(double interval);
     int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
     int StopSequenceAcquisition(); 

--- a/DeviceAdapters/PointGrey/PointGrey.h
+++ b/DeviceAdapters/PointGrey/PointGrey.h
@@ -84,7 +84,7 @@ public:
    int      GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int      ClearROI();
    //////////////////////////////////////////////////////////////
-   int      PrepareSequenceAcqusition(){ return DEVICE_OK; };
+   int      PrepareSequenceAcquisition(){ return DEVICE_OK; };
    int      StartSequenceAcquisition(double interval);
    int      StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int      StopSequenceAcquisition();

--- a/DeviceAdapters/PrincetonInstruments/PVCAMInt.h
+++ b/DeviceAdapters/PrincetonInstruments/PVCAMInt.h
@@ -175,7 +175,7 @@ public:
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();
    // temporary debug methods
-   int PrepareSequenceAcqusition();
+   int PrepareSequenceAcquisition();
 #endif
 
    // action interface

--- a/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
@@ -1964,7 +1964,7 @@ int Universal::ThreadRun(void)
    return ret;
 }
 
-int Universal::PrepareSequenceAcqusition()
+int Universal::PrepareSequenceAcquisition()
 {
    if (IsCapturing())
       return ERR_BUSY_ACQUIRING;
@@ -1996,7 +1996,7 @@ int Universal::StartSequenceAcquisition(long numImages, double interval_ms, bool
 {
    if (!sequenceModeReady_)
    {
-      int ret = PrepareSequenceAcqusition();
+      int ret = PrepareSequenceAcquisition();
       if (ret != DEVICE_OK)
          return ret;
    }

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.h
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.h
@@ -188,7 +188,7 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
-   int PrepareSequenceAcqusition()
+   int PrepareSequenceAcquisition()
    {
          return DEVICE_OK;
    }

--- a/DeviceAdapters/SigmaKoki/Camera.h
+++ b/DeviceAdapters/SigmaKoki/Camera.h
@@ -85,7 +85,7 @@ public:
 	int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
 	int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
 	int ClearROI();
-	int PrepareSequenceAcqusition() { return DEVICE_OK; };
+	int PrepareSequenceAcquisition() { return DEVICE_OK; };
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StartSequenceAcquisition(double interval_ms);
 	int StopSequenceAcquisition();

--- a/DeviceAdapters/Spinnaker/SpinnakerCamera.cpp
+++ b/DeviceAdapters/Spinnaker/SpinnakerCamera.cpp
@@ -1534,7 +1534,7 @@ int SpinnakerCamera::allocateImageBuffer(const std::size_t size, const SPKR::Pix
 }
 
 
-int SpinnakerCamera::PrepareSequenceAcqusition()
+int SpinnakerCamera::PrepareSequenceAcquisition()
 {
    return DEVICE_OK;
 }

--- a/DeviceAdapters/Spinnaker/SpinnakerCamera.h
+++ b/DeviceAdapters/Spinnaker/SpinnakerCamera.h
@@ -42,7 +42,7 @@ public:
    int SetBinning(int binSize);
    int IsExposureSequenceable(bool& isSequenceable) const { isSequenceable = false; return DEVICE_OK; };
 
-   int PrepareSequenceAcqusition();
+   int PrepareSequenceAcquisition();
    int StartSequenceAcquisition(double interval);
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();

--- a/DeviceAdapters/TSI/TSI3Cam.cpp
+++ b/DeviceAdapters/TSI/TSI3Cam.cpp
@@ -741,7 +741,7 @@ int Tsi3Cam::ClearROI()
    return ResizeImageBuffer();
 }
 
-int Tsi3Cam::PrepareSequenceAcqusition()
+int Tsi3Cam::PrepareSequenceAcquisition()
 {
    if (IsCapturing())
    {
@@ -765,7 +765,7 @@ int Tsi3Cam::StartSequenceAcquisition(long numImages, double /*interval_ms*/, bo
    }
    if (!prepared) 
    {
-      this->PrepareSequenceAcqusition();
+      this->PrepareSequenceAcquisition();
    }
 
    // the camera ignores interval, running at the rate dictated by the exposure
@@ -785,7 +785,7 @@ int Tsi3Cam::StartSequenceAcquisition(double /*interval_ms*/)
    }
    if (!prepared) 
    {
-      this->PrepareSequenceAcqusition();
+      this->PrepareSequenceAcquisition();
    }
 
    // the camera ignores interval, running at the rate dictated by the exposure

--- a/DeviceAdapters/TSI/TSI3Cam.h
+++ b/DeviceAdapters/TSI/TSI3Cam.h
@@ -139,7 +139,7 @@ public:
 
    // overrides the same in the base class
    int InsertImage();
-   int PrepareSequenceAcqusition();
+   int PrepareSequenceAcquisition();
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StartSequenceAcquisition(double interval);
    int StopSequenceAcquisition(); 

--- a/DeviceAdapters/TSI/TSICam.cpp
+++ b/DeviceAdapters/TSI/TSICam.cpp
@@ -689,7 +689,7 @@ int TsiCam::ClearROI()
    return ResizeImageBuffer(roiBinData);
 }
 
-int TsiCam::PrepareSequenceAcqusition()
+int TsiCam::PrepareSequenceAcquisition()
 {
    if (IsCapturing())
    {

--- a/DeviceAdapters/TSI/TSICam.h
+++ b/DeviceAdapters/TSI/TSICam.h
@@ -109,7 +109,7 @@ public:
 
    // overrides the same in the base class
    int InsertImage();
-   int PrepareSequenceAcqusition();
+   int PrepareSequenceAcquisition();
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StartSequenceAcquisition(double interval);
    int StopSequenceAcquisition(); 

--- a/DeviceAdapters/TUCam/MMTUCam.h
+++ b/DeviceAdapters/TUCam/MMTUCam.h
@@ -225,7 +225,7 @@ public:
     int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
     int ClearROI();
 
-    int PrepareSequenceAcqusition() { return DEVICE_OK; }
+    int PrepareSequenceAcquisition() { return DEVICE_OK; }
     int StartSequenceAcquisition(double interval);
     int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
     int StopSequenceAcquisition();

--- a/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.h
+++ b/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.h
@@ -76,7 +76,7 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
-   int PrepareSequenceAcqusition()
+   int PrepareSequenceAcquisition()
    {
       return DEVICE_OK;
    }

--- a/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
+++ b/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
@@ -635,7 +635,7 @@ int BitFlowCamera::StopSequenceAcquisition()
    return DEVICE_OK;
 }
 
-int BitFlowCamera::PrepareSequenceAcqusition()
+int BitFlowCamera::PrepareSequenceAcquisition()
 {
    // nothing to prepare
    return DEVICE_OK;

--- a/DeviceAdapters/TwoPhoton/TwoPhoton.h
+++ b/DeviceAdapters/TwoPhoton/TwoPhoton.h
@@ -101,7 +101,7 @@ public:
     int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
     int StartSequenceAcquisition(double interval_ms);
     int StopSequenceAcquisition();
-    int PrepareSequenceAcqusition();
+    int PrepareSequenceAcquisition();
     
     /**
      * Flag to indicate whether Sequence Acquisition is currently running.

--- a/DeviceAdapters/UniversalMMHubUsb/ummhUsb.h
+++ b/DeviceAdapters/UniversalMMHubUsb/ummhUsb.h
@@ -430,7 +430,7 @@ public:
 	int ClearROI();
 
 	// sequence acquisition
-	int PrepareSequenceAcqusition() { return DEVICE_OK; }
+	int PrepareSequenceAcquisition() { return DEVICE_OK; }
 	int StartSequenceAcquisition(double interval);
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StopSequenceAcquisition();

--- a/DeviceAdapters/Utilities/MultiCamera.cpp
+++ b/DeviceAdapters/Utilities/MultiCamera.cpp
@@ -433,7 +433,7 @@ int MultiCamera::ClearROI()
    return DEVICE_OK;
 }
 
-int MultiCamera::PrepareSequenceAcqusition()
+int MultiCamera::PrepareSequenceAcquisition()
 {
    if (nrCamerasInUse_ < 1)
       return ERR_NO_PHYSICAL_CAMERA;
@@ -443,7 +443,7 @@ int MultiCamera::PrepareSequenceAcqusition()
       MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
       if (camera != 0)
       {
-         int ret = camera->PrepareSequenceAcqusition();
+         int ret = camera->PrepareSequenceAcquisition();
          if (ret != DEVICE_OK)
             return ret;
       }

--- a/DeviceAdapters/Utilities/Utilities.h
+++ b/DeviceAdapters/Utilities/Utilities.h
@@ -162,7 +162,7 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
    int ClearROI();
-   int PrepareSequenceAcqusition();
+   int PrepareSequenceAcquisition();
    int StartSequenceAcquisition(double interval);
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();

--- a/DeviceAdapters/Ximea/XIMEACamera.cpp
+++ b/DeviceAdapters/Ximea/XIMEACamera.cpp
@@ -798,7 +798,7 @@ int XimeaCamera::InsertImage()
 	// Important:  metadata about the image are generated here:
 	Metadata md;
 	double exp_time = (double)image.GetExpTime() / 1000;
-	md.put(MM::g_Keyword_Meatdata_Exposure, CDeviceUtils::ConvertToString(exp_time));
+	md.put(MM::g_Keyword_Metadata_Exposure, CDeviceUtils::ConvertToString(exp_time));
 	md.put(MM::g_Keyword_Elapsed_Time_ms, CDeviceUtils::ConvertToString((timeStamp - sequenceStartTime_).getMsec()));
 	md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(imageCounter_));
 	md.put(MM::g_Keyword_Metadata_ROI_X, CDeviceUtils::ConvertToString((long)roiX_));

--- a/DeviceAdapters/Ximea/XIMEACamera.h
+++ b/DeviceAdapters/Ximea/XIMEACamera.h
@@ -89,7 +89,7 @@ public:
 	int      SetMultiROI(const unsigned* xs, const unsigned* ys, const unsigned* widths, const unsigned* heights, unsigned numROIs);
 	int      GetMultiROI(unsigned* xs, unsigned* ys, unsigned* widths, unsigned* heights, unsigned* length);
 	//////////////////////////////////////////////////////////////
-	int      PrepareSequenceAcqusition() { return DEVICE_OK; }
+	int      PrepareSequenceAcquisition() { return DEVICE_OK; }
 	int      StartSequenceAcquisition(double interval);
 	int      StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int      StopSequenceAcquisition();

--- a/DeviceAdapters/ZWO/MyASICam2.cpp
+++ b/DeviceAdapters/ZWO/MyASICam2.cpp
@@ -1073,7 +1073,7 @@ int CMyASICam::SetBinning(int binF)
 	return SetProperty(MM::g_Keyword_Binning, CDeviceUtils::ConvertToString(binF));//就是onBinning(, afterSet)
 }
 
-int CMyASICam::PrepareSequenceAcqusition()
+int CMyASICam::PrepareSequenceAcquisition()
 {
 	if (IsCapturing())
 		return DEVICE_CAMERA_BUSY_ACQUIRING;

--- a/DeviceAdapters/ZWO/MyASICam2.h
+++ b/DeviceAdapters/ZWO/MyASICam2.h
@@ -41,7 +41,7 @@ public:
 	int SetBinning(int binSize);
 
 	int IsExposureSequenceable(bool& seq) const {seq = false; return DEVICE_OK;}
-	int PrepareSequenceAcqusition();
+	int PrepareSequenceAcquisition();
 	int StartSequenceAcquisition(double interval);
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StopSequenceAcquisition();

--- a/MMCore/Devices/CameraInstance.cpp
+++ b/MMCore/Devices/CameraInstance.cpp
@@ -130,7 +130,7 @@ int CameraInstance::GetMultiROI(unsigned* xs, unsigned* ys, unsigned* widths,
 int CameraInstance::StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow) { RequireInitialized(__func__); return GetImpl()->StartSequenceAcquisition(numImages, interval_ms, stopOnOverflow); }
 int CameraInstance::StartSequenceAcquisition(double interval_ms) { RequireInitialized(__func__); return GetImpl()->StartSequenceAcquisition(interval_ms); }
 int CameraInstance::StopSequenceAcquisition() { RequireInitialized(__func__); return GetImpl()->StopSequenceAcquisition(); }
-int CameraInstance::PrepareSequenceAcqusition() { RequireInitialized(__func__); return GetImpl()->PrepareSequenceAcqusition(); }
+int CameraInstance::PrepareSequenceAcquisition() { RequireInitialized(__func__); return GetImpl()->PrepareSequenceAcquisition(); }
 bool CameraInstance::IsCapturing() { RequireInitialized(__func__); return GetImpl()->IsCapturing(); }
 
 std::string CameraInstance::GetTags()

--- a/MMCore/Devices/CameraInstance.h
+++ b/MMCore/Devices/CameraInstance.h
@@ -70,7 +70,7 @@ public:
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StartSequenceAcquisition(double interval_ms);
    int StopSequenceAcquisition();
-   int PrepareSequenceAcqusition();
+   int PrepareSequenceAcquisition();
    bool IsCapturing();
    std::string GetTags();
    void AddTag(const char* key, const char* deviceLabel, const char* value);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -2754,7 +2754,7 @@ void CMMCore::prepareSequenceAcquisition(const char* label) throw (CMMError)
 
    LOG_DEBUG(coreLogger_) << "Will prepare camera " << label <<
       " for sequence acquisition";
-   int nRet = pCam->PrepareSequenceAcqusition();
+   int nRet = pCam->PrepareSequenceAcquisition();
    if (nRet != DEVICE_OK)
       throw CMMError(getDeviceErrorText(nRet, pCam).c_str(), MMERR_DEVICE_GENERIC);
 

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1415,7 +1415,7 @@ public:
    }
 
    // temporary debug methods
-   virtual int PrepareSequenceAcqusition() {return DEVICE_OK;}
+   virtual int PrepareSequenceAcquisition() {return DEVICE_OK;}
 
    /**
    * Default implementation.

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -503,7 +503,7 @@ namespace MM {
       /**
        * Sets up the camera so that Sequence acquisition can start without delay
        */
-      virtual int PrepareSequenceAcqusition() = 0;
+      virtual int PrepareSequenceAcquisition() = 0;
       /**
        * Flag to indicate whether Sequence Acquisition is currently running.
        * Return true when Sequence acquisition is active, false otherwise

--- a/MMDevice/MMDeviceConstants.h
+++ b/MMDevice/MMDeviceConstants.h
@@ -144,7 +144,7 @@ namespace MM {
 
    // image annotations
    const char* const g_Keyword_Metadata_CameraLabel = "Camera";
-   const char* const g_Keyword_Meatdata_Exposure    = "Exposure-ms";
+   const char* const g_Keyword_Metadata_Exposure    = "Exposure-ms";
    const char* const g_Keyword_Metadata_Score       = "Score";
    const char* const g_Keyword_Metadata_ImageNumber = "ImageNumber";
    // Removed: g_Keyword_Metadata_StartTime         = "StartTime-ms";


### PR DESCRIPTION
This replaces `PrepareSequenceAcqusition` with `PrepareSequenceAcquisition` and `g_Keyword_Meatdata_Exposure` with `g_Keyword_Metadata_Exposure`. It touches a lot of files because the first typo is present in most of the camera device adapters.