### PR TITLE
Set isSequenceable=false as this is not implemented.

### DIFF
--- a/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.cpp
+++ b/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.cpp
@@ -557,6 +557,8 @@ int AlliedVisionCamera::ClearROI()
 
 int AlliedVisionCamera::IsExposureSequenceable(bool &isSequenceable) const
 {
+    isSequenceable = false;
+  
     // TODO implement
     return VmbErrorSuccess;
 }


### PR DESCRIPTION

This fixes an issue with this device adapter that causes it to fail in some cases, such as when you try and acquire an image time series using pyrco-manager.
