### PR TITLE
NIDAQ: Added analog input functionality

### DIFF
--- a/DeviceAdapters/NIDAQ/NIAnalogInputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIAnalogInputPort.cpp
@@ -111,11 +111,15 @@ int NIAnalogInputPort::SetRunning(bool open)
 {
     if (open && !running_)
     {
-        GetHub()->StartAIMeasuringForPort(this);
+        int err = GetHub()->StartAIMeasuringForPort(this);
+        if (err != DEVICE_OK)
+            return err;
     }
     else if (!open && running_)
     {
-        GetHub()->StopAIMeasuringForPort(this);
+        int err = GetHub()->StopAIMeasuringForPort(this);
+        if (err != DEVICE_OK)
+            return err;
     }
 
     running_ = open;

--- a/DeviceAdapters/NIDAQ/NIAnalogInputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIAnalogInputPort.cpp
@@ -111,11 +111,11 @@ int NIAnalogInputPort::SetRunning(bool open)
 {
     if (open && !running_)
     {
-        //TODO: implement actual measuring
+        GetHub()->StartAIMeasuringForPort(this);
     }
     else if (!open && running_)
     {
-        //TODO: implement actual measuring
+        GetHub()->StopAIMeasuringForPort(this);
     }
 
     running_ = open;
@@ -153,6 +153,13 @@ int NIAnalogInputPort::OnMeasuring(MM::PropertyBase* pProp, MM::ActionType eAct)
         if (err != DEVICE_OK)
             return err;
     }
+    return DEVICE_OK;
+}
+
+int NIAnalogInputPort::UpdateState(float value)
+{
+    state_ = value;
+    OnPropertiesChanged();
     return DEVICE_OK;
 }
 

--- a/DeviceAdapters/NIDAQ/NIAnalogInputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIAnalogInputPort.cpp
@@ -1,0 +1,168 @@
+// DESCRIPTION:   Drive multiple analog and digital outputs on NI DAQ
+// AUTHOR:        Mark Tsuchida, 2015, Nico Stuurman 2022
+// COPYRIGHT:     2015-2016, Open Imaging, Inc., 2022 Altos Labs
+// LICENSE:       This library is free software; you can redistribute it and/or
+//                modify it under the terms of the GNU Lesser General Public
+//                License as published by the Free Software Foundation; either
+//                version 2.1 of the License, or (at your option) any later
+//                version.
+//
+//                This library is distributed in the hope that it will be
+//                useful, but WITHOUT ANY WARRANTY; without even the implied
+//                warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//                PURPOSE.  See the GNU Lesser General Public License for more
+//                details.
+//
+//                You should have received a copy of the GNU Lesser General
+//                Public License along with this library; if not, write to the
+//                Free Software Foundation, Inc., 51 Franklin Street, Fifth
+//                Floor, Boston, MA  02110-1301  USA
+
+#include "NIDAQ.h"
+
+#include "ModuleInterface.h"
+
+//
+// MultiAnalogInPort
+//
+
+NIAnalogInputPort::NIAnalogInputPort(const std::string& port) :
+    ErrorTranslator(22000, 22999, &NIAnalogInputPort::SetErrorText),
+    niPort_(port),
+    initialized_(false),
+    running_(false),
+    state_(0.0)
+{
+    InitializeDefaultErrorMessages();
+}
+
+
+NIAnalogInputPort::~NIAnalogInputPort()
+{
+    Shutdown();
+}
+
+
+int NIAnalogInputPort::Initialize()
+{
+    if (initialized_)
+        return DEVICE_OK;
+
+    CPropertyAction* pAct = new CPropertyAction(this, &NIAnalogInputPort::OnVoltage);
+    int err = CreateFloatProperty("Voltage", state_, true, pAct);
+    if (err != DEVICE_OK)
+        return err;
+
+    pAct = new CPropertyAction(this, &NIAnalogInputPort::OnMeasuring);
+    err = CreateStringProperty("Measuring", "false", false, pAct);
+    if (err != DEVICE_OK)
+        return err;
+    AddAllowedValue("Measuring", "false");
+    AddAllowedValue("Measuring", "true");
+
+    initialized_ = true;
+    return DEVICE_OK;
+}
+
+
+int NIAnalogInputPort::Shutdown()
+{
+    if (!initialized_)
+        return DEVICE_OK;
+
+    running_ = false;
+    initialized_ = false;
+    return DEVICE_OK;
+}
+
+
+void NIAnalogInputPort::GetName(char* name) const
+{
+    CDeviceUtils::CopyLimitedString(name,
+        (g_DeviceNameNIDAQAIPortPrefix + niPort_).c_str());
+}
+
+
+int NIAnalogInputPort::GetSignal(double& volts)
+{
+    volts = state_;
+    return DEVICE_OK;
+}
+
+
+int NIAnalogInputPort::GetLimits(double& minVolts, double& maxVolts)
+{
+    float64 ranges[1024] = {0};
+    char hub_name[1024];
+    GetHub()->GetName(hub_name);
+
+    int err = DAQmxGetDevAIVoltageRngs(hub_name, ranges, 1024);
+    if (err != DEVICE_OK)
+        return err;
+
+    maxVolts = *std::max_element(ranges, ranges + 1024);
+    minVolts = *std::min_element(ranges, ranges + 1024);
+
+    return DEVICE_OK;
+}
+
+
+int NIAnalogInputPort::SetRunning(bool open)
+{
+    if (open && !running_)
+    {
+        //TODO: implement actual measuring
+    }
+    else if (!open && running_)
+    {
+        //TODO: implement actual measuring
+    }
+
+    running_ = open;
+    return DEVICE_OK;
+}
+
+
+int NIAnalogInputPort::GetRunning(bool& open)
+{
+    open = running_;
+    return DEVICE_OK;
+}
+
+
+int NIAnalogInputPort::OnVoltage(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+    if (eAct == MM::BeforeGet)
+    {
+        pProp->Set(state_);
+    }
+    return DEVICE_OK;
+}
+
+int NIAnalogInputPort::OnMeasuring(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+    if (eAct == MM::BeforeGet)
+    {
+        pProp->Set(running_? "true": "false");
+    }
+    else if (eAct == MM::AfterSet)
+    {
+        std::string running;
+        pProp->Get(running);
+        int err = SetRunning(running.compare("true") == 0);
+        if (err != DEVICE_OK)
+            return err;
+    }
+    return DEVICE_OK;
+}
+
+
+int NIAnalogInputPort::TranslateHubError(int err)
+{
+    if (err == DEVICE_OK)
+        return DEVICE_OK;
+    char buf[MM::MaxStrLength];
+    if (GetHub()->GetErrorText(err, buf))
+        return NewErrorCode(buf);
+    return NewErrorCode("Unknown hub error");
+}

--- a/DeviceAdapters/NIDAQ/NIDAQ.cpp
+++ b/DeviceAdapters/NIDAQ/NIDAQ.cpp
@@ -1190,7 +1190,8 @@ int NIDAQHub::OnExpectedMaxVoltsIn(MM::PropertyBase* pProp, MM::ActionType eAct)
         mThread_->wait();
         delete mThread_;
         mThread_ = new InputMonitoringThread(this);
-        mThread_->Start(GetPhysicalChannelListForMeasuring(physicalAIChannels_), expectedMinVoltsIn_, expectedMaxVoltsIn_);
+        if (physicalAIChannels_.size() > 1)
+            mThread_->Start(GetPhysicalChannelListForMeasuring(physicalAIChannels_), expectedMinVoltsIn_, expectedMaxVoltsIn_);
 
     }
     return DEVICE_OK;
@@ -1213,7 +1214,8 @@ int NIDAQHub::OnExpectedMinVoltsIn(MM::PropertyBase* pProp, MM::ActionType eAct)
         mThread_->wait();
         delete mThread_;
         mThread_ = new InputMonitoringThread(this);
-        mThread_->Start(GetPhysicalChannelListForMeasuring(physicalAIChannels_), expectedMinVoltsIn_, expectedMaxVoltsIn_);
+        if (physicalAIChannels_.size() > 1)
+            mThread_->Start(GetPhysicalChannelListForMeasuring(physicalAIChannels_), expectedMinVoltsIn_, expectedMaxVoltsIn_);
     }
     return DEVICE_OK;
 }

--- a/DeviceAdapters/NIDAQ/NIDAQ.cpp
+++ b/DeviceAdapters/NIDAQ/NIDAQ.cpp
@@ -927,7 +927,7 @@ int NIDAQHub::StartAIMeasuringForPort(NIAnalogInputPort* port)
 
         tThread_ = new TraceMonitoringThread(this);
         err = tThread_->Start(GetPhysicalChannelListForMeasuring(physicalAIChannels_), expectedMinVoltsIn_,
-            expectedMaxVoltsIn_, traceFrequency_, traceAmount_, physicalAIChannels_.size());
+            expectedMaxVoltsIn_, (float) traceFrequency_, traceAmount_, (int) physicalAIChannels_.size());
     }
     else
     {
@@ -963,7 +963,7 @@ int NIDAQHub::StopAIMeasuringForPort(NIAnalogInputPort* port)
                 int err = DEVICE_OK;
                 if (n > 1)
                     err = tThread_->Start(GetPhysicalChannelListForMeasuring(physicalAIChannels_), expectedMinVoltsIn_,
-                        expectedMaxVoltsIn_, traceFrequency_, traceAmount_, physicalAIChannels_.size());
+                        expectedMaxVoltsIn_, (float) traceFrequency_, traceAmount_, (int) physicalAIChannels_.size());
 
                 return err;
             }
@@ -995,7 +995,7 @@ int NIDAQHub::UpdateAIValues(float64* values, int32 amount)
     size_t n = physicalAIChannels_.size();
     for (size_t i = 0; i < n; ++i)
     {
-        physicalAIChannels_[i]->UpdateState(values[i]);
+        physicalAIChannels_[i]->UpdateState((float) values[i]);
     }
 
     return DEVICE_OK;
@@ -1026,7 +1026,7 @@ int NIDAQHub::StartTrace()
     delete tThread_;
     tThread_ = new TraceMonitoringThread(this);
     int err  = tThread_->Start(GetPhysicalChannelListForMeasuring(physicalAIChannels_), expectedMinVoltsIn_,
-        expectedMaxVoltsIn_, traceFrequency_, traceAmount_, physicalAIChannels_.size());
+        expectedMaxVoltsIn_, (float) traceFrequency_, traceAmount_, (int) physicalAIChannels_.size());
 
     return err;
 }
@@ -1184,7 +1184,7 @@ int NIDAQHub::OnExpectedMaxVoltsIn(MM::PropertyBase* pProp, MM::ActionType eAct)
     {
         double temp_max = 5.0;
         pProp->Get(temp_max);
-        expectedMaxVoltsIn_ = temp_max;
+        expectedMaxVoltsIn_ = (float) temp_max;
         
         mThread_->Stop();
         mThread_->wait();
@@ -1208,7 +1208,7 @@ int NIDAQHub::OnExpectedMinVoltsIn(MM::PropertyBase* pProp, MM::ActionType eAct)
     {
         double temp_min = -5.0;
         pProp->Get(temp_min);
-        expectedMinVoltsIn_ = temp_min;
+        expectedMinVoltsIn_ = (float) temp_min;
 
         mThread_->Stop();
         mThread_->wait();

--- a/DeviceAdapters/NIDAQ/NIDAQ.cpp
+++ b/DeviceAdapters/NIDAQ/NIDAQ.cpp
@@ -298,11 +298,9 @@ int NIDAQHub::Shutdown()
    else if (doHub32_ != 0)
       delete  doHub32_;
 
-   if (mThread_ != 0)
-   {
-       mThread_->wait();
-       delete mThread_;
-   }
+   tThread_->Stop();
+   tThread_->wait();
+   delete tThread_;
 
    initialized_ = false;
    return err;

--- a/DeviceAdapters/NIDAQ/NIDAQ.cpp
+++ b/DeviceAdapters/NIDAQ/NIDAQ.cpp
@@ -1727,6 +1727,10 @@ int TraceMonitoringThread::Start(std::string AIChannelList, float minVal, float 
     if (err != DEVICE_OK)
         return err;
 
+    err = DAQmxSetSampTimingType(aiTask_, DAQmx_Val_SampClk);
+    if (err != DEVICE_OK)
+        return err;
+
     path_ += boost::posix_time::to_iso_string(boost::posix_time::second_clock::local_time()) + ".csv";
     numberOfChannels_ = numberOfChannels;
 

--- a/DeviceAdapters/NIDAQ/NIDAQ.cpp
+++ b/DeviceAdapters/NIDAQ/NIDAQ.cpp
@@ -1634,7 +1634,8 @@ template class NIDAQDOHub<uInt32>;
 
 
 InputMonitoringThread::InputMonitoringThread(NIDAQHub* hub) :
-    stop_(false)
+    stop_(false),
+    aiTask_(NULL)
 {
     hub_ = hub;
 }

--- a/DeviceAdapters/NIDAQ/NIDAQ.h
+++ b/DeviceAdapters/NIDAQ/NIDAQ.h
@@ -485,12 +485,12 @@ public:
 
     virtual int SetGateOpen(bool open = true) { return SetRunning(open); }
     virtual int GetGateOpen(bool& open) { return GetRunning(open); }
-    virtual int SetSignal(double volts) { return DEVICE_UNSUPPORTED_COMMAND; }
+    virtual int SetSignal(double) { return DEVICE_UNSUPPORTED_COMMAND; }
     virtual int GetSignal(double& volts);
     virtual int GetLimits(double& minVolts, double& maxVolts);
 
     virtual int IsDASequenceable(bool& isSequenceable) const { isSequenceable = false; return DEVICE_OK; }
-    virtual int GetDASequenceMaxLength(long& maxLength) { return DEVICE_UNSUPPORTED_COMMAND; }
+    virtual int GetDASequenceMaxLength(long&) { return DEVICE_UNSUPPORTED_COMMAND; }
     virtual int StartDASequence() { return DEVICE_UNSUPPORTED_COMMAND; }
     virtual int StopDASequence() { return DEVICE_UNSUPPORTED_COMMAND; }
     virtual int ClearDASequence() { return DEVICE_UNSUPPORTED_COMMAND; }

--- a/DeviceAdapters/NIDAQ/NIDAQ.h
+++ b/DeviceAdapters/NIDAQ/NIDAQ.h
@@ -253,6 +253,8 @@ private:
    int OnTriggerInputPort(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnSampleRate(MM::PropertyBase* pProp, MM::ActionType eAct);
 
+   int OnExpectedMaxVoltsIn(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnExpectedMinVoltsIn(MM::PropertyBase* pProp, MM::ActionType eAct);
 
    bool initialized_;
    size_t maxSequenceLength_;

--- a/DeviceAdapters/NIDAQ/NIDAQ.vcxproj
+++ b/DeviceAdapters/NIDAQ/NIDAQ.vcxproj
@@ -90,6 +90,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="NIAnalogInputPort.cpp" />
     <ClCompile Include="NIDAQ.cpp" />
     <ClCompile Include="NIAnalogOutputPort.cpp" />
     <ClCompile Include="NIDigitalOutputPort.cpp" />

--- a/DeviceAdapters/NIDAQ/NIDAQ.vcxproj.filters
+++ b/DeviceAdapters/NIDAQ/NIDAQ.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="NIDigitalOutputPort.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="NIAnalogInputPort.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="NIDAQ.h">

--- a/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
@@ -30,6 +30,7 @@ DigitalOutputPort::DigitalOutputPort(const std::string& port) :
    sequenceRunning_(false),
    blanking_(false),
    blankOnLow_(true),
+   open_(true),
    pos_(0),
    numPos_(0),
    portWidth_(0),
@@ -148,7 +149,7 @@ int DigitalOutputPort::Initialize()
    CreateProperty(MM::g_Keyword_Closed_Position, "0", MM::Integer, false);
    GetGateOpen(open_);
 
-   if (supportsBlankingAndSequencing_ && nrOfStateSliders_ >= portWidth_) {
+   if (supportsBlankingAndSequencing_ && (uint32_t) nrOfStateSliders_ >= portWidth_) {
       nrOfStateSliders_ = portWidth_ - 1;
    }
 


### PR DESCRIPTION
Expanded the driver to be able to read analog inputs and capture traces. Has been tested with NI MAX emulation software but not with actual hardware.

Things to check before merging:
- [x] Run tests with actual hardware.
- [x] Currently the trace values are read out one sample at the time but I am unsure whether this is a mistake on my side or a side effect of the emulator. 
- [x] Check whether the NIDAQmx commands used are available in the 9.2 version of the library.