### PR TITLE
Aravis/pkgconfig

### DIFF
--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -32,7 +32,7 @@
 #include <vector>
 #include <string>
 #include <algorithm>
-
+#include <cstdint>
 
 std::vector<std::string> supportedPixelFormats = {
   "Mono8",

--- a/DeviceAdapters/Aravis/Makefile.am
+++ b/DeviceAdapters/Aravis/Makefile.am
@@ -1,14 +1,10 @@
 
-AM_CXXFLAGS=$(MMDEVAPI_CXXFLAGS)
-
-# Linux, use output from from pkg-config (aravis-0.10).
-ARAVISCPPFLAGS = -I/usr/local/include/aravis-0.10 -I/usr/include/libxml2 -I/usr/include/libusb-1.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include
-ARAVISLDFLAGS = -Wl,--enable-new-dtags -Wl,-rpath,/usr/local/lib/x86_64-linux-gnu,-L/usr/local/lib/x86_64-linux-gnu
-ARAVISLDLIBS = -laravis-0.10 -lgio-2.0 -lgobject-2.0 -lglib-2.0
+AM_CPPFLAGS = $(ARAVIS_CPPFLAGS)
+AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS) $(ARAVIS_CFLAGS)
+AM_LDFLAGS = $(MMDEVAPI_LDFLAGS) $(ARAVIS_LDFLAGS)
 
 deviceadapter_LTLIBRARIES=libmmgr_dal_AravisCamera.la
+
 libmmgr_dal_AravisCamera_la_SOURCES=AravisCamera.cpp AravisCamera.h
-libmmgr_dal_AravisCamera_la_CPPFLAGS=$(ARAVISCPPFLAGS)
-libmmgr_dal_AravisCamera_la_LIBADD=$(MMDEVAPI_LIBADD) $(ARAVISLDLIBS)
-libmmgr_dal_AravisCamera_la_LDFLAGS=$(MMDEVAPI_LDFLAGS) $(ARAVISLDLIBS) $(ARAVISLDFLAGS)
+libmmgr_dal_AravisCamera_la_LIBADD=$(MMDEVAPI_LIBADD) $(ARAVIS_LIBS)
 

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -306,16 +306,6 @@ else
    AC_MSG_RESULT([not found])
 fi
 
-# Aravis (v0.10).
-#AC_MSG_CHECKING(for Aravis_Linux)
-#AM_CONDITIONAL([BUILD_ARAVIS_LINUX],[test -f "/usr/local/include/aravis-0.10/arv.h"])
-#if test -f "/usr/local/include/aravis-0.10/arv.h"; then
-#   AC_MSG_RESULT([found])
-#else 
-#   AC_MSG_RESULT([not found])
-#fi
-
-
 
 # BaslerPylon
 AC_MSG_CHECKING(for Basler_Linux)

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -307,13 +307,15 @@ else
 fi
 
 # Aravis (v0.10).
-AC_MSG_CHECKING(for Aravis_Linux)
-AM_CONDITIONAL([BUILD_ARAVIS_LINUX],[test -f "/usr/local/include/aravis-0.10/arv.h"])
-if test -f "/usr/local/include/aravis-0.10/arv.h"; then
-   AC_MSG_RESULT([found])
-else 
-   AC_MSG_RESULT([not found])
-fi
+#AC_MSG_CHECKING(for Aravis_Linux)
+#AM_CONDITIONAL([BUILD_ARAVIS_LINUX],[test -f "/usr/local/include/aravis-0.10/arv.h"])
+#if test -f "/usr/local/include/aravis-0.10/arv.h"; then
+#   AC_MSG_RESULT([found])
+#else 
+#   AC_MSG_RESULT([not found])
+#fi
+
+
 
 # BaslerPylon
 AC_MSG_CHECKING(for Basler_Linux)
@@ -362,6 +364,23 @@ else
 fi
 
 AC_SUBST(LIBITC18)
+
+
+# Aravis SDK
+MM_ARG_WITH_OPTIONAL_LIB([Aravis], [aravis], [ARAVIS])
+AS_IF([test "x$want_aravis" != xno],
+[
+   MM_LIB_ARAVIS([$ARAVIS_PREFIX],
+                  [use_aravis=yes],
+                  [
+                     use_aravis=no
+                     AS_IF([test "x$want_aravis" = xyes],
+                           [MM_MSG_OPTIONAL_LIB_FAILURE([aravis], [Aravis])])
+                  ])
+],
+[use_aravis=no])
+
+AM_CONDITIONAL([BUILD_ARAVIS_LINUX], [test "x$use_aravis" = xyes])
 
 
 # MessagePack
@@ -429,6 +448,7 @@ AS_IF([test "x$want_vimba_x" != xno],
 [use_vimba_x=no])
 
 AM_CONDITIONAL([BUILD_ALLIED_VISION_CAMERA], [test "x$use_vimba_x" = xyes])
+
 
 # Zaber Motion Library (hack: only support 3rdpartypublic copy currently)
 zml_version="3.4.4"

--- a/m4/mm_libs.m4
+++ b/m4/mm_libs.m4
@@ -66,6 +66,21 @@ AC_DEFUN([MM_LIB_HIDAPI], [
 ])
 
 
+# Check for Aravis library
+#
+# MM_LIB_ARAVIS([aravis prefix], [action-if-found], [action-if-not-found])
+#
+# Defines precious variables ARAVIS_CPPFLAGS, ARAVIS_CFLAGS, ARAVIS_LDFLAGS,
+# ARAVIS_LIBS.
+#
+AC_DEFUN([MM_LIB_ARAVIS], [
+   MM_LIB_WITH_PKG_CONFIG([ARAVIS], [Aravis], [aravis-0.10], [],
+      [$1], [-laravis],
+      [arv.h], [arv_update_device_list],
+      [$2], [$3])
+])
+
+
 # MM_LIB_MSGPACK([msgpack-prefix], [action-if-found], [action-if-not-found])
 AC_DEFUN([MM_LIB_MSGPACK], [
    AC_LANG_PUSH([C++])


### PR DESCRIPTION
This uses pkgconfig to find the Aravis library, so this is no longer hard coded. However it still only looks for the aravis-0.10 library.