### PR TITLE
Add keyword 'g_Keyword_Metadata_Exposure'

### DIFF
--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -172,6 +172,7 @@ void AravisCamera::AcquisitionCallback(ArvStreamCallbackType type, ArvBuffer *cb
     md.put(MM::g_Keyword_Metadata_ROI_X, CDeviceUtils::ConvertToString((long)img_buffer_width));
     md.put(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString((long)img_buffer_height));
     md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(counter));
+    md.put(MM::g_Keyword_Metadata_Exposure, exposure_time);
     md.put(MM::g_Keyword_Meatdata_Exposure, exposure_time);
     md.put(MM::g_Keyword_PixelType, pixel_type);
     

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -173,7 +173,6 @@ void AravisCamera::AcquisitionCallback(ArvStreamCallbackType type, ArvBuffer *cb
     md.put(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString((long)img_buffer_height));
     md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(counter));
     md.put(MM::g_Keyword_Metadata_Exposure, exposure_time);
-    md.put(MM::g_Keyword_Meatdata_Exposure, exposure_time);
     md.put(MM::g_Keyword_PixelType, pixel_type);
     
     // Pass data to MM.

--- a/DeviceAdapters/Basler/BaslerPylonCamera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylonCamera.cpp
@@ -2131,6 +2131,7 @@ void CircularBufferInserter::OnImageGrabbed(CInstantCamera& /* camera */, const 
 	md.put(MM::g_Keyword_Metadata_ROI_X, CDeviceUtils::ConvertToString((long)ptrGrabResult->GetWidth()));
 	md.put(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString((long)ptrGrabResult->GetHeight()));
 	md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString((long)ptrGrabResult->GetImageNumber()));
+	md.put(MM::g_Keyword_Metadata_Exposure, dev_->GetExposure());
 	md.put(MM::g_Keyword_Meatdata_Exposure, dev_->GetExposure());
 	// Image grabbed successfully?
 	if (ptrGrabResult->GrabSucceeded())

--- a/DeviceAdapters/Basler/BaslerPylonCamera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylonCamera.cpp
@@ -2132,7 +2132,6 @@ void CircularBufferInserter::OnImageGrabbed(CInstantCamera& /* camera */, const 
 	md.put(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString((long)ptrGrabResult->GetHeight()));
 	md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString((long)ptrGrabResult->GetImageNumber()));
 	md.put(MM::g_Keyword_Metadata_Exposure, dev_->GetExposure());
-	md.put(MM::g_Keyword_Meatdata_Exposure, dev_->GetExposure());
 	// Image grabbed successfully?
 	if (ptrGrabResult->GrabSucceeded())
 	{

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
@@ -1863,6 +1863,7 @@ void CircularBufferInserter::DoOnImageCaptured(CImageDataPointer& objImageDataPo
     md.put(MM::g_Keyword_Metadata_ROI_X, CDeviceUtils::ConvertToString((long)objImageDataPointer->GetWidth()));
     md.put(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString((long)objImageDataPointer->GetHeight()));
     md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString((long)objImageDataPointer->GetFrameID()));
+    md.put(MM::g_Keyword_Metadata_Exposure, dev_->GetExposure());
     md.put(MM::g_Keyword_Meatdata_Exposure, dev_->GetExposure());
     // Image grabbed successfully ?
     if (objImageDataPointer->GetStatus()== GX_FRAME_STATUS_SUCCESS)

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
@@ -1864,7 +1864,6 @@ void CircularBufferInserter::DoOnImageCaptured(CImageDataPointer& objImageDataPo
     md.put(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString((long)objImageDataPointer->GetHeight()));
     md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString((long)objImageDataPointer->GetFrameID()));
     md.put(MM::g_Keyword_Metadata_Exposure, dev_->GetExposure());
-    md.put(MM::g_Keyword_Meatdata_Exposure, dev_->GetExposure());
     // Image grabbed successfully ?
     if (objImageDataPointer->GetStatus()== GX_FRAME_STATUS_SUCCESS)
     {

--- a/DeviceAdapters/Ximea/XIMEACamera.cpp
+++ b/DeviceAdapters/Ximea/XIMEACamera.cpp
@@ -798,6 +798,7 @@ int XimeaCamera::InsertImage()
 	// Important:  metadata about the image are generated here:
 	Metadata md;
 	double exp_time = (double)image.GetExpTime() / 1000;
+	md.put(MM::g_Keyword_Metadata_Exposure, CDeviceUtils::ConvertToString(exp_time));
 	md.put(MM::g_Keyword_Meatdata_Exposure, CDeviceUtils::ConvertToString(exp_time));
 	md.put(MM::g_Keyword_Elapsed_Time_ms, CDeviceUtils::ConvertToString((timeStamp - sequenceStartTime_).getMsec()));
 	md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(imageCounter_));

--- a/DeviceAdapters/Ximea/XIMEACamera.cpp
+++ b/DeviceAdapters/Ximea/XIMEACamera.cpp
@@ -799,7 +799,6 @@ int XimeaCamera::InsertImage()
 	Metadata md;
 	double exp_time = (double)image.GetExpTime() / 1000;
 	md.put(MM::g_Keyword_Metadata_Exposure, CDeviceUtils::ConvertToString(exp_time));
-	md.put(MM::g_Keyword_Meatdata_Exposure, CDeviceUtils::ConvertToString(exp_time));
 	md.put(MM::g_Keyword_Elapsed_Time_ms, CDeviceUtils::ConvertToString((timeStamp - sequenceStartTime_).getMsec()));
 	md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(imageCounter_));
 	md.put(MM::g_Keyword_Metadata_ROI_X, CDeviceUtils::ConvertToString((long)roiX_));

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -52,20 +52,6 @@
 #include <string>
 #include <vector>
 
-
-#ifdef MMDEVICE_CLIENT_BUILD
-// Hide deprecation warnings when building MMCore
-#   define MM_DEPRECATED(prototype) prototype
-#else
-#   ifdef _MSC_VER
-#      define MM_DEPRECATED(prototype) __declspec(deprecated) prototype
-#   elif defined(__GNUC__)
-#      define MM_DEPRECATED(prototype) prototype __attribute__((deprecated))
-#   else
-#      define MM_DEPRECATED(prototype) prototype
-#   endif
-#endif
-
 // To be removed once the deprecated Get/SetModuleHandle() is removed:
 #ifdef _WIN32
    #define WIN32_LEAN_AND_MEAN

--- a/MMDevice/MMDeviceConstants.h
+++ b/MMDevice/MMDeviceConstants.h
@@ -21,6 +21,19 @@
 
 #pragma once
 
+#ifdef MMDEVICE_CLIENT_BUILD
+// Hide deprecation warnings when building MMCore
+#   define MM_DEPRECATED(prototype) prototype
+#else
+#   ifdef _MSC_VER
+#      define MM_DEPRECATED(prototype) __declspec(deprecated) prototype
+#   elif defined(__GNUC__)
+#      define MM_DEPRECATED(prototype) prototype __attribute__((deprecated))
+#   else
+#      define MM_DEPRECATED(prototype) prototype
+#   endif
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // Global error codes
 //
@@ -145,7 +158,7 @@ namespace MM {
    // image annotations
    const char* const g_Keyword_Metadata_CameraLabel = "Camera";
    const char* const g_Keyword_Metadata_Exposure    = "Exposure-ms";
-   const char* const g_Keyword_Meatdata_Exposure    = "Exposure-ms"; // Deprecated, use g_Keyword_Metadata_Exposure.
+   MM_DEPRECATED(const char* const g_Keyword_Meatdata_Exposure) = "Exposure-ms"; // Typo
    const char* const g_Keyword_Metadata_Score       = "Score";
    const char* const g_Keyword_Metadata_ImageNumber = "ImageNumber";
    // Removed: g_Keyword_Metadata_StartTime         = "StartTime-ms";

--- a/MMDevice/MMDeviceConstants.h
+++ b/MMDevice/MMDeviceConstants.h
@@ -144,7 +144,8 @@ namespace MM {
 
    // image annotations
    const char* const g_Keyword_Metadata_CameraLabel = "Camera";
-   const char* const g_Keyword_Meatdata_Exposure    = "Exposure-ms";
+   const char* const g_Keyword_Metadata_Exposure    = "Exposure-ms";
+   const char* const g_Keyword_Meatdata_Exposure    = "Exposure-ms"; // Deprecated, use g_Keyword_Metadata_Exposure.
    const char* const g_Keyword_Metadata_Score       = "Score";
    const char* const g_Keyword_Metadata_ImageNumber = "ImageNumber";
    // Removed: g_Keyword_Metadata_StartTime         = "StartTime-ms";


### PR DESCRIPTION
Add keyword 'g_Keyword_Metadata_Exposure' to replace 'g_Keyword_Meatdata_Exposure'. 
Add comment to indicate that 'g_Keyword_Meatdata_Exposure' is deprecated.

This was discussed in pull request #499.

This keyword does not seem to be widely used. Should it also be propagated to the other camera drivers?