### PR TITLE
expose MMCore_version variables in MMCore.h

### DIFF
--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -86,6 +86,9 @@
 #   define MMCORE_DEPRECATED(prototype) prototype
 #endif
 
+extern const int MMCore_versionMajor;
+extern const int MMCore_versionMinor;
+extern const int MMCore_versionPatch;
 
 class CPluginManager;
 class CircularBuffer;


### PR DESCRIPTION
The MMCore version info is only declared in MMCore.cpp, making it a bit harder to access in bindings like pymmcore.  (you have to resort to [manually declaring it](https://github.com/micro-manager/pymmcore/blob/main/src/pymmcore/_version.py#L1) which is error prone.  this exposes those variables in the public header