### PR TITLE
Utilities: changed values for TTL Voltage in DA TTL device to 3.30 and 5.00

### DIFF
--- a/DeviceAdapters/Utilities/DATTLStateDevice.cpp
+++ b/DeviceAdapters/Utilities/DATTLStateDevice.cpp
@@ -37,6 +37,10 @@
 extern const char* g_DeviceNameDATTLStateDevice;
 extern const char* g_normalLogicString;
 extern const char* g_invertedLogicString;
+extern const char* g_InvertLogic;
+extern const char* g_TTLVoltage;
+extern const char* g_3_3;
+extern const char* g_5_0;
 
 
 DATTLStateDevice::DATTLStateDevice() :
@@ -124,18 +128,18 @@ int DATTLStateDevice::Initialize()
    SetPropertyLimits(MM::g_Keyword_State, 0, numPos - 1);
 
    pAct = new CPropertyAction(this, &DATTLStateDevice::OnInvert);
-   ret = CreateStringProperty("Invert Logic", g_normalLogicString, false, pAct);
+   ret = CreateStringProperty(g_InvertLogic, g_normalLogicString, false, pAct);
    if (ret != DEVICE_OK)
       return ret;
-   AddAllowedValue("Invert Logic", g_normalLogicString);
-   AddAllowedValue("Invert Logic", g_invertedLogicString);
+   AddAllowedValue(g_InvertLogic, g_normalLogicString);
+   AddAllowedValue(g_InvertLogic, g_invertedLogicString);
 
    pAct = new CPropertyAction(this, &DATTLStateDevice::OnTTLLevel);
-   ret = CreateStringProperty("TTL Voltage", "3.3", false, pAct);
+   ret = CreateStringProperty(g_TTLVoltage, g_3_3, false, pAct);
    if (ret != DEVICE_OK)
       return ret;
-   AddAllowedValue("TTL Voltage", "3.3");
-   AddAllowedValue("TTL Voltage", "5.0");
+   AddAllowedValue(g_TTLVoltage, g_3_3);
+   AddAllowedValue(g_TTLVoltage, g_5_0);
 
    pAct = new CPropertyAction(this, &DATTLStateDevice::OnLabel);
    ret = CreateStringProperty(MM::g_Keyword_Label, "0", false, pAct);

--- a/DeviceAdapters/Utilities/Utilities.cpp
+++ b/DeviceAdapters/Utilities/Utilities.cpp
@@ -63,6 +63,10 @@ const char* g_SyncNow = "Sync positions now";
 
 const char* g_normalLogicString = "Normal";
 const char* g_invertedLogicString = "Inverted";
+const char* g_InvertLogic = "Invert Logic";
+const char* g_TTLVoltage = "TTL Voltage";
+const char* g_3_3 = "3.30";
+const char* g_5_0 = "5.00";
 
 
 


### PR DESCRIPTION
Without this, the core will change 3.3 to 3.30, resulting in values in configs not matching.  It is unclear where exactly in the core this undesired change in values happens.

Closes #504 