### PR TITLE
make all metadata based on keywords in InsertMultiChannel

### DIFF
--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -282,23 +282,23 @@ bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned 
       auto now = std::chrono::system_clock::now();
       md.PutImageTag(MM::g_Keyword_Metadata_TimeInCore, FormatLocalTime(now));
 
-      md.PutImageTag("Width",width);
-      md.PutImageTag("Height",height);
+      md.PutImageTag(MM::g_Keyword_Metadata_Width, width);
+      md.PutImageTag(MM::g_Keyword_Metadata_Height, height);
       if (byteDepth == 1)
-         md.PutImageTag("PixelType","GRAY8");
+         md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_GRAY8);
       else if (byteDepth == 2)
-         md.PutImageTag("PixelType","GRAY16");
+         md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_GRAY16);
       else if (byteDepth == 4)
       {
          if (nComponents == 1)
-            md.PutImageTag("PixelType","GRAY32");
+            md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_GRAY32);
          else
-            md.PutImageTag("PixelType","RGB32");
+            md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_RGB32);
       }
       else if (byteDepth == 8)
-         md.PutImageTag("PixelType","RGB64");
+         md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_RGB64);
       else
-         md.PutImageTag("PixelType","Unknown"); 
+         md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_Unknown);
 
       pImg->SetMetadata(md);
       //pImg->SetPixels(pixArray + i * singleChannelSize);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -112,7 +112,7 @@
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 11, MMCore_versionMinor = 2, MMCore_versionPatch = 1;
+const int MMCore_versionMajor = 11, MMCore_versionMinor = 3, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMDevice/MMDeviceConstants.h
+++ b/MMDevice/MMDeviceConstants.h
@@ -141,8 +141,16 @@ namespace MM {
    const char* const g_Keyword_Closed_Position = "ClosedPosition";
    const char* const g_Keyword_HubID = "HubID";
 
+   const char* const g_Keyword_PixelType_GRAY8   = "GRAY8";
+   const char* const g_Keyword_PixelType_GRAY16  = "GRAY16";
+   const char* const g_Keyword_PixelType_GRAY32  = "GRAY32";
+   const char* const g_Keyword_PixelType_RGB32   = "RGB32";
+   const char* const g_Keyword_PixelType_RGB64   = "RGB64";
+   const char* const g_Keyword_PixelType_Unknown = "Unknown";
 
    // image annotations
+   const char* const g_Keyword_Metadata_Width       = "Width";
+   const char* const g_Keyword_Metadata_Height      = "Height";
    const char* const g_Keyword_Metadata_CameraLabel = "Camera";
    const char* const g_Keyword_Meatdata_Exposure    = "Exposure-ms";
    const char* const g_Keyword_Metadata_Score       = "Score";


### PR DESCRIPTION
`CircularBuffer::InsertMultiChannel` is a pretty important method that populates a `Metadata` object with some pretty critical parameters during sequence acquisition.  That Metadata object is even publicly retrievable using `getLastImageMD`; unfortunately, the keys and values in that object are hardcoded in the source code with un-exposed keywords... making it hard to rely on these values when inspecting metadata.  This PR adds a few new keywords (for "Width", "Height" and all of the pixel types, and ensures that these keywords are used when populating metadata