### PR TITLE
Faster device initialization by multi-threading.

### DIFF
--- a/MMCore/CoreFeatures.cpp
+++ b/MMCore/CoreFeatures.cpp
@@ -112,6 +112,12 @@ const auto& featureMap() {
             // enabled perhaps a few years later.
          }
       },
+      {
+         "ParallelDeviceInitialization", {
+            [] { return g_flags.ParallelDeviceInitialization; },
+            [](bool e) { g_flags.ParallelDeviceInitialization = e; }
+         }
+      },
       // How to add a new Core feature: see the comment at the top of this file.
       // Features (the string names) must never be removed once added!
    };

--- a/MMCore/CoreFeatures.h
+++ b/MMCore/CoreFeatures.h
@@ -26,6 +26,7 @@ namespace features {
 
 struct Flags {
    bool strictInitializationChecks = false;
+   bool ParallelDeviceInitialization = true;
    // How to add a new Core feature: see the comment in the .cpp file.
 };
 

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -112,7 +112,7 @@
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 11, MMCore_versionMinor = 1, MMCore_versionPatch = 1;
+const int MMCore_versionMajor = 11, MMCore_versionMinor = 2, MMCore_versionPatch = 1;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -946,7 +946,7 @@ void CMMCore::initializeAllDevicesParallel() throw (CMMError)
       }
    }
 
-   // Initialize ports first.  This should be gast, so no need to go parallel (also could not hurt really)
+   // Initialize ports first.  This should be fast, so no need to go parallel (also could not hurt really)
    for (std::shared_ptr<DeviceInstance> pPort : ports)
    {
       mm::DeviceModuleLockGuard guard(pPort);

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -696,6 +696,8 @@ private:
    void assignDefaultRole(std::shared_ptr<DeviceInstance> pDev);
    void updateCoreProperty(const char* propName, MM::DeviceType devType) throw (CMMError);
    void loadSystemConfigurationImpl(const char* fileName) throw (CMMError);
+   void initializeAllDevicesSerial() throw (CMMError);
+   void initializeAllDevicesParallel() throw (CMMError);
    int initializeDequeOfDevices(std::deque<std::pair<std::shared_ptr<DeviceInstance>, std::string>> pDevices);
 };
 

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -698,7 +698,7 @@ private:
    void loadSystemConfigurationImpl(const char* fileName) throw (CMMError);
    void initializeAllDevicesSerial() throw (CMMError);
    void initializeAllDevicesParallel() throw (CMMError);
-   int initializeDequeOfDevices(std::deque<std::pair<std::shared_ptr<DeviceInstance>, std::string>> pDevices);
+   int initializeVectorOfDevices(std::vector<std::pair<std::shared_ptr<DeviceInstance>, std::string>> pDevices);
 };
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -696,6 +696,7 @@ private:
    void assignDefaultRole(std::shared_ptr<DeviceInstance> pDev);
    void updateCoreProperty(const char* propName, MM::DeviceType devType) throw (CMMError);
    void loadSystemConfigurationImpl(const char* fileName) throw (CMMError);
+   int initializeDequeOfDevices(std::deque<std::pair<std::shared_ptr<DeviceInstance>, std::string>> pDevices);
 };
 
 #if defined(__GNUC__) && !defined(__clang__)


### PR DESCRIPTION
This PR changes the behavior of the Core function initializeAllDevices.  It will discover all device modules contained in the list of devices to be initialized, spin up one thread per module and initialize all requested devices in that module.  This parallelizes device initialization which can improve startup times of the Micro-Manager application considerably.  Tested with a limited number of devices, I will test on a few more microscopes before merging, but requesting review (especially since I am not very experienced writing multi-threaded code in C++) now.

Minor version of Studio was upgraded according to Semver. I will wait for review before merging.