### PR TITLE
Adds Teensy firmware and corresponding device adapter that can send pulses to an external device (such as a camera)

### DIFF
--- a/DeviceAdapters/ArduinoCounter/ArduinoCounter.cpp
+++ b/DeviceAdapters/ArduinoCounter/ArduinoCounter.cpp
@@ -65,7 +65,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 
 
 ArduinoCounterCamera::ArduinoCounterCamera() :
-   imageBuffer_(0),
    nrCamerasInUse_(0),
    initialized_(false),
    invert_(false)
@@ -101,7 +100,6 @@ ArduinoCounterCamera::~ArduinoCounterCamera()
 
 int ArduinoCounterCamera::Shutdown()
 {
-   delete imageBuffer_;
    // Rely on the cameras to shut themselves down
    return DEVICE_OK;
 }

--- a/DeviceAdapters/ArduinoCounter/ArduinoCounter.h
+++ b/DeviceAdapters/ArduinoCounter/ArduinoCounter.h
@@ -121,7 +121,6 @@ public:
 private:
    int Logical2Physical(int logical);
    bool ImageSizesAreEqual();
-   unsigned char* imageBuffer_;
    int startCommunication();
    int startCounting(int number);
    int stopCounting();

--- a/DeviceAdapters/TeensyPulseGenerator/CameraPulser.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/CameraPulser.cpp
@@ -1,0 +1,716 @@
+#include "CameraPulser.h"
+#include "ModuleInterface.h"
+#include <sstream>
+#include <cstdio>
+
+#ifdef WIN32
+   #define WIN32_LEAN_AND_MEAN
+   #include <windows.h>
+#endif
+
+
+// Global info about the state of the Arduino.  
+const uint32_t g_Min_MMVersion = 1;
+const uint32_t g_Max_MMVersion = 1;
+const char* g_versionProp = "Version";
+const char* g_Undefined = "Undefined";
+const char* g_Logic = "Output Logic";
+const char* g_Direct = "Direct";
+const char* g_Invert = "Invert";
+
+
+const char* g_DeviceNameCameraPulser = "TeensySendsPulsesToCamera";
+
+CameraPulser::CameraPulser() :
+   initialized_(false),
+   version_(0)
+{
+   InitializeDefaultErrorMessages();
+
+   SetErrorText(ERR_INVALID_DEVICE_NAME, "Please select a valid camera");
+   SetErrorText(ERR_NO_PHYSICAL_CAMERA, "No physical camera assigned");
+   SetErrorText(ERR_FIRMWARE_VERSION_TOO_NEW, "Firmware version is newer than expected");
+   SetErrorText(ERR_FIRMWARE_VERSION_TOO_OLD, "Firmware version is older than expected");
+
+   // Name                                                                   
+   CreateProperty(MM::g_Keyword_Name, g_DeviceNameCameraPulser, MM::String, true);
+
+   // Description                                                            
+   CreateProperty(MM::g_Keyword_Description, "Use Camera in external trigger mode and provide triggers with Teensy", MM::String, true);
+
+
+   CPropertyAction* pAct = new CPropertyAction(this, &CameraPulser::OnPort);
+   CreateProperty(MM::g_Keyword_Port, "Undefined", MM::String, false, pAct, true);
+}
+
+CameraPulser::~CameraPulser()
+{
+   if (initialized_)
+      Shutdown();
+}
+
+int CameraPulser::Shutdown()
+{
+   delete imageBuffer_;
+   // Rely on the cameras to shut themselves down
+   return DEVICE_OK;
+}
+
+int CameraPulser::Initialize()
+{
+   // get list with available Cameras.   
+   std::vector<std::string> availableCameras;
+   availableCameras.clear();
+   char deviceName[MM::MaxStrLength];
+   unsigned int deviceIterator = 0;
+   for (;;)
+   {
+      GetLoadedDeviceOfType(MM::CameraDevice, deviceName, deviceIterator++);
+      if (0 < strlen(deviceName))
+      {
+         availableCameras.push_back(std::string(deviceName));
+      }
+      else
+         break;
+   }
+
+   availableCameras_.push_back(g_Undefined);
+   std::vector<std::string>::iterator iter;
+   for (iter = availableCameras.begin();
+      iter != availableCameras.end();
+      iter++)
+   {
+      MM::Device* camera = GetDevice((*iter).c_str());
+      std::ostringstream os;
+      os << this << " " << camera;
+      LogMessage(os.str().c_str());
+      if (camera && (this != camera))
+         availableCameras_.push_back(*iter);
+   }
+
+   for (unsigned i = 0; i < MAX_NUMBER_PHYSICAL_CAMERAS; i++)
+   {
+      CPropertyActionEx* pAct = new CPropertyActionEx(this, &CameraPulser::OnPhysicalCamera, i);
+      std::ostringstream os;
+      os << "Triggered Camera-" << i;
+      CreateProperty(os.str().c_str(), availableCameras_[0].c_str(), MM::String, false, pAct, false);
+      SetAllowedValues(os.str().c_str(), availableCameras_);
+   }
+
+   CPropertyAction* pAct = new CPropertyAction(this, &CameraPulser::OnBinning);
+   CreateProperty(MM::g_Keyword_Binning, "1", MM::Integer, false, pAct, false);
+
+   // start Teensy
+   teensyCom_ = new TeensyCom(GetCoreCallback(), this, port_.c_str());
+   int ret = teensyCom_->GetVersion(version_);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (version_ < g_Min_MMVersion)
+       return ERR_FIRMWARE_VERSION_TOO_OLD;
+   if (version_ > g_Max_MMVersion)
+       return ERR_FIRMWARE_VERSION_TOO_NEW;
+
+   pAct = new CPropertyAction(this, &CameraPulser::OnVersion);
+   CreateIntegerProperty(g_versionProp, version_, true, pAct);
+
+
+   initialized_ = true;
+
+   return DEVICE_OK;
+}
+
+void CameraPulser::GetName(char* name) const
+{
+   CDeviceUtils::CopyLimitedString(name, g_DeviceNameCameraPulser);
+}
+
+int CameraPulser::SnapImage()
+{
+   if (nrCamerasInUse_ < 1)
+      return ERR_NO_PHYSICAL_CAMERA;
+
+   if (!ImageSizesAreEqual())
+      return ERR_NO_EQUAL_SIZE;
+
+   CameraSnapThread t[MAX_NUMBER_PHYSICAL_CAMERAS];
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         t[i].SetCamera(camera);
+         t[i].Start();
+      }
+   }
+   // I think that the CameraSnapThread destructor waits until the SnapImage function is done
+   // So, we are likely to be waiting here until all cameras are done snapping
+
+   return DEVICE_OK;
+}
+
+/**
+ * return the ImageBuffer of the first physical camera
+ */
+const unsigned char* CameraPulser::GetImageBuffer()
+{
+   if (nrCamerasInUse_ < 1)
+      return 0;
+
+   return GetImageBuffer(0);
+}
+
+const unsigned char* CameraPulser::GetImageBuffer(unsigned channelNr)
+{
+   // We have a vector of physicalCameras, and a vector of Strings listing the cameras
+   // we actually use.  
+   int j = -1;
+   unsigned height = GetImageHeight();
+   unsigned width = GetImageWidth();
+   unsigned pixDepth = GetImageBytesPerPixel();
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (usedCameras_[i] != g_Undefined)
+         j++;
+      if (j == (int)channelNr)
+      {
+         unsigned thisHeight = camera->GetImageHeight();
+         unsigned thisWidth = camera->GetImageWidth();
+         if (height == thisHeight && width == thisWidth)
+            return camera->GetImageBuffer();
+         else
+         {
+            img_.Resize(width, height, pixDepth);
+            img_.ResetPixels();
+            if (width == thisWidth)
+            {
+               memcpy(img_.GetPixelsRW(), camera->GetImageBuffer(), thisHeight * thisWidth * pixDepth);
+            }
+            else
+            {
+               // we need to copy line by line
+               const unsigned char* pixels = camera->GetImageBuffer();
+               for (unsigned k = 0; k < thisHeight; k++)
+               {
+                  memcpy(img_.GetPixelsRW() + k * width, pixels + k * thisWidth, thisWidth);
+               }
+            }
+            return img_.GetPixels();
+         }
+      }
+   }
+   return 0;
+}
+
+bool CameraPulser::IsCapturing()
+{
+   std::vector<std::string>::iterator iter;
+   for (iter = usedCameras_.begin(); iter != usedCameras_.end(); iter++) {
+      MM::Camera* camera = (MM::Camera*)GetDevice((*iter).c_str());
+      if ((camera != 0) && camera->IsCapturing())
+         return true;
+   }
+
+   return false;
+}
+
+/**
+ * Returns the largest width of cameras used
+ */
+unsigned CameraPulser::GetImageWidth() const
+{
+   // TODO: should we use cached width?
+   // If so, when do we cache?
+   // Since this function is const, we can not cache the width found
+   unsigned width = 0;
+   unsigned int j = 0;
+   while (j < usedCameras_.size())
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[j].c_str());
+      if (camera != 0) {
+         unsigned tmp = camera->GetImageWidth();
+         if (tmp > width)
+            width = tmp;
+      }
+      j++;
+   }
+
+   return width;
+}
+
+/**
+ * Returns the largest height of cameras used
+ */
+unsigned CameraPulser::GetImageHeight() const
+{
+   unsigned height = 0;
+   unsigned int j = 0;
+   while (j < usedCameras_.size())
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[j].c_str());
+      if (camera != 0)
+      {
+         unsigned tmp = camera->GetImageHeight();
+         if (tmp > height)
+            height = tmp;
+      }
+      j++;
+   }
+
+   return height;
+}
+
+
+/**
+ * Returns true if image sizes of all available cameras are identical
+ * false otherwise
+ * edge case: if we have no or one camera, their sizes are equal
+ */
+bool CameraPulser::ImageSizesAreEqual() {
+   unsigned height = 0;
+   unsigned width = 0;
+   for (unsigned int i = 0; i < usedCameras_.size(); i++) {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         height = camera->GetImageHeight();
+         width = camera->GetImageWidth();
+      }
+   }
+
+   for (unsigned int i = 0; i < usedCameras_.size(); i++) {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         if (height != camera->GetImageHeight())
+            return false;
+         if (width != camera->GetImageWidth())
+            return false;
+      }
+   }
+   return true;
+}
+
+unsigned CameraPulser::GetImageBytesPerPixel() const
+{
+   MM::Camera* camera0 = (MM::Camera*)GetDevice(usedCameras_[0].c_str());
+   if (camera0 != 0)
+   {
+      unsigned bytes = camera0->GetImageBytesPerPixel();
+      for (unsigned int i = 1; i < usedCameras_.size(); i++)
+      {
+         MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+         if (camera != 0)
+            if (bytes != camera->GetImageBytesPerPixel())
+               return 0;
+      }
+      return bytes;
+   }
+   return 0;
+}
+
+unsigned CameraPulser::GetBitDepth() const
+{
+   // Return the maximum bit depth found in all channels.
+   MM::Camera* camera0 = (MM::Camera*)GetDevice(usedCameras_[0].c_str());
+   if (camera0 != 0)
+   {
+      unsigned bitDepth = 0;
+      for (unsigned int i = 0; i < usedCameras_.size(); i++)
+      {
+         MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+         if (camera != 0)
+         {
+            unsigned nextBitDepth = camera->GetBitDepth();
+            if (nextBitDepth > bitDepth)
+            {
+               bitDepth = nextBitDepth;
+            }
+         }
+      }
+      return bitDepth;
+   }
+   return 0;
+}
+
+long CameraPulser::GetImageBufferSize() const
+{
+   long maxSize = 0;
+   int unsigned counter = 0;
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         counter++;
+         long tmp = camera->GetImageBufferSize();
+         if (tmp > maxSize)
+            maxSize = tmp;
+      }
+   }
+
+   return counter * maxSize;
+}
+
+double CameraPulser::GetExposure() const
+{
+   MM::Camera* camera0 = (MM::Camera*)GetDevice(usedCameras_[0].c_str());
+   if (camera0 != 0)
+   {
+      double exposure = camera0->GetExposure();
+      for (unsigned int i = 1; i < usedCameras_.size(); i++)
+      {
+         MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+         if (camera != 0)
+            if (exposure != camera->GetExposure())
+               return 0;
+      }
+      return exposure;
+   }
+   return 0.0;
+}
+
+void CameraPulser::SetExposure(double exp)
+{
+   if (exp > 0.0)
+   {
+      for (unsigned int i = 0; i < usedCameras_.size(); i++)
+      {
+         MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+         if (camera != 0)
+            camera->SetExposure(exp);
+      }
+   }
+}
+
+int CameraPulser::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize)
+{
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      // TODO: deal with case when CCD size are not identical
+      if (camera != 0)
+      {
+         int ret = camera->SetROI(x, y, xSize, ySize);
+         if (ret != DEVICE_OK)
+            return ret;
+      }
+   }
+   return DEVICE_OK;
+}
+
+int CameraPulser::GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize)
+{
+   MM::Camera* camera0 = (MM::Camera*)GetDevice(usedCameras_[0].c_str());
+   // TODO: check if ROI is same on all cameras
+   if (camera0 != 0)
+   {
+      int ret = camera0->GetROI(x, y, xSize, ySize);
+      if (ret != DEVICE_OK)
+         return ret;
+   }
+
+   return DEVICE_OK;
+}
+
+int CameraPulser::ClearROI()
+{
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         int ret = camera->ClearROI();
+         if (ret != DEVICE_OK)
+            return ret;
+      }
+   }
+
+   return DEVICE_OK;
+}
+
+int CameraPulser::PrepareSequenceAcqusition()
+{
+   if (nrCamerasInUse_ < 1)
+      return ERR_NO_PHYSICAL_CAMERA;
+
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         int ret = camera->PrepareSequenceAcqusition();
+         if (ret != DEVICE_OK)
+            return ret;
+      }
+   }
+
+   return DEVICE_OK;
+}
+
+int CameraPulser::StartSequenceAcquisition(double interval)
+{
+   if (nrCamerasInUse_ < 1)
+      return ERR_NO_PHYSICAL_CAMERA;
+
+   if (!ImageSizesAreEqual())
+      return ERR_NO_EQUAL_SIZE;
+
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         std::ostringstream os;
+         os << i;
+         camera->AddTag(MM::g_Keyword_CameraChannelName, usedCameras_[i].c_str(),
+            usedCameras_[i].c_str());
+         camera->AddTag(MM::g_Keyword_CameraChannelIndex, usedCameras_[i].c_str(),
+            os.str().c_str());
+
+         int ret = camera->StartSequenceAcquisition(interval);
+         if (ret != DEVICE_OK)
+            return ret;
+      }
+   }
+   return DEVICE_OK;
+}
+
+int CameraPulser::StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow)
+{
+   if (nrCamerasInUse_ < 1)
+      return ERR_NO_PHYSICAL_CAMERA;
+
+   uint32_t response;
+   int ret = teensyCom_->SetNumberOfPulses(numImages, response);
+   if (response != (uint32_t) numImages)
+      return ERR_COMMUNICATION;
+
+   // First start camera sequences, then start trigger
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         ret = camera->StartSequenceAcquisition(numImages, interval_ms, stopOnOverflow);
+         if (ret != DEVICE_OK)
+            return ret;
+      }
+   }
+
+   ret = teensyCom_->SetStart(response);
+   if (ret != DEVICE_OK) // TODO: Check response
+      return ret;
+
+   return DEVICE_OK;
+}
+
+int CameraPulser::StopSequenceAcquisition()
+{
+   uint32_t response;
+   int ret = teensyCom_->SetStop(response);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         ret = camera->StopSequenceAcquisition();
+         if (ret != DEVICE_OK)
+            return ret;
+
+         std::ostringstream os;
+         os << i;
+         camera->AddTag(MM::g_Keyword_CameraChannelName, usedCameras_[i].c_str(),
+            "");
+         camera->AddTag(MM::g_Keyword_CameraChannelIndex, usedCameras_[i].c_str(),
+            os.str().c_str());
+      }
+   }
+   std::ostringstream os;
+   os << "Stopp Sequence after sending " << response << " pulses.";
+   GetCoreCallback()->LogMessage(this, os.str().c_str(), false);
+
+   return DEVICE_OK;
+}
+
+int CameraPulser::GetBinning() const
+{
+   MM::Camera* camera0 = (MM::Camera*)GetDevice(usedCameras_[0].c_str());
+   int binning = 0;
+   if (camera0 != 0)
+      binning = camera0->GetBinning();
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         if (binning != camera->GetBinning())
+            return 0;
+      }
+   }
+   return binning;
+}
+
+int CameraPulser::SetBinning(int bS)
+{
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         int ret = camera->SetBinning(bS);
+         if (ret != DEVICE_OK)
+            return ret;
+      }
+   }
+   return DEVICE_OK;
+}
+
+int CameraPulser::IsExposureSequenceable(bool& isSequenceable) const
+{
+   isSequenceable = false;
+
+   return DEVICE_OK;
+}
+
+unsigned CameraPulser::GetNumberOfComponents() const
+{
+   return 1;
+}
+
+unsigned CameraPulser::GetNumberOfChannels() const
+{
+   return nrCamerasInUse_;
+}
+
+int CameraPulser::GetChannelName(unsigned channel, char* name)
+{
+   CDeviceUtils::CopyLimitedString(name, "");
+   int ch = Logical2Physical(channel);
+   if (ch >= 0 && static_cast<unsigned>(ch) < usedCameras_.size())
+   {
+      CDeviceUtils::CopyLimitedString(name, usedCameras_[ch].c_str());
+   }
+   return DEVICE_OK;
+}
+
+int CameraPulser::Logical2Physical(int logical)
+{
+   int j = -1;
+   for (unsigned int i = 0; i < usedCameras_.size(); i++)
+   {
+      if (usedCameras_[i] != g_Undefined)
+         j++;
+      if (j == logical)
+         return i;
+   }
+   return -1;
+}
+
+
+int CameraPulser::OnPhysicalCamera(MM::PropertyBase* pProp, MM::ActionType eAct, long i)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(usedCameras_[i].c_str());
+   }
+
+   else if (eAct == MM::AfterSet)
+   {
+      MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
+      if (camera != 0)
+      {
+         camera->RemoveTag(MM::g_Keyword_CameraChannelName);
+         camera->RemoveTag(MM::g_Keyword_CameraChannelIndex);
+      }
+
+      std::string cameraName;
+      pProp->Get(cameraName);
+
+      if (cameraName == g_Undefined) {
+         usedCameras_[i] = g_Undefined;
+      }
+      else {
+         camera = (MM::Camera*)GetDevice(cameraName.c_str());
+         if (camera != 0) {
+            usedCameras_[i] = cameraName;
+            std::ostringstream os;
+            os << i;
+            char myName[MM::MaxStrLength];
+            GetLabel(myName);
+            camera->AddTag(MM::g_Keyword_CameraChannelName, myName, usedCameras_[i].c_str());
+            camera->AddTag(MM::g_Keyword_CameraChannelIndex, myName, os.str().c_str());
+         }
+         else
+            return ERR_INVALID_DEVICE_NAME;
+      }
+      nrCamerasInUse_ = 0;
+      for (unsigned int usedCameraCounter = 0; usedCameraCounter < usedCameras_.size(); usedCameraCounter++)
+      {
+         if (usedCameras_[usedCameraCounter] != g_Undefined)
+            nrCamerasInUse_++;
+      }
+
+      // TODO: Set allowed binning values correctly
+      MM::Camera* camera0 = (MM::Camera*)GetDevice(usedCameras_[0].c_str());
+      if (camera0 != 0)
+      {
+         ClearAllowedValues(MM::g_Keyword_Binning);
+         int nr = camera0->GetNumberOfPropertyValues(MM::g_Keyword_Binning);
+         for (int j = 0; j < nr; j++)
+         {
+            char value[MM::MaxStrLength];
+            camera0->GetPropertyValueAt(MM::g_Keyword_Binning, j, value);
+            AddAllowedValue(MM::g_Keyword_Binning, value);
+         }
+      }
+   }
+
+   return DEVICE_OK;
+}
+
+int CameraPulser::OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set((long)GetBinning());
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      long binning;
+      pProp->Get(binning);
+      int ret = SetBinning(binning);
+      if (ret != DEVICE_OK)
+         return ret;
+   }
+   return DEVICE_OK;
+}
+
+int CameraPulser::OnPort(MM::PropertyBase* pProp, MM::ActionType pAct)
+{
+   if (pAct == MM::BeforeGet)
+   {
+      pProp->Set(port_.c_str());
+   }
+   else if (pAct == MM::AfterSet)
+   {
+      pProp->Get(port_);
+   }
+   return DEVICE_OK;
+}
+
+
+int CameraPulser::OnVersion(MM::PropertyBase* pProp, MM::ActionType pAct)
+{
+   if (pAct == MM::BeforeGet)
+   {
+      pProp->Set((long)version_);
+   }
+   return DEVICE_OK;
+}
+
+

--- a/DeviceAdapters/TeensyPulseGenerator/CameraPulser.h
+++ b/DeviceAdapters/TeensyPulseGenerator/CameraPulser.h
@@ -63,16 +63,18 @@ public:
    int OnPhysicalCamera(MM::PropertyBase* pProp, MM::ActionType eAct, long i);
    int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnVersion(MM::PropertyBase* pProp, MM::ActionType pAct);
+   int OnPulseDuration(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnInterval(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
    bool ImageSizesAreEqual();
    int Logical2Physical(int logical);
 
-   unsigned char* imageBuffer_;
-
    std::vector<std::string> availableCameras_;
    std::vector<std::string> usedCameras_;
    std::string usedCamera_;
+   double interval_; // Interval in ms
+   double pulseDuration_; // Pulse duration in milli-seconds
    bool initialized_;
    unsigned int nrCamerasInUse_;
    ImgBuffer img_;
@@ -81,4 +83,6 @@ private:
    TeensyCom* teensyCom_;
 
    uint32_t version_;
+   uint32_t nrPulses_; // nr Pulses we request
+   uint32_t nrPulsesCounted_; // as returned by the Teensy
 };

--- a/DeviceAdapters/TeensyPulseGenerator/CameraPulser.h
+++ b/DeviceAdapters/TeensyPulseGenerator/CameraPulser.h
@@ -64,7 +64,7 @@ public:
    int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnVersion(MM::PropertyBase* pProp, MM::ActionType pAct);
    int OnPulseDuration(MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnInterval(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnIntervalBeyondExposure(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
    bool ImageSizesAreEqual();
@@ -73,7 +73,7 @@ private:
    std::vector<std::string> availableCameras_;
    std::vector<std::string> usedCameras_;
    std::string usedCamera_;
-   double interval_; // Interval in ms
+   double intervalBeyondExposure_; // Interval beyond exposure time in ms
    double pulseDuration_; // Pulse duration in milli-seconds
    bool initialized_;
    unsigned int nrCamerasInUse_;

--- a/DeviceAdapters/TeensyPulseGenerator/CameraPulser.h
+++ b/DeviceAdapters/TeensyPulseGenerator/CameraPulser.h
@@ -1,0 +1,84 @@
+#pragma once
+
+
+#include "DeviceBase.h"
+#include "MMDevice.h"
+#include "ImgBuffer.h"
+#include "TeensyCom.h"
+
+#define ERR_INVALID_DEVICE_NAME            10001
+#define ERR_NO_PHYSICAL_CAMERA             10010
+#define ERR_NO_EQUAL_SIZE                  10011
+#define ERR_FIRMWARE_VERSION_TOO_NEW       10012
+#define ERR_FIRMWARE_VERSION_TOO_OLD       10013
+#define MAX_NUMBER_PHYSICAL_CAMERAS       1
+
+
+class CameraPulser : public CCameraBase<CameraPulser>
+{
+public:
+   CameraPulser();
+   ~CameraPulser();
+
+   // MMDevice API
+   // ------------
+   int Initialize();
+   int Shutdown();
+  
+   void GetName(char* name) const;      
+   
+   // MMCamera API
+   // ------------
+
+   int SnapImage();
+   const unsigned char* GetImageBuffer();
+   const unsigned char* GetImageBuffer(unsigned channelNr);
+   unsigned GetImageWidth() const;
+   unsigned GetImageHeight() const;
+   unsigned GetImageBytesPerPixel() const;
+   unsigned GetBitDepth() const;
+   long GetImageBufferSize() const;
+   double GetExposure() const;
+   void SetExposure(double exp);
+   int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
+   int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
+   int ClearROI();
+   int PrepareSequenceAcqusition();
+   int StartSequenceAcquisition(double interval);
+   int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
+   int StopSequenceAcquisition();
+   int GetBinning() const;
+   int SetBinning(int bS);
+   int IsExposureSequenceable(bool& isSequenceable) const;
+   unsigned  GetNumberOfComponents() const;
+   unsigned  GetNumberOfChannels() const;
+   int GetChannelName(unsigned channel, char* name);
+   bool IsCapturing();
+
+   // action interface
+   // ---------------
+
+   // property handlers
+   int OnPort(MM::PropertyBase* pPropt, MM::ActionType eAct);
+   int OnPhysicalCamera(MM::PropertyBase* pProp, MM::ActionType eAct, long i);
+   int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnVersion(MM::PropertyBase* pProp, MM::ActionType pAct);
+
+private:
+   bool ImageSizesAreEqual();
+   int Logical2Physical(int logical);
+
+   unsigned char* imageBuffer_;
+
+   std::vector<std::string> availableCameras_;
+   std::vector<std::string> usedCameras_;
+   std::string usedCamera_;
+   bool initialized_;
+   unsigned int nrCamerasInUse_;
+   ImgBuffer img_;
+   std::string port_;
+
+   TeensyCom* teensyCom_;
+
+   uint32_t version_;
+};

--- a/DeviceAdapters/TeensyPulseGenerator/CameraPulser.h
+++ b/DeviceAdapters/TeensyPulseGenerator/CameraPulser.h
@@ -65,6 +65,7 @@ public:
    int OnVersion(MM::PropertyBase* pProp, MM::ActionType pAct);
    int OnPulseDuration(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnIntervalBeyondExposure(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnWaitForInput(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
    bool ImageSizesAreEqual();
@@ -75,6 +76,7 @@ private:
    std::string usedCamera_;
    double intervalBeyondExposure_; // Interval beyond exposure time in ms
    double pulseDuration_; // Pulse duration in milli-seconds
+   bool waitForInput_; // Whether to wait sending the pulse for the input to go high
    bool initialized_;
    unsigned int nrCamerasInUse_;
    ImgBuffer img_;

--- a/DeviceAdapters/TeensyPulseGenerator/Module.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/Module.cpp
@@ -1,0 +1,37 @@
+#include "TeensyPulseGenerator.h"
+#include "CameraPulser.h"
+
+///////////////////////////////////////////////////////////////////////////////
+// Exported MMDevice API
+///////////////////////////////////////////////////////////////////////////////
+
+const char* g_PulseGenerator = "TeensyPulseGenerator";
+const char* g_CameraPulser = "TeensySendsPulsesToCamera";
+
+MODULE_API void InitializeModuleData()
+{
+   RegisterDevice(g_PulseGenerator, MM::GenericDevice, "Teensy Pulse Generator");
+   RegisterDevice(g_CameraPulser, MM::CameraDevice, "CameraPulser");
+}
+
+MODULE_API MM::Device* CreateDevice(const char* deviceName)
+{
+   if (deviceName == 0)
+       return 0;
+
+   if (strcmp(deviceName, g_PulseGenerator) == 0)
+   {
+       return new TeensyPulseGenerator();
+   } 
+   else if (strcmp(deviceName, g_CameraPulser) == 0)
+   {
+      return new CameraPulser;
+   }
+
+   return 0;
+}
+
+MODULE_API void DeleteDevice(MM::Device* pDevice)
+{
+    delete pDevice;
+}

--- a/DeviceAdapters/TeensyPulseGenerator/SingleThread.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/SingleThread.cpp
@@ -1,0 +1,51 @@
+#include "SingleThread.h"
+
+#include <thread>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <functional>
+
+SingleThread::SingleThread() : running(true) 
+{
+  thread = std::thread(&SingleThread::run, this);
+}
+
+SingleThread::~SingleThread() 
+{
+   {
+      std::unique_lock<std::mutex> lock(mutex);
+      running = false;
+      condition.notify_one();
+   }
+   thread.join();
+}
+
+void SingleThread::enqueue(std::function<void()> task) {
+   {
+      std::unique_lock<std::mutex> lock(mutex);
+      tasks.push(task);
+   }
+   condition.notify_one();
+}
+
+void SingleThread::run() {
+   while (running) 
+   {
+      std::function<void()> task;
+      {
+         std::unique_lock<std::mutex> lock(mutex);
+         condition.wait(lock, [this] { return !tasks.empty() || !running; });
+         if (!tasks.empty()) 
+         {
+            task = tasks.front();
+            tasks.pop();
+         }
+      }
+      if (task) {
+         task();
+      }
+  }
+}
+
+

--- a/DeviceAdapters/TeensyPulseGenerator/SingleThread.h
+++ b/DeviceAdapters/TeensyPulseGenerator/SingleThread.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <thread>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <functional>
+
+class SingleThread {
+public:
+   SingleThread();
+   ~SingleThread();
+   void enqueue(std::function<void()> task);
+
+private:
+   void run(); 
+
+   std::thread thread;
+   std::queue<std::function<void()>> tasks;
+   std::mutex mutex;
+   std::condition_variable condition;
+   bool running;
+};
+

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyCom.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyCom.cpp
@@ -1,0 +1,105 @@
+#include "TeensyCom.h"
+
+TeensyCom::TeensyCom(MM::Core* callback, MM::Device* device, const char* portLabel) :
+   callback_(callback),
+   device_(device),
+   portLabel_(portLabel)
+{
+   callback->PurgeSerial(device, portLabel_);
+}
+
+int TeensyCom::SendCommand(uint8_t cmd, uint32_t param)
+{
+   // This should not be needed, but just in case:
+   
+   callback_->PurgeSerial(device_, portLabel_);
+
+    // Prepare buffer
+   const unsigned int buflen = 5;
+   unsigned char buffer[buflen];
+   buffer[0] = cmd;
+   // This needs work when we have a Big Endian host, the Teensy is little endian
+   alignas(uint32_t) char alignedByteArray[4];
+   std::memcpy(alignedByteArray, &param, 4);
+
+   // For commands that require a parameter, convert to little-endian
+   buffer[1] = alignedByteArray[0];
+   buffer[2] = alignedByteArray[1];
+   buffer[3] = alignedByteArray[2];
+   buffer[4] = alignedByteArray[3];
+
+   // Send 5-byte command
+   return callback_->WriteToSerial(device_, portLabel_, buffer, buflen);
+}
+
+int TeensyCom::Enquire(uint8_t cmd)
+{
+   const unsigned int buflen = 2;
+   unsigned char buffer[buflen];
+   buffer[0] = 255;
+   buffer[1] = cmd;
+
+   return callback_->WriteToSerial(device_, portLabel_, buffer, buflen);
+}
+
+
+int TeensyCom::GetResponse(uint8_t cmd, uint32_t& param)
+{
+   unsigned char buf[1] = { 0 };
+   unsigned long read = 0;
+   MM::TimeoutMs timeout = MM::TimeoutMs(callback_->GetCurrentMMTime(), 1000);
+   while (read == 0) {
+      if (timeout.expired(callback_->GetCurrentMMTime()))
+      {
+         return ERR_COMMUNICATION;
+      }
+      callback_->ReadFromSerial(device_, portLabel_, buf, 1, read);
+   }
+   if (read == 1 && buf[0] == cmd)
+   {
+      unsigned char buf2[4] = { 0, 0, 0, 0 };
+      read = 0;
+      unsigned long tmpRead = 0;
+      while (read < 4)
+      {
+         if (timeout.expired(callback_->GetCurrentMMTime()))
+         {
+            return ERR_COMMUNICATION;
+         }
+         callback_->ReadFromSerial(device_, portLabel_, &buf2[read], 4 - read, tmpRead);
+         read += tmpRead;
+      }
+      alignas(uint32_t) char alignedByteArray[4];
+      std::memcpy(alignedByteArray, buf2, sizeof(buf2));
+
+      // This needs change on a Big endian host (PC and Teensy are both little endian).
+      param = *(reinterpret_cast<uint32_t*>(alignedByteArray));
+
+      std::ostringstream os;
+      os << "Read: " << param;
+      callback_->LogMessage(device_, os.str().c_str(), true);
+   }
+   else
+   {
+      return ERR_COMMUNICATION;
+   }
+   return DEVICE_OK;
+}
+
+// get firmware version
+int TeensyCom::GetVersion(uint32_t& version)
+{
+   int ret = SendCommand(cmd_version, 0);
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(0, version);
+}
+
+// Get interval between pulses
+int TeensyCom::GetInterval(uint32_t& interval)
+{
+   int ret = Enquire(cmd_interval);
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(cmd_interval, interval);
+}

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyCom.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyCom.cpp
@@ -1,5 +1,6 @@
 #include "TeensyCom.h"
 
+
 TeensyCom::TeensyCom(MM::Core* callback, MM::Device* device, const char* portLabel) :
    callback_(callback),
    device_(device),
@@ -86,9 +87,19 @@ int TeensyCom::GetResponse(uint8_t cmd, uint32_t& param)
    return DEVICE_OK;
 }
 
+int TeensyCom::GetRunningStatus(uint32_t& status)
+{
+   const std::lock_guard<std::mutex> lock(mutex_);
+   int ret = Enquire(cmd_start);
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(cmd_start, status);
+}
+
 // get firmware version
 int TeensyCom::GetVersion(uint32_t& version)
 {
+   const std::lock_guard<std::mutex> lock(mutex_);
    int ret = SendCommand(cmd_version, 0);
    if (ret != DEVICE_OK)
       return ret;
@@ -98,8 +109,98 @@ int TeensyCom::GetVersion(uint32_t& version)
 // Get interval between pulses
 int TeensyCom::GetInterval(uint32_t& interval)
 {
+   const std::lock_guard<std::mutex> lock(mutex_);
    int ret = Enquire(cmd_interval);
    if (ret != DEVICE_OK)
       return ret;
    return GetResponse(cmd_interval, interval);
 }
+
+int TeensyCom::GetPulseDuration(uint32_t& pulseDuration)
+{
+   const std::lock_guard<std::mutex> lock(mutex_);
+   int ret = Enquire(cmd_pulse_duration);
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(cmd_pulse_duration, pulseDuration);
+}
+
+int TeensyCom::GetWaitForInput(uint32_t& waitForInput)
+{
+   const std::lock_guard<std::mutex> lock(mutex_);
+   int ret = Enquire(cmd_wait_for_input);
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(cmd_wait_for_input, waitForInput);
+}
+
+int TeensyCom::GetNumberOfPulses(uint32_t& nrPulses)
+{
+   const std::lock_guard<std::mutex> lock(mutex_);
+   int ret = Enquire(cmd_number_of_pulses);
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(cmd_number_of_pulses, nrPulses);
+}
+
+int TeensyCom::SetStart(uint32_t& response)
+{
+   const std::lock_guard<std::mutex> lock(mutex_);
+   int ret = SendCommand(cmd_start, 0); // Start command
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(cmd_start, response);
+}
+
+int TeensyCom::SetStop(uint32_t& response)
+{
+   const std::lock_guard<std::mutex> lock(mutex_);
+   int ret = SendCommand(cmd_stop, 0); // Start command
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(cmd_stop, response);
+}
+
+int TeensyCom::SetInterval(uint32_t interval, uint32_t& response)
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    int ret = SendCommand(cmd_interval, interval);
+    if (ret != DEVICE_OK)
+       return ret;
+    return GetResponse(cmd_interval, response);
+}
+
+
+// Sets the pulse duration in microseconds
+// return error on serial comm problem.  
+// response contains Teensy reposonse (hopefully same as pulseDuration).
+int TeensyCom::SetPulseDuration(uint32_t pulseDuration, uint32_t& response)
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    int ret = SendCommand(cmd_pulse_duration, pulseDuration);
+    if (ret != DEVICE_OK)
+       return ret;
+    return GetResponse(cmd_pulse_duration, response);
+}
+
+
+int TeensyCom::SetWaitForInput(uint32_t waitForInput, uint32_t& response)
+{
+   const std::lock_guard<std::mutex> lock(mutex_);
+   int ret = SendCommand(cmd_wait_for_input, waitForInput);
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(cmd_wait_for_input, response);
+}
+
+
+int TeensyCom::SetNumberOfPulses(uint32_t numberOfPulses, uint32_t& response)
+{
+   const std::lock_guard<std::mutex> lock(mutex_);
+   int ret = SendCommand(cmd_number_of_pulses, numberOfPulses);
+   if (ret != DEVICE_OK)
+      return ret;
+   return GetResponse(cmd_number_of_pulses, response);
+}
+
+

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyCom.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyCom.h
@@ -18,6 +18,31 @@ const unsigned char cmd_wait_for_input = 5;
 const unsigned char cmd_number_of_pulses = 6;
 
 
+/**
+ * CameraSnapThread: helper thread
+ */
+class CameraSnapThread : public MMDeviceThreadBase
+{
+public:
+   CameraSnapThread() :
+      camera_(0),
+      started_(false)
+   {}
+
+   ~CameraSnapThread() { if (started_) wait(); }
+
+   void SetCamera(MM::Camera* camera) { camera_ = camera; }
+
+   int svc() { camera_->SnapImage(); return 0; }
+
+   void Start() { activate(); started_ = true; }
+
+private:
+   MM::Camera* camera_;
+   bool started_;
+};
+
+
 class TeensyCom
 {
 public:

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyCom.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyCom.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "DeviceBase.h"
+#include "MMDevice.h"
+
+#define ERR_PORT_OPEN_FAILED 106
+#define ERR_COMMUNICATION 107
+#define ERR_NO_PORT_SET 108
+#define ERR_VERSION_MISMATCH 109
+
+const unsigned char cmd_version = 0;
+const unsigned char cmd_start = 1;
+const unsigned char cmd_stop = 2;
+const unsigned char cmd_interval = 3; // interval in microseconds
+const unsigned char cmd_pulse_duration = 4; // in microsconds
+const unsigned char cmd_wait_for_input = 5;
+const unsigned char cmd_number_of_pulses = 6;
+
+
+class TeensyCom
+{
+public:
+
+   TeensyCom(MM::Core* callback, MM::Device* device, const char* portLabel);
+
+   ~TeensyCom() {};
+
+   int SendCommand(uint8_t cmd, uint32_t param);
+   int Enquire(uint8_t cmd);
+   int GetResponse(uint8_t cmd, uint32_t& param);
+   int GetVersion(uint32_t& version);
+   int GetInterval(uint32_t& interval);
+
+
+private:
+   MM::Core* callback_;
+   MM::Device* device_;
+   const char* portLabel_;
+};

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyCom.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyCom.h
@@ -2,6 +2,7 @@
 
 #include "DeviceBase.h"
 #include "MMDevice.h"
+#include <mutex>
 
 #define ERR_PORT_OPEN_FAILED 106
 #define ERR_COMMUNICATION 107
@@ -27,13 +28,24 @@ public:
 
    int SendCommand(uint8_t cmd, uint32_t param);
    int Enquire(uint8_t cmd);
+   int GetRunningStatus(uint32_t& status);
    int GetResponse(uint8_t cmd, uint32_t& param);
    int GetVersion(uint32_t& version);
    int GetInterval(uint32_t& interval);
+   int GetPulseDuration(uint32_t& pulseDuration);
+   int GetWaitForInput(uint32_t& waitForInput);
+   int GetNumberOfPulses(uint32_t& numberOfPulses);
+   int SetStart(uint32_t& response);
+   int SetStop(uint32_t& response);
+   int SetInterval(uint32_t interval, uint32_t& response);
+   int SetPulseDuration(uint32_t pulseDuration, uint32_t& response);
+   int SetWaitForInput(uint32_t waitForInput, uint32_t& response);
+   int SetNumberOfPulses(uint32_t numberOfPulses, uint32_t& response);
 
 
 private:
    MM::Core* callback_;
    MM::Device* device_;
    const char* portLabel_;
+   std::mutex mutex_;
 };

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
@@ -1,0 +1,284 @@
+#include "TeensyPulseGenerator.h"
+
+
+TeensyPulseGenerator::TeensyPulseGenerator() :
+    initialized_(false),
+    port_(""),
+    interval_(10000),     // Default 10ms interval
+    pulseDuration_(500),  // Default 500us pulse
+    triggerMode_(true),   // Default trigger mode on
+    running_(false)       // Not running initially
+{
+   InitializeDefaultErrorMessages();
+
+   // Add custom error messages
+   SetErrorText(ERR_PORT_OPEN_FAILED, "Failed to open serial port");
+   SetErrorText(ERR_COMMUNICATION, "Communication error with device");
+
+   // Create serial port property
+   CPropertyAction* pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnPort);
+   CreateProperty(MM::g_Keyword_Port, "Undefined", MM::String, false, pAct, true);
+}
+
+TeensyPulseGenerator::~TeensyPulseGenerator()
+{
+    Shutdown();
+}
+
+void TeensyPulseGenerator::GetName(char* name) const
+{
+    CDeviceUtils::CopyLimitedString(name, "TeensyPulseGenerator");
+}
+
+int TeensyPulseGenerator::Initialize()
+{
+    if (initialized_)
+        return DEVICE_OK;
+
+    // Ensure port is set
+    if (port_.empty())
+        return ERR_NO_PORT_SET;
+
+    // Open serial port
+    PurgeComPort(port_.c_str());
+
+
+    // Create properties
+
+    // Interval property
+    CPropertyAction* pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnInterval);
+    CreateProperty("Interval-us", CDeviceUtils::ConvertToString(interval_), MM::Float, false, pAct);
+    SetPropertyLimits("Interval-us", 1.0, 1000000.0);
+
+    // Pulse Duration property
+    pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnPulseDuration);
+    CreateProperty("PulseDuration-us", CDeviceUtils::ConvertToString(pulseDuration_), MM::Float, false, pAct);
+    SetPropertyLimits("PulseDuration-us", 1.0, 100000.0);
+
+    // Trigger Mode property
+    pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnTriggerMode);
+    CreateProperty("TriggerMode", triggerMode_ ? "On" : "Off", MM::String, false, pAct);
+    AddAllowedValue("TriggerMode", "Off");
+    AddAllowedValue("TriggerMode", "On");
+
+    // State (Start/Stop) property
+    pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnState);
+    CreateProperty("State", "Stop", MM::String, false, pAct);
+    AddAllowedValue("State", "Stop");
+    AddAllowedValue("State", "Start");
+
+    initialized_ = true;
+    return DEVICE_OK;
+}
+
+int TeensyPulseGenerator::Shutdown()
+{
+    if (port_ != "")
+    {
+       // Ensure device is stopped
+       SendCommand(2);  // Stop command
+    }
+    initialized_ = false;
+    return DEVICE_OK;
+}
+
+bool TeensyPulseGenerator::Busy()
+{
+    return false;  // This device doesn't have a concept of "busy"
+}
+
+int TeensyPulseGenerator::SendCommand(uint8_t cmd, uint32_t param)
+{
+    // Prepare buffer
+   const unsigned int buflen = 5;
+   unsigned char buffer[buflen];
+   buffer[0] = cmd;
+
+   // For commands that require a parameter, convert to little-endian
+   if (cmd >= 3 && cmd <= 5)
+   {
+      buffer[1] = param & 0xFF;
+      buffer[2] = (param >> 8) & 0xFF;
+      buffer[3] = (param >> 16) & 0xFF;
+      buffer[4] = (param >> 24) & 0xFF;
+
+      // Send 5-byte command
+      return WriteToComPort(port_.c_str(), buffer, buflen);
+   }
+   else
+   {
+      // Send 1-byte command
+      return WriteToComPort(port_.c_str(), buffer, 1);
+   }
+}
+
+
+bool TeensyPulseGenerator::ReadResponse(std::string& response)
+{
+   return GetSerialAnswer(port_.c_str(), "\r\n", response);
+}
+
+int TeensyPulseGenerator::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+    if (eAct == MM::BeforeGet)
+    {
+        pProp->Set(port_.c_str());
+    }
+    else if (eAct == MM::AfterSet)
+    {
+        pProp->Get(port_);
+    }
+    return DEVICE_OK;
+}
+
+int TeensyPulseGenerator::OnInterval(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+    if (eAct == MM::BeforeGet)
+    {
+        pProp->Set(interval_);
+    }
+    else if (eAct == MM::AfterSet)
+    {
+        pProp->Get(interval_);
+        
+        // Send interval command if initialized
+        if (initialized_)
+        {
+           int ret = SendCommand(3, static_cast<uint32_t>(interval_));
+           if (ret != DEVICE_OK)
+              return ret;
+           std::string response;
+           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) 
+           {
+               return ERR_COMMUNICATION;
+           }
+           // TODO: check we received the correct asnwer, for now: log
+           GetCoreCallback()->LogMessage(this, response.c_str(), true);
+        }
+    }
+    return DEVICE_OK;
+}
+
+int TeensyPulseGenerator::OnPulseDuration(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+    if (eAct == MM::BeforeGet)
+    {
+        pProp->Set(pulseDuration_);
+    }
+    else if (eAct == MM::AfterSet)
+    {
+        pProp->Get(pulseDuration_);
+        
+        // Send pulse duration command if initialized
+        if (initialized_)
+        {
+           int ret = SendCommand(4, static_cast<uint32_t>(interval_));
+           if (ret != DEVICE_OK)
+              return ret;
+           std::string response;
+           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) {
+               return ERR_COMMUNICATION;
+           }
+           // TODO: check we received the correct asnwer, for now: log
+           GetCoreCallback()->LogMessage(this, response.c_str(), true);
+        }
+    }
+    return DEVICE_OK;
+}
+
+int TeensyPulseGenerator::OnTriggerMode(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+    if (eAct == MM::BeforeGet)
+    {
+        pProp->Set(triggerMode_ ? "On" : "Off");
+    }
+    else if (eAct == MM::AfterSet)
+    {
+        std::string triggerModeStr;
+        pProp->Get(triggerModeStr);
+        triggerMode_ = (triggerModeStr == "On");
+        
+        // Send trigger mode command if initialized
+        if (initialized_)
+        {
+           int ret = SendCommand(5, triggerMode_ ? 1 : 0);
+           if (ret != DEVICE_OK)
+              return ret;
+           std::string response;
+           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) {
+               return ERR_COMMUNICATION;
+           }
+           // TODO: check we received the correct asnwer, for now: log
+           GetCoreCallback()->LogMessage(this, response.c_str(), true);
+        }
+    }
+    return DEVICE_OK;
+}
+
+int TeensyPulseGenerator::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+    if (eAct == MM::BeforeGet)
+    {
+        pProp->Set(running_ ? "Start" : "Stop");
+    }
+    else if (eAct == MM::AfterSet)
+    {
+        std::string stateStr;
+        pProp->Get(stateStr);
+        
+        if (stateStr == "Start" && !running_)
+        {
+           int ret = SendCommand(1); // Start command
+           if (ret != DEVICE_OK)
+              return ret;
+           std::string response;
+           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) {
+               return ERR_COMMUNICATION;
+           }
+           // TODO: check we received the correct asnwer, for now: log
+           GetCoreCallback()->LogMessage(this, response.c_str(), true);
+           running_ = true;
+        }
+        else if (stateStr == "Stop" && running_)
+        {
+           int ret = SendCommand(2); // Stop command
+           if (ret != DEVICE_OK)
+              return ret;
+           std::string response;
+           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) {
+               return ERR_COMMUNICATION;
+           }
+           // TODO: check we received the correct asnwer, for now: log
+           GetCoreCallback()->LogMessage(this, response.c_str(), true);
+           running_ = false;
+        }
+    }
+    return DEVICE_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Exported MMDevice API
+///////////////////////////////////////////////////////////////////////////////
+
+MODULE_API void InitializeModuleData()
+{
+    RegisterDevice("TeensyPulseGenerator", MM::GenericDevice, "Teensy Pulse Generator");
+}
+
+MODULE_API MM::Device* CreateDevice(const char* deviceName)
+{
+    if (deviceName == 0)
+        return 0;
+
+    if (strcmp(deviceName, "TeensyPulseGenerator") == 0)
+    {
+        return new TeensyPulseGenerator();
+    }
+
+    return 0;
+}
+
+MODULE_API void DeleteDevice(MM::Device* pDevice)
+{
+    delete pDevice;
+}

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
@@ -440,13 +440,12 @@ int TeensyPulseGenerator::OnNrPulses(MM::PropertyBase* pProp, MM::ActionType eAc
  */
 void TeensyPulseGenerator::CheckStatus()
 {
-   long microSecondWait = (long) ((nrPulses_ - 1) * interval_ + pulseDuration_);
-   long wait = (microSecondWait / 1000);
+   long milliSecondWait = (long) ((nrPulses_ - 1) * interval_ + pulseDuration_);
    long waited = 0;
-   long waitDuration = 500;
+   long waitDuration = 500; // arbitrary wait
    // Break the wait up and check whether the destructor has been called so that we will not 
    // delay destruction of this object.
-   while (waited < wait)
+   while (waited < milliSecondWait)
    {
       if (!initialized_)
          return;
@@ -462,7 +461,7 @@ void TeensyPulseGenerator::CheckStatus()
          GetResponse(cmd_start, response);
          running_ = (bool)response;
       }
-      Sleep((long) (interval_ / 1000));
+      Sleep((long) (interval_));
    }
    GetCoreCallback()->OnPropertyChanged(this, "Status", "Idle");
 }
@@ -501,12 +500,6 @@ int TeensyPulseGenerator::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
                   return this->CheckStatus();
                };
                singleThread_.enqueue(func);
-             // std::function<void()> func = (TeensyPulseGenerator::CheckStatus, this);
-
-              //std::thread t (&TeensyPulseGenerator::CheckStatus, this, wait);
-              // Note: we will crash if the destructor of this is called while the thread is running
-              // need to come up with something cleaner..
-              //t.detach();
            }
         }
         else if (stateStr == "Stop" && running_)

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
@@ -435,14 +435,24 @@ int TeensyPulseGenerator::OnNrPulses(MM::PropertyBase* pProp, MM::ActionType eAc
    return DEVICE_OK;
 }
 
+/**
+ * Called from a seperate thread.
+ */
 void TeensyPulseGenerator::CheckStatus()
 {
-               long microSecondWait = (long) ((nrPulses_ - 1) * interval_ + pulseDuration_);
-               long wait = (microSecondWait / 1000);
-   // TODO: this could be a long wait.
-   // Break it up and check whether the destructor has been called so that we will not 
+   long microSecondWait = (long) ((nrPulses_ - 1) * interval_ + pulseDuration_);
+   long wait = (microSecondWait / 1000);
+   long waited = 0;
+   long waitDuration = 500;
+   // Break the wait up and check whether the destructor has been called so that we will not 
    // delay destruction of this object.
-   Sleep(wait);
+   while (waited < wait)
+   {
+      if (!initialized_)
+         return;
+      Sleep(waitDuration);
+      waited += waitDuration;
+   }
    while (running_)
    {
       {

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
@@ -1,13 +1,25 @@
 #include "TeensyPulseGenerator.h"
 
+#ifdef WIN32
+#include <winsock.h>
+#else
+#include <netinet/in.h> // #include <arpa/inet.h>
+#endif
+
+const char* g_RunUntilStopped = "Run_Until_Stopped";
+const char* g_NrPulses = "Number_of_Pulses";
 
 TeensyPulseGenerator::TeensyPulseGenerator() :
     initialized_(false),
     port_(""),
-    interval_(10000),     // Default 10ms interval
-    pulseDuration_(500),  // Default 500us pulse
-    triggerMode_(true),   // Default trigger mode on
-    running_(false)       // Not running initially
+    interval_(100),      // Default 100ms interval
+    pulseDuration_(10),   // Default 10ms pulse
+    triggerMode_(false),    // Default trigger mode on
+    running_(false),        // Not running initially
+    runUntilStopped_(true), // Keep on pulsing until stopped
+    version_(0),            // version of the firmware
+    nrPulses_(1)            // Number of pulses, only relevant if !runUntilStopped_ 
+
 {
    InitializeDefaultErrorMessages();
 
@@ -32,43 +44,68 @@ void TeensyPulseGenerator::GetName(char* name) const
 
 int TeensyPulseGenerator::Initialize()
 {
-    if (initialized_)
-        return DEVICE_OK;
+   if (initialized_)
+       return DEVICE_OK;
 
     // Ensure port is set
-    if (port_.empty())
-        return ERR_NO_PORT_SET;
+   if (port_.empty())
+       return ERR_NO_PORT_SET;
 
-    // Open serial port
-    PurgeComPort(port_.c_str());
+   // Open serial port
+   PurgeComPort(port_.c_str());
 
 
-    // Create properties
+   // Create properties
 
-    // Interval property
-    CPropertyAction* pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnInterval);
-    CreateProperty("Interval-us", CDeviceUtils::ConvertToString(interval_), MM::Float, false, pAct);
-    SetPropertyLimits("Interval-us", 1.0, 1000000.0);
+   // Interval property
+   CPropertyAction* pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnInterval);
+   CreateFloatProperty("Interval-ms", interval_, false, pAct);
+   //SetPropertyLimits("Interval-ms", 1, 1000000);
 
-    // Pulse Duration property
-    pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnPulseDuration);
-    CreateProperty("PulseDuration-us", CDeviceUtils::ConvertToString(pulseDuration_), MM::Float, false, pAct);
-    SetPropertyLimits("PulseDuration-us", 1.0, 100000.0);
+   // Pulse Duration property
+   pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnPulseDuration);
+   CreateFloatProperty("PulseDuration-ms", pulseDuration_, false, pAct);
+   //SetPropertyLimits("PulseDuration-us", 1, 100000);
 
-    // Trigger Mode property
-    pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnTriggerMode);
-    CreateProperty("TriggerMode", triggerMode_ ? "On" : "Off", MM::String, false, pAct);
-    AddAllowedValue("TriggerMode", "Off");
-    AddAllowedValue("TriggerMode", "On");
+   // Trigger Mode property
+   pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnTriggerMode);
+   CreateProperty("TriggerMode", triggerMode_ ? "On" : "Off", MM::String, false, pAct);
+   AddAllowedValue("TriggerMode", "Off");
+   AddAllowedValue("TriggerMode", "On");
 
-    // State (Start/Stop) property
-    pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnState);
-    CreateProperty("State", "Stop", MM::String, false, pAct);
-    AddAllowedValue("State", "Stop");
-    AddAllowedValue("State", "Start");
+   // Run until Stopped property
+   pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnRunUntilStopped);
+   CreateProperty(g_RunUntilStopped, runUntilStopped_ ? "On" : "Off", MM::String, false, pAct);
+   AddAllowedValue(g_RunUntilStopped, "Off");
+   AddAllowedValue(g_RunUntilStopped, "On");
 
-    initialized_ = true;
-    return DEVICE_OK;
+   // Sets the Number of pulses.  Will only be used if runUntilStopped == false
+   pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnNrPulses);
+   CreateIntegerProperty(g_NrPulses, nrPulses_, false, pAct);
+
+
+   // State (Start/Stop) property
+   pAct = new CPropertyAction(this, &TeensyPulseGenerator::OnState);
+   CreateProperty("State", "Stop", MM::String, false, pAct);
+   AddAllowedValue("State", "Stop");
+   AddAllowedValue("State", "Start");
+
+   int ret = SendCommand(0, 0); 
+   if (ret != DEVICE_OK)
+      return ret;
+   ret = GetResponse(0, version_);
+   if (ret != DEVICE_OK)
+      return ret;
+   std::ostringstream os;
+   os << version_;
+   CreateProperty("Firmware-version", os.str().c_str(), MM::String, true);
+
+   ret = UpdateStatus();
+   if (ret != DEVICE_OK)
+      return ret;
+
+   initialized_ = true;
+   return DEVICE_OK;
 }
 
 int TeensyPulseGenerator::Shutdown()
@@ -76,7 +113,7 @@ int TeensyPulseGenerator::Shutdown()
     if (port_ != "")
     {
        // Ensure device is stopped
-       SendCommand(2);  // Stop command
+       SendCommand(2, 0);  // Stop command
     }
     initialized_ = false;
     return DEVICE_OK;
@@ -89,34 +126,70 @@ bool TeensyPulseGenerator::Busy()
 
 int TeensyPulseGenerator::SendCommand(uint8_t cmd, uint32_t param)
 {
+   // This should not be needed, but just in case:
+   PurgeComPort(port_.c_str());
+
     // Prepare buffer
    const unsigned int buflen = 5;
    unsigned char buffer[buflen];
    buffer[0] = cmd;
+   // This needs work when we have a Big Endian host, the Teensy is little endian
+   alignas(uint32_t) char alignedByteArray[4];
+   std::memcpy(alignedByteArray, &param, 4);
 
    // For commands that require a parameter, convert to little-endian
-   if (cmd >= 3 && cmd <= 5)
-   {
-      buffer[1] = param & 0xFF;
-      buffer[2] = (param >> 8) & 0xFF;
-      buffer[3] = (param >> 16) & 0xFF;
-      buffer[4] = (param >> 24) & 0xFF;
+   buffer[1] = alignedByteArray[0];
+   buffer[2] = alignedByteArray[1];
+   buffer[3] = alignedByteArray[2];
+   buffer[4] = alignedByteArray[3];
 
-      // Send 5-byte command
-      return WriteToComPort(port_.c_str(), buffer, buflen);
-   }
-   else
-   {
-      // Send 1-byte command
-      return WriteToComPort(port_.c_str(), buffer, 1);
-   }
+   // Send 5-byte command
+   return WriteToComPort(port_.c_str(), buffer, buflen);
 }
 
+int TeensyPulseGenerator::GetResponse(uint8_t cmd, uint32_t& param) 
+{ 
+   unsigned char buf[1] = { 0 };
+   unsigned long read = 0;
+   MM::TimeoutMs timeout = MM::TimeoutMs(GetCurrentMMTime(), 1000);
+   while (read == 0) {
+      if (timeout.expired(GetCurrentMMTime()))
+      {
+         return ERR_COMMUNICATION;
+      }
+      ReadFromComPort(port_.c_str(), buf, 1, read);
+   }
+   if (read == 1 && buf[0] == cmd)
+   {
+      unsigned char buf2[4] = { 0, 0, 0, 0 };
+      read = 0;
+      unsigned long tmpRead = 0;
+      while (read < 4)
+      {
+         if (timeout.expired(GetCurrentMMTime()))
+         {
+            return ERR_COMMUNICATION;
+         }
+         ReadFromComPort(port_.c_str(), &buf2[read], 4 - read, tmpRead);
+         read += tmpRead;
+      }
+      alignas(uint32_t) char alignedByteArray[4];
+      std::memcpy(alignedByteArray, buf2, sizeof(buf2));
 
-bool TeensyPulseGenerator::ReadResponse(std::string& response)
-{
-   return GetSerialAnswer(port_.c_str(), "\r\n", response);
+      // This needs change on a Big endian host (PC and Teensy are both little endian).
+      param =  *(reinterpret_cast<uint32_t*>(alignedByteArray));
+
+      std::ostringstream os;
+      os << "Read: " << param;
+      GetCoreCallback()->LogMessage(this, os.str().c_str(), true);
+    } 
+    else
+    {
+       return ERR_COMMUNICATION;
+    }
+   return DEVICE_OK;
 }
+
 
 int TeensyPulseGenerator::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
@@ -139,25 +212,31 @@ int TeensyPulseGenerator::OnInterval(MM::PropertyBase* pProp, MM::ActionType eAc
     }
     else if (eAct == MM::AfterSet)
     {
-        pProp->Get(interval_);
+       pProp->Get(interval_);
         
-        // Send interval command if initialized
-        if (initialized_)
-        {
-           int ret = SendCommand(3, static_cast<uint32_t>(interval_));
-           if (ret != DEVICE_OK)
-              return ret;
-           std::string response;
-           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) 
-           {
-               return ERR_COMMUNICATION;
-           }
-           // TODO: check we received the correct asnwer, for now: log
-           GetCoreCallback()->LogMessage(this, response.c_str(), true);
-        }
+       // Send interval command if initialized
+       if (initialized_)
+       {
+          PurgeComPort(port_.c_str());
+          uint32_t interval = static_cast<uint32_t> (interval_ * 1000.0);
+          unsigned char cmd = 3;
+          int ret = SendCommand(cmd, interval);
+          if (ret != DEVICE_OK)
+             return ret;
+          uint32_t parm;
+          ret = GetResponse(cmd, parm);
+          if (ret != DEVICE_OK)
+             return ret;
+          if (parm != interval)
+          {
+            GetCoreCallback()->LogMessage(this, "Interval sent not the same as interval echoed back", false);
+            return ERR_COMMUNICATION;
+          }
+       }
     }
     return DEVICE_OK;
 }
+
 
 int TeensyPulseGenerator::OnPulseDuration(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
@@ -167,53 +246,142 @@ int TeensyPulseGenerator::OnPulseDuration(MM::PropertyBase* pProp, MM::ActionTyp
     }
     else if (eAct == MM::AfterSet)
     {
-        pProp->Get(pulseDuration_);
+       pProp->Get(pulseDuration_);
         
-        // Send pulse duration command if initialized
-        if (initialized_)
-        {
-           int ret = SendCommand(4, static_cast<uint32_t>(interval_));
-           if (ret != DEVICE_OK)
-              return ret;
-           std::string response;
-           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) {
-               return ERR_COMMUNICATION;
-           }
-           // TODO: check we received the correct asnwer, for now: log
-           GetCoreCallback()->LogMessage(this, response.c_str(), true);
-        }
-    }
-    return DEVICE_OK;
+       // Send pulse duration command if initialized
+       if (initialized_)
+       {
+          uint32_t pulseDurationUs =  static_cast<uint32_t>(pulseDuration_ * 1000.0);
+          unsigned char cmd = 4;
+
+          int ret = SendCommand(cmd, pulseDurationUs);
+          if (ret != DEVICE_OK)
+             return ret;
+          uint32_t param;
+          ret = GetResponse(cmd, param);
+          if (ret != DEVICE_OK)
+             return ret;
+          if (param != pulseDurationUs)
+          {
+            GetCoreCallback()->LogMessage(this, "PulseDuration sent not the same as pulseDuration echoed back", false);
+            return ERR_COMMUNICATION;
+
+          }
+       }
+   }
+   return DEVICE_OK;
 }
+
 
 int TeensyPulseGenerator::OnTriggerMode(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-    if (eAct == MM::BeforeGet)
-    {
-        pProp->Set(triggerMode_ ? "On" : "Off");
-    }
-    else if (eAct == MM::AfterSet)
-    {
-        std::string triggerModeStr;
-        pProp->Get(triggerModeStr);
-        triggerMode_ = (triggerModeStr == "On");
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(triggerMode_ ? "On" : "Off");
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      std::string triggerModeStr;
+      pProp->Get(triggerModeStr);
+      triggerMode_ = (triggerModeStr == "On");
         
-        // Send trigger mode command if initialized
-        if (initialized_)
-        {
-           int ret = SendCommand(5, triggerMode_ ? 1 : 0);
-           if (ret != DEVICE_OK)
-              return ret;
-           std::string response;
-           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) {
-               return ERR_COMMUNICATION;
-           }
-           // TODO: check we received the correct asnwer, for now: log
-           GetCoreCallback()->LogMessage(this, response.c_str(), true);
-        }
-    }
-    return DEVICE_OK;
+      // Send trigger mode command if initialized
+      if (initialized_)
+      {
+         unsigned char cmd = 5;
+         uint32_t sp = triggerMode_ ? 1 : 0;
+         int ret = SendCommand(cmd, sp);
+         if (ret != DEVICE_OK)
+            return ret;
+         uint32_t param;
+         ret = GetResponse(cmd, param);
+         if (param != sp)
+         {
+            GetCoreCallback()->LogMessage(this, "Triggermode sent not the same as triggermode echoed back", false);
+            return ERR_COMMUNICATION;
+         }
+      }
+   }
+   return DEVICE_OK;
 }
+
+int TeensyPulseGenerator::OnRunUntilStopped(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(runUntilStopped_ ? "On" : "Off");
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      std::string stateStr;
+      pProp->Get(stateStr);
+      if (stateStr == "On" && !runUntilStopped_)
+      {
+         unsigned char cmd = 6;
+         int ret = SendCommand(cmd, static_cast<uint32_t> (0));
+         if (ret != DEVICE_OK)
+            return ret;
+         uint32_t param;
+         ret = GetResponse(cmd, param);
+         if (param != 0)
+         {
+            GetCoreCallback()->LogMessage(this, "NrPulses sent (0) not the same as number of pulses received", false);
+            return ERR_COMMUNICATION;
+
+         }
+         runUntilStopped_ = true;
+      }
+      else if (stateStr == "Off" && runUntilStopped_)
+      {
+         unsigned char cmd = 6;
+         int ret = SendCommand(cmd, nrPulses_);
+         if (ret != DEVICE_OK)
+            return ret;
+         uint32_t param;
+         ret = GetResponse(cmd, param);
+         if (nrPulses_ != param) {
+            GetCoreCallback()->LogMessage(this, "NrPulses sent not the same as number of pulses received", false);
+            return ERR_COMMUNICATION;
+         }
+         runUntilStopped_ = false;
+      }
+   }
+   return DEVICE_OK;
+}
+
+
+int TeensyPulseGenerator::OnNrPulses(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set((long) nrPulses_);
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      long nrPulses;
+      pProp->Get(nrPulses);
+      if ((unsigned) nrPulses != nrPulses_)
+      {
+
+         nrPulses_ = (unsigned) nrPulses;
+         if (!runUntilStopped_)
+         {
+            unsigned char cmd = 6;
+            int ret = SendCommand(cmd, nrPulses_);
+            if (ret != DEVICE_OK)
+               return ret;
+            uint32_t param;
+            ret = GetResponse(cmd, param);
+            if (nrPulses_ != param) {
+               GetCoreCallback()->LogMessage(this, "NrPulses sent not the same as number of pulses received", false);
+               return ERR_COMMUNICATION;
+            }
+         }
+      }
+   }
+   return DEVICE_OK;
+}
+
 
 int TeensyPulseGenerator::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
@@ -228,33 +396,35 @@ int TeensyPulseGenerator::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
         
         if (stateStr == "Start" && !running_)
         {
-           int ret = SendCommand(1); // Start command
+           unsigned char cmd = 1;
+           int ret = SendCommand(cmd, 0); // Start command
            if (ret != DEVICE_OK)
               return ret;
-           std::string response;
-           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) {
-               return ERR_COMMUNICATION;
-           }
-           // TODO: check we received the correct asnwer, for now: log
-           GetCoreCallback()->LogMessage(this, response.c_str(), true);
+           uint32_t param;
+           ret = GetResponse(cmd, param);
+           if (ret != DEVICE_OK)
+              return ret;
+           if (param != 0)
+              return ERR_COMMUNICATION;
            running_ = true;
         }
         else if (stateStr == "Stop" && running_)
         {
-           int ret = SendCommand(2); // Stop command
+           unsigned char cmd = 2;
+           int ret = SendCommand(cmd, 0); // Stop command
            if (ret != DEVICE_OK)
               return ret;
-           std::string response;
-           if (GetSerialAnswer(port_.c_str(), "\r\n", response) != DEVICE_OK) {
-               return ERR_COMMUNICATION;
-           }
-           // TODO: check we received the correct asnwer, for now: log
-           GetCoreCallback()->LogMessage(this, response.c_str(), true);
+           uint32_t param;
+           ret = GetResponse(cmd, param);
+           if (ret != DEVICE_OK)
+              return ret;
            running_ = false;
+           // param holds the number of pulses
         }
     }
     return DEVICE_OK;
 }
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // Exported MMDevice API

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.cpp
@@ -1,4 +1,5 @@
 #include "TeensyPulseGenerator.h"
+#include "CameraPulser.h"
 #include <thread>
 
 #ifdef WIN32
@@ -11,6 +12,7 @@ const char* g_RunUntilStopped = "Run_Until_Stopped";
 const char* g_NrPulses = "Number_of_Pulses";
 const char* g_NrPulsesCounted = "Number_of_Actual_Pulses";
 
+const char* g_TeensyPulseGenerator = "TeensyPulseGenerator";
 
 TeensyPulseGenerator::TeensyPulseGenerator() :
    initialized_(false),
@@ -43,7 +45,7 @@ TeensyPulseGenerator::~TeensyPulseGenerator()
 
 void TeensyPulseGenerator::GetName(char* name) const
 {
-    CDeviceUtils::CopyLimitedString(name, "TeensyPulseGenerator");
+    CDeviceUtils::CopyLimitedString(name, g_TeensyPulseGenerator);
 }
 
 int TeensyPulseGenerator::Initialize()
@@ -418,31 +420,4 @@ int TeensyPulseGenerator::OnNrPulsesCounted(MM::PropertyBase* pProp, MM::ActionT
       pProp->Set((long) nrPulsesCounted_);
    }
    return DEVICE_OK;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Exported MMDevice API
-///////////////////////////////////////////////////////////////////////////////
-
-MODULE_API void InitializeModuleData()
-{
-    RegisterDevice("TeensyPulseGenerator", MM::GenericDevice, "Teensy Pulse Generator");
-}
-
-MODULE_API MM::Device* CreateDevice(const char* deviceName)
-{
-    if (deviceName == 0)
-        return 0;
-
-    if (strcmp(deviceName, "TeensyPulseGenerator") == 0)
-    {
-        return new TeensyPulseGenerator();
-    }
-
-    return 0;
-}
-
-MODULE_API void DeleteDevice(MM::Device* pDevice)
-{
-    delete pDevice;
 }

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
@@ -7,15 +7,11 @@
 #include "ModuleInterface.h"
 #include "MMDevice.h"
 #include "SingleThread.h"
+#include "TeensyCom.h"
 #include <cstdio>
 #include <string>
 #include <vector>
 #include <mutex>
-
-#define ERR_PORT_OPEN_FAILED 106
-#define ERR_COMMUNICATION 107
-#define ERR_NO_PORT_SET 108
-#define ERR_VERSION_MISMATCH 109
 
 class TeensyPulseGenerator : public CGenericBase<TeensyPulseGenerator>
 {
@@ -42,6 +38,7 @@ public:
 private:
     std::atomic<bool> initialized_;
     std::string port_;
+    TeensyCom* teensyCom_;
 
     // Current configuration
     double interval_;     // Interval in milli-seconds

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
@@ -2,10 +2,11 @@
 #ifndef _TeensyPulseGenerator_H
 #define _TeensyPulseGenerator_H_
 
-#include "MMDevice.h"
 #include "DeviceBase.h"
 #include "DeviceUtils.h"
 #include "ModuleInterface.h"
+#include "MMDevice.h"
+#include "SingleThread.h"
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -51,12 +52,13 @@ private:
     uint32_t version_;
     uint32_t nrPulses_;
     std::mutex mutex_;
+    SingleThread singleThread_;
 
     // Helper methods for serial communication
     int SendCommand(uint8_t cmd, uint32_t param = 0);
     int Enquire(uint8_t cmd);
     int GetResponse(uint8_t cmd, uint32_t& param);
-    void CheckStatus(long wait);
+    void CheckStatus();
 };
 
 #endif

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #define ERR_PORT_OPEN_FAILED 106
 #define ERR_COMMUNICATION 107
@@ -33,6 +34,7 @@ public:
     int OnPulseDuration(MM::PropertyBase* pProp, MM::ActionType eAct);
     int OnTriggerMode(MM::PropertyBase* pProp, MM::ActionType eAct);
     int OnState(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnStatus(MM::PropertyBase* pProp, MM::ActionType eAct);
     int OnRunUntilStopped(MM::PropertyBase* pProp, MM::ActionType eAct);
     int OnNrPulses(MM::PropertyBase* pProp, MM::ActionType eAct);
 
@@ -48,10 +50,13 @@ private:
     bool runUntilStopped_;
     uint32_t version_;
     uint32_t nrPulses_;
+    std::mutex mutex_;
 
     // Helper methods for serial communication
     int SendCommand(uint8_t cmd, uint32_t param = 0);
+    int Enquire(uint8_t cmd);
     int GetResponse(uint8_t cmd, uint32_t& param);
+    void CheckStatus(long wait);
 };
 
 #endif

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
@@ -33,20 +33,25 @@ public:
     int OnPulseDuration(MM::PropertyBase* pProp, MM::ActionType eAct);
     int OnTriggerMode(MM::PropertyBase* pProp, MM::ActionType eAct);
     int OnState(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnRunUntilStopped(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnNrPulses(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
     bool initialized_;
     std::string port_;
 
     // Current configuration
-    double interval_;     // Interval in microseconds
-    double pulseDuration_; // Pulse duration in microseconds
+    double interval_;     // Interval in milli-seconds
+    double pulseDuration_; // Pulse duration in milli-seconds
     bool triggerMode_;    // Trigger mode enabled/disabled
     bool running_;        // Pulse generator running state
+    bool runUntilStopped_;
+    uint32_t version_;
+    uint32_t nrPulses_;
 
     // Helper methods for serial communication
     int SendCommand(uint8_t cmd, uint32_t param = 0);
-    bool ReadResponse(std::string& response);
+    int GetResponse(uint8_t cmd, uint32_t& param);
 };
 
 #endif

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
@@ -40,7 +40,7 @@ public:
     int OnNrPulses(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
-    bool initialized_;
+    std::atomic<bool> initialized_;
     std::string port_;
 
     // Current configuration

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
@@ -1,0 +1,52 @@
+
+#ifndef _TeensyPulseGenerator_H
+#define _TeensyPulseGenerator_H_
+
+#include "MMDevice.h"
+#include "DeviceBase.h"
+#include "DeviceUtils.h"
+#include "ModuleInterface.h"
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#define ERR_PORT_OPEN_FAILED 106
+#define ERR_COMMUNICATION 107
+#define ERR_NO_PORT_SET 108
+#define ERR_VERSION_MISMATCH 109
+
+class TeensyPulseGenerator : public CGenericBase<TeensyPulseGenerator>
+{
+public:
+    TeensyPulseGenerator();
+    ~TeensyPulseGenerator();
+
+    // MMDevice API
+    int Initialize();
+    int Shutdown();
+    void GetName(char* name) const;
+    bool Busy();
+
+    // action interface 
+    int OnPort(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnInterval(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnPulseDuration(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnTriggerMode(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnState(MM::PropertyBase* pProp, MM::ActionType eAct);
+
+private:
+    bool initialized_;
+    std::string port_;
+
+    // Current configuration
+    double interval_;     // Interval in microseconds
+    double pulseDuration_; // Pulse duration in microseconds
+    bool triggerMode_;    // Trigger mode enabled/disabled
+    bool running_;        // Pulse generator running state
+
+    // Helper methods for serial communication
+    int SendCommand(uint8_t cmd, uint32_t param = 0);
+    bool ReadResponse(std::string& response);
+};
+
+#endif

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.h
@@ -34,6 +34,7 @@ public:
     int OnStatus(MM::PropertyBase* pProp, MM::ActionType eAct);
     int OnRunUntilStopped(MM::PropertyBase* pProp, MM::ActionType eAct);
     int OnNrPulses(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnNrPulsesCounted(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
     std::atomic<bool> initialized_;
@@ -47,14 +48,12 @@ private:
     bool running_;        // Pulse generator running state
     bool runUntilStopped_;
     uint32_t version_;
-    uint32_t nrPulses_;
+    uint32_t nrPulses_; // nr Pulses we request
+    uint32_t nrPulsesCounted_; // as returned by the Teensy
     std::mutex mutex_;
     SingleThread singleThread_;
 
     // Helper methods for serial communication
-    int SendCommand(uint8_t cmd, uint32_t param = 0);
-    int Enquire(uint8_t cmd);
-    int GetResponse(uint8_t cmd, uint32_t& param);
     void CheckStatus();
 };
 

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
@@ -92,10 +92,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SingleThread.h" />
+    <ClInclude Include="TeensyCom.h" />
     <ClInclude Include="TeensyPulseGenerator.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SingleThread.cpp" />
+    <ClCompile Include="TeensyCom.cpp" />
     <ClCompile Include="TeensyPulseGenerator.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
@@ -91,11 +91,14 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="CameraPulser.h" />
     <ClInclude Include="SingleThread.h" />
     <ClInclude Include="TeensyCom.h" />
     <ClInclude Include="TeensyPulseGenerator.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="CameraPulser.cpp" />
+    <ClCompile Include="Module.cpp" />
     <ClCompile Include="SingleThread.cpp" />
     <ClCompile Include="TeensyCom.cpp" />
     <ClCompile Include="TeensyPulseGenerator.cpp" />

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{4C9DE8BC-FAFE-43C6-A2D8-4169DBA9BDD9}</ProjectGuid>
+    <RootNamespace>TeensyPulseGenerator</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\MMDevice\MMDevice-SharedRuntime.vcxproj">
+      <Project>{4C9DE8BC-FAFE-43C6-A2D8-4169DBA9BDD9}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="TeensyPulseGenerator.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="TeensyPulseGenerator.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
@@ -62,6 +62,7 @@
     <Link>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -81,6 +82,7 @@
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj
@@ -91,9 +91,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="SingleThread.h" />
     <ClInclude Include="TeensyPulseGenerator.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="SingleThread.cpp" />
     <ClCompile Include="TeensyPulseGenerator.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj.filters
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj.filters
@@ -21,12 +21,18 @@
     <ClInclude Include="SingleThread.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="TeensyCom.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="TeensyPulseGenerator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="SingleThread.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="TeensyCom.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj.filters
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj.filters
@@ -18,9 +18,15 @@
     <ClInclude Include="TeensyPulseGenerator.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="SingleThread.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="TeensyPulseGenerator.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SingleThread.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj.filters
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4C9DE8BC-FAFE-43C6-A2D8-4169DBA9BDD9}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{4C9DE8BC-FAFE-43C6-A2D8-4169DBA9BDD9}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="TeensyPulseGenerator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="TeensyPulseGenerator.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj.filters
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClInclude Include="TeensyCom.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CameraPulser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="TeensyPulseGenerator.cpp">
@@ -33,6 +36,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="TeensyCom.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CameraPulser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Module.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator/TeensyPulseGenerator.ino
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator/TeensyPulseGenerator.ino
@@ -42,7 +42,7 @@ private:
     // Configuration parameters
     uint8_t outputPin = LED_BUILTIN;
     uint8_t triggerPin = 2;
-    uint32_t pulseDuration = 5000;     // Pulse duration in microseconds
+    uint32_t pulseDuration = 1000;     // Pulse duration in microseconds
     uint32_t pulseInterval = 100000;   // Interval between pulses in microseconds
     uint32_t numberOfPulses;  // When set to zero go on until stop
     bool waitForTrigger;        // Flag to wait for input trigger

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator/TeensyPulseGenerator.ino
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator/TeensyPulseGenerator.ino
@@ -2,6 +2,9 @@
 
 static const uint32_t version = 1;
 
+uint8_t outputPin = 8;  // LED_BUILTIN;
+uint8_t inputPin = 2;
+
 /**
 Note: The pulse pin nr and input pin nr are hard coded.
 Change as needed.
@@ -37,10 +40,12 @@ Commands:
 */
 
 
+
 class PulseGenerator {
 private:
-    // Configuration parameters
-    uint8_t outputPin = LED_BUILTIN;
+    // Configuration parameters, note that outputPin and triggerPin 
+    // will be overwritten in the constructor 
+    uint8_t outputPin = LED_BUILTIN;    
     uint8_t triggerPin = 2;
     uint32_t pulseDuration = 1000;     // Pulse duration in microseconds
     uint32_t pulseInterval = 100000;   // Interval between pulses in microseconds
@@ -403,7 +408,7 @@ void setup() {
     delay(1000);
 
     // Create pulse generator on pin 13 with optional trigger on pin 12
-    pulsegen = new PulseGenerator(13, 12);
+    pulsegen = new PulseGenerator(outputPin, inputPin);
 
     // Configure initial defaults
     pulsegen->configure(50000, 500000, 0, false);

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator/TeensyPulseGenerator.ino
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator/TeensyPulseGenerator.ino
@@ -1,0 +1,297 @@
+#include <Arduino.h>
+
+class PulseGenerator {
+private:
+    // Configuration parameters
+    uint8_t outputPin = LED_BUILTIN;
+    uint8_t triggerPin = 2;
+    uint32_t pulseDuration = 5000;     // Pulse duration in microseconds
+    uint32_t pulseInterval = 100000;   // Interval between pulses in microseconds
+    uint32_t numberOfPulses;  // When set to zero go on until stop
+    bool waitForTrigger;        // Flag to wait for input trigger
+    bool isRunning;             // Flag to track running state
+
+    // Timer interrupt variables
+    IntervalTimer pulseTimer;
+    IntervalTimer intervalTimer;
+
+    // State tracking
+    volatile bool isPulseActive = false;
+    volatile bool isReadyToTrigger = true;
+    volatile bool countPulses = false;
+    volatile uint32_t pulseNumber = 0;
+
+    // Static callback methods for timer interrupts
+    static PulseGenerator* volatile instancePtr;
+
+    // Turn pulse off
+    static void stopPulseISR() {
+        if (instancePtr) {
+            digitalWriteFast(instancePtr->outputPin, LOW);
+            instancePtr->isPulseActive = false;
+        }
+    }
+
+    // Trigger next pulse cycle
+    static void intervalISR() {
+        if (instancePtr) {
+            instancePtr->isReadyToTrigger = true;
+        }
+    }
+
+    // Trigger pin interrupt handler
+    static void triggerPinISR() {
+        if (instancePtr && instancePtr->waitForTrigger) {
+            instancePtr->isReadyToTrigger = true;
+        }
+    }
+
+public:
+    PulseGenerator(uint8_t outPin, uint8_t trigPin = 255) : 
+          outputPin(outPin), 
+          triggerPin(trigPin), 
+          pulseDuration(1000), 
+          pulseInterval(10000), 
+          waitForTrigger(false), 
+          isRunning(false),
+          countPulses(false),
+          pulseNumber(0) {
+        instancePtr = this;
+        pinMode(outputPin, OUTPUT);
+        digitalWriteFast(outputPin, LOW);
+
+        if (triggerPin != 255) {
+            pinMode(triggerPin, INPUT_PULLDOWN);
+            attachInterrupt(digitalPinToInterrupt(triggerPin), triggerPinISR, RISING);
+        }
+    }
+
+    void configure(uint32_t duration, uint32_t interval, uint32_t number, bool useInputTrigger = false) {
+        noInterrupts();
+        pulseDuration = duration;
+        pulseInterval = interval;
+        waitForTrigger = useInputTrigger;
+        numberOfPulses = number;
+        countPulses = number != 0;
+        interrupts();
+
+        // Simplified configuration confirmation
+        Serial.print("Config: ");
+        Serial.println(useInputTrigger);
+    }
+
+    void setInterval(uint32_t interval) {
+        noInterrupts();
+        pulseInterval = interval;
+        
+        // Restart timer if currently running
+        if (isRunning) {
+            intervalTimer.end();
+            intervalTimer.begin(intervalISR, pulseInterval);
+        }
+        interrupts();
+
+        // Simplified interval confirmation
+        Serial.print("3 ");
+        Serial.println(interval);
+    }
+
+    void setPulseDuration(uint32_t duration) {
+        noInterrupts();
+        pulseDuration = duration;
+        interrupts();
+
+        // Simplified duration confirmation
+        Serial.print("4 ");
+        Serial.println(duration);
+    }
+
+    void setTriggerMode(bool useInputTrigger) {
+        noInterrupts();
+        waitForTrigger = useInputTrigger;
+        interrupts();
+
+        // Simplified trigger mode confirmation
+        Serial.print("5 ");
+        Serial.println(useInputTrigger);
+    }
+
+    void setNumberOfPulses(uint32_t number) {
+      noInterrupts();
+      numberOfPulses = number;
+      countPulses = number != 0;
+      interrupts();
+
+      Serial.print(6);
+      Serial.println(number);
+    }
+
+    void start() {
+        // Reset state
+        isReadyToTrigger = true;
+        isPulseActive = false;
+        isRunning = true;
+
+        // Stop any existing timers
+        pulseTimer.end();
+        intervalTimer.end();
+
+        // no timers running, so we can set volatile variables without interupting interrupts
+        pulseNumber = 0;
+
+        // Start interval timer to manage pulse cycles
+        intervalTimer.begin(intervalISR, pulseInterval);
+
+        // Simplified start confirmation
+        Serial.println("1");
+    }
+
+    void stopNoSerialMessage() {
+        // Stop timers
+        pulseTimer.end();
+        intervalTimer.end();
+        
+        // Ensure output is low
+        digitalWriteFast(outputPin, LOW);
+        
+        // Reset state
+        isRunning = false;
+        isPulseActive = false;
+        isReadyToTrigger = true;
+    }
+
+    void stop() {
+        stopNoSerialMessage();
+
+        // Simplified stop confirmation
+        Serial.print("2");
+        Serial.println(numberOfPulses);
+    }
+
+    void run() {
+        // Only run if active
+        if (!isRunning) return;
+
+        if (countPulses && pulseNumber == numberOfPulses) {
+          stopNoSerialMessage();
+          return;
+        }
+
+        // Check if we're ready to trigger a pulse
+        if (isReadyToTrigger) {
+            // If waiting for trigger and trigger not received, do nothing
+            if (waitForTrigger && digitalReadFast(triggerPin) == LOW) {
+                return;
+            }
+
+            // Generate pulse
+            digitalWriteFast(outputPin, HIGH);
+            isPulseActive = true;
+            isReadyToTrigger = false;
+            //if (countPulses) {
+            pulseNumber++;
+            //}
+
+            // Set timer to stop pulse after duration
+            pulseTimer.begin(stopPulseISR, pulseDuration);
+        }
+    }
+
+    bool getRunningState() const {
+        return isRunning;
+    }
+};
+
+// Static instance pointer initialization
+PulseGenerator* volatile PulseGenerator::instancePtr = nullptr;
+
+// Global instance
+PulseGenerator* pulsegen = nullptr;
+
+// Serial command parsing
+void processSerialCommands() {
+    static uint8_t commandState = 0;
+    static uint8_t currentCommand = 0;
+    static uint32_t parameterBuffer = 0;
+    static uint8_t parameterByteCount = 0;
+
+    while (Serial.available() > 0) {
+        uint8_t incomingByte = Serial.read();
+
+        switch (commandState) {
+            case 0:  // Command byte
+                currentCommand = incomingByte;
+                switch (incomingByte) {
+                    case 1:  // Start
+                        pulsegen->start();
+                        break;
+                    
+                    case 2:  // Stop
+                        pulsegen->stop();
+                        break;
+                    
+                    case 3:  // Set Interval
+                    case 4:  // Set Pulse Duration
+                    case 5:  // Set Trigger Mode
+                    case 6:  // Number of Triggers, zero for always on
+                        commandState = 1;
+                        parameterByteCount = 0;
+                        parameterBuffer = 0;
+                        break;
+                    
+                    default:
+                        break;
+                }
+                break;
+
+            case 1:  // Receiving 32-bit parameter
+                // Construct 32-bit value (little-endian)
+                parameterBuffer |= ((uint32_t)incomingByte << (parameterByteCount * 8));
+                parameterByteCount++;
+
+                if (parameterByteCount == 4) {
+                    switch (currentCommand) {
+                        case 3:  // Set Interval
+                            pulsegen->setInterval(parameterBuffer);
+                            break;
+                        
+                        case 4:  // Set Pulse Duration
+                            pulsegen->setPulseDuration(parameterBuffer);
+                            break;
+                        
+                        case 5:  // Set Trigger Mode
+                            pulsegen->setTriggerMode(parameterBuffer > 0);
+                            break;
+                        case 6:  // Set number of Pulses
+                            pulsegen->setNumberOfPulses(parameterBuffer);
+                            break;
+                    }
+                    
+                    commandState = 0;
+                }
+                break;
+        }
+    }
+}
+
+void setup() {
+    // Initialize serial for communication
+    Serial.begin(115200);
+    
+    // Give some time for serial to initialize
+    delay(1000);
+
+    // Create pulse generator on pin 13 with optional trigger on pin 12
+    pulsegen = new PulseGenerator(13, 12);
+
+    // Configure initial defaults
+    pulsegen->configure(50000, 500000, 0, false);
+}
+
+void loop() {
+    // Process any incoming serial commands
+    processSerialCommands();
+
+    // Run pulse generator
+    pulsegen->run();
+}

--- a/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator/TeensyPulseGenerator.ino
+++ b/DeviceAdapters/TeensyPulseGenerator/TeensyPulseGenerator/TeensyPulseGenerator.ino
@@ -2,7 +2,7 @@
 
 static const uint32_t version = 1;
 
-uint8_t outputPin = 8;  // LED_BUILTIN;
+uint8_t outputPin = LED_BUILTIN;  // LED_BUILTIN;
 uint8_t inputPin = 2;
 
 /**
@@ -232,8 +232,8 @@ public:
 
         // Start interval timer to manage pulse cycles
         // start first pulse here, otherwise we would wait pulseInterval for the first pulse
-        pulse();
         intervalTimer.begin(intervalISR, pulseInterval);
+        pulse();
 
         // Simplified start confirmation
         Serial.write(1);

--- a/DeviceAdapters/TeensyPulseGenerator/TestTeensyPulseGenerator.py
+++ b/DeviceAdapters/TeensyPulseGenerator/TestTeensyPulseGenerator.py
@@ -1,0 +1,19 @@
+import serial
+import struct
+
+ser = serial.Serial('/dev/ttyACM0', 115200)
+
+# Start pulse generator
+ser.write(bytes([1]))
+
+# Set interval to 5000 microseconds
+ser.write(bytes([3]) + struct.pack('<I', 5000))
+
+# Set pulse duration to 250 microseconds
+ser.write(bytes([4]) + struct.pack('<I', 250))
+
+# Disable trigger mode
+ser.write(bytes([5]) + struct.pack('<I', 0))
+
+# Stop pulse generator
+ser.write(bytes([2]))

--- a/micromanager.sln
+++ b/micromanager.sln
@@ -500,6 +500,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OpenFlexure", "DeviceAdapte
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ScientificaMotion8", "DeviceAdapters\ScientificaMotion8\ScientificaMotion8.vcxproj", "{E4E9FA4F-E9DD-4483-9140-2FD472C28F1D}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TeensyPulseGenerator", "DeviceAdapters\TeensyPulseGenerator\TeensyPulseGenerator.vcxproj", "{4C9DE8BC-FAFE-43C6-A2D8-4169DBA9BDD9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -1502,6 +1504,10 @@ Global
 		{E4E9FA4F-E9DD-4483-9140-2FD472C28F1D}.Debug|x64.Build.0 = Debug|x64
 		{E4E9FA4F-E9DD-4483-9140-2FD472C28F1D}.Release|x64.ActiveCfg = Release|x64
 		{E4E9FA4F-E9DD-4483-9140-2FD472C28F1D}.Release|x64.Build.0 = Release|x64
+		{4C9DE8BC-FAFE-43C6-A2D8-4169DBA9BDD9}.Debug|x64.ActiveCfg = Debug|x64
+		{4C9DE8BC-FAFE-43C6-A2D8-4169DBA9BDD9}.Debug|x64.Build.0 = Debug|x64
+		{4C9DE8BC-FAFE-43C6-A2D8-4169DBA9BDD9}.Release|x64.ActiveCfg = Release|x64
+		{4C9DE8BC-FAFE-43C6-A2D8-4169DBA9BDD9}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The Teensy firmware can 
- send pulses at defined intervals
- send pulse of defined duration
- send a defined number of pulses or continue until stopped
- optionally wait for an input signal before sending the pulse (after waiting for a defined interval).

The device adapter defines two devices
- A pulse device that allows to set all the Teensy properties and send defined pulses.
- A virtual camera that can be use to trigger the real camera with the Teensy.  

External triggering using the Teensy was tested with the Daheng camera.   Pulse intervals have an sd of ~50ns (although there seems to be a systematic error of about 1 us for 100 ms pulses).  

This firmware and device adapter should allow reliable external triggering of devices and can be a foundation for testing extension of the Micro-Manager camera interface. 