### PR TITLE
add onImageSnapped, onSequenceAcquisitionStarted, onSequenceAcquisitionStopped events

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -2543,6 +2543,12 @@ void CMMCore::snapImage() throw (CMMError)
             }
             waitForDevice(shutter);
          }
+
+         if (externalCallback_)
+         {
+            std::string cameraLabel = camera->GetLabel();
+            externalCallback_->onImageSnapped(cameraLabel.c_str());
+         }         
 		}catch( CMMError& e){
 			throw e;
 		}
@@ -2856,6 +2862,11 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
    }
    LOG_DEBUG(coreLogger_) << "Did start sequence acquisition from default camera";
+   if (externalCallback_)
+   {
+      std::string cameraLabel = camera->GetLabel();
+      externalCallback_->onSequenceAcquisitionStarted(cameraLabel.c_str(), numImages, intervalMs, stopOnOverflow);
+   }
 }
 
 /**
@@ -2889,6 +2900,10 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
 
    LOG_DEBUG(coreLogger_) <<
       "Did start sequence acquisition from camera " << label;
+   if (externalCallback_)
+   {
+      externalCallback_->onSequenceAcquisitionStarted(label, numImages, intervalMs, stopOnOverflow);
+   }
 }
 
 /**
@@ -2994,6 +3009,11 @@ void CMMCore::startContinuousSequenceAcquisition(double intervalMs) throw (CMMEr
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
    }
    LOG_DEBUG(coreLogger_) << "Did start continuous sequence acquisition from current camera";
+   if (externalCallback_)
+   {
+      std::string cameraLabel = camera->GetLabel();
+      externalCallback_->onSequenceAcquisitionStarted(cameraLabel.c_str(), -1, intervalMs, false);
+   }
 }
 
 /**
@@ -3020,6 +3040,11 @@ void CMMCore::stopSequenceAcquisition() throw (CMMError)
    }
 
    LOG_DEBUG(coreLogger_) << "Did stop sequence acquisition from current camera";
+   if (externalCallback_)
+   {
+      std::string cameraLabel = camera->GetLabel();
+      externalCallback_->onSequenceAcquisitionStopped(cameraLabel.c_str());
+   }
 }
 
 /**

--- a/MMCore/MMEventCallback.h
+++ b/MMCore/MMEventCallback.h
@@ -86,4 +86,19 @@ public:
       std::cout << "onSLMExposureChanged()" << name << " " << newExposure << '\n';
    }
 
+   virtual void onImageSnapped(const char* name)
+   {
+      std::cout << "onImageSnapped()" << name << '\n';
+   }
+
+   virtual void onSequenceAcquisitionStarted(const char* name, long numImages, double intervalMs, bool stopOnOverflow)
+   {
+      std::cout << "onSequenceAcquisitionStarted()" << name << " " << numImages << " " << intervalMs << " " << stopOnOverflow << '\n';
+   }
+
+   virtual void onSequenceAcquisitionStopped(const char* name)
+   {
+      std::cout << "onSequenceAcquisitionEnded()" << name << '\n';
+   }
+
 };


### PR DESCRIPTION
These events would make it easier for the application side to "know" that a new image buffer is available to display.

As with most callbacks here, I'm aware that this implementation is slightly leaky (in that some devices may snap/start/stop without these events being emitted).  That's certainly less than ideal, but it's still better than not knowing at all, and covers cases where the core API itself is used to snap/start/stop