### PR TITLE
ASI Stage: add property caching

### DIFF
--- a/DeviceAdapters/ASIStage/ASIBase.cpp
+++ b/DeviceAdapters/ASIStage/ASIBase.cpp
@@ -14,6 +14,7 @@ ASIBase::ASIBase(MM::Device* device, const char* prefix) :
 	initialized_(false),
 	device_(device),
 	oldstagePrefix_(prefix),
+	version_("undefined"),
 	port_("Undefined")
 {
 	versionData_ = VersionData();
@@ -212,34 +213,32 @@ VersionData ASIBase::ExtractVersionData(const std::string &version) const
 	return VersionData(major, minor, revision);
 }
 
+int ASIBase::GetVersion(std::string& version)
+{
+   std::ostringstream command;
+   command << "V";
+   std::string answer;
+   // query the device
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+   {
+      return ret;
+   }
+   if (answer.substr(0, 2).compare(":A") == 0)
+   {
+		version = answer.substr(3);
+		return DEVICE_OK;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
+}
+
 // Get the version of this controller
 int ASIBase::OnVersion(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		std::ostringstream command;
-		command << "V";
-		std::string answer;
-		// query the device
-		int ret = QueryCommand(command.str().c_str(), answer);
-		if (ret != DEVICE_OK)
-		{
-			return ret;
-		}
-		if (answer.substr(0, 2).compare(":A") == 0)
-		{
-			pProp->Set(answer.substr(3).c_str());
-			return DEVICE_OK;
-		}
-		// deal with error later
-		else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-		{
-			int errNo = atoi(answer.substr(3).c_str());
-			return ERR_OFFSET + errNo;
-		}
-		return ERR_UNRECOGNIZED_ANSWER;
+      pProp->Set(version_.c_str());
 	}
-
 	return DEVICE_OK;
 }
 

--- a/DeviceAdapters/ASIStage/ASIBase.h
+++ b/DeviceAdapters/ASIStage/ASIBase.h
@@ -75,6 +75,7 @@ protected:
 	int OnVersion(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnBuildName(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnCompileDate(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetVersion(std::string& version);
 
 	bool oldstage_;
 	MM::Core* core_;
@@ -82,6 +83,7 @@ protected:
 	MM::Device* device_;
 	std::string oldstagePrefix_;
 	std::string port_;
+	std::string version_;
 	VersionData versionData_;
 	unsigned int compileDay_; // "days" since Jan 1 2000 since the firmware was compiled according to (compile day + 31*(compile month-1) + 12*31*(compile year-2000))
 };

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -79,8 +79,11 @@ int CRISP::Initialize()
 	// Read-only "AxisLetter" property, axis_ is set using a pre-init property named "Axis".
 	CreateProperty("AxisLetter", axis_.c_str(), MM::String, true);
 	
+	ret = GetVersion(version_);
+	if (ret != DEVICE_OK)
+		return ret;
 	CPropertyAction* pAct = new CPropertyAction(this, &CRISP::OnVersion);
-	CreateProperty("Version", "", MM::String, true, pAct);
+	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
 
 	pAct = new CPropertyAction(this, &CRISP::OnCompileDate);
 	CreateProperty("CompileDate", "", MM::String, true, pAct);

--- a/DeviceAdapters/ASIStage/ASILED.cpp
+++ b/DeviceAdapters/ASIStage/ASILED.cpp
@@ -74,8 +74,11 @@ int LED::Initialize()
 	if (ret != DEVICE_OK)
 		return ret;
 
+	ret = GetVersion(version_);
+	if (ret != DEVICE_OK)
+		return ret;
 	CPropertyAction* pAct = new CPropertyAction(this, &LED::OnVersion);
-	CreateProperty("Version", "", MM::String, true, pAct);
+	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
 
 	pAct = new CPropertyAction(this, &LED::OnCompileDate);
 	CreateProperty("CompileDate", "", MM::String, true, pAct);

--- a/DeviceAdapters/ASIStage/ASIMagnifier.cpp
+++ b/DeviceAdapters/ASIStage/ASIMagnifier.cpp
@@ -67,8 +67,11 @@ int Magnifier::Initialize()
         return ret;
     }
 
+	 ret = GetVersion(version_);
+	 if (ret != DEVICE_OK)
+       return ret;
     CPropertyAction* pAct = new CPropertyAction(this, &Magnifier::OnVersion);
-    CreateProperty("Version", "", MM::String, true, pAct);
+    CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
 
     pAct = new CPropertyAction(this, &Magnifier::OnCompileDate);
     CreateProperty("CompileDate", "", MM::String, true, pAct);

--- a/DeviceAdapters/ASIStage/ASIStateDevice.cpp
+++ b/DeviceAdapters/ASIStage/ASIStateDevice.cpp
@@ -65,8 +65,11 @@ int StateDevice::Initialize()
 {
 	core_ = GetCoreCallback();
 
+   int ret = GetVersion(version_);
+	if (ret != DEVICE_OK)
+       return ret;
 	CPropertyAction* pAct = new CPropertyAction(this, &StateDevice::OnVersion);
-	CreateProperty("Version", "", MM::String, true, pAct);
+	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
 
 	pAct = new CPropertyAction(this, &StateDevice::OnCompileDate);
 	CreateProperty("CompileDate", "", MM::String, true, pAct);
@@ -91,7 +94,7 @@ int StateDevice::Initialize()
 
 	// state
 	pAct = new CPropertyAction(this, &StateDevice::OnState);
-	int ret = CreateProperty(MM::g_Keyword_State, "0", MM::Integer, false, pAct);
+	ret = CreateProperty(MM::g_Keyword_State, "0", MM::Integer, false, pAct);
 	if (ret != DEVICE_OK)
 	{
 		return ret;

--- a/DeviceAdapters/ASIStage/ASITIRF.cpp
+++ b/DeviceAdapters/ASIStage/ASITIRF.cpp
@@ -75,8 +75,11 @@ int TIRF::Initialize()
         return ret;
     }
 
+    ret = GetVersion(version_);
+    if (ret != DEVICE_OK)
+       return ret;
     CPropertyAction* pAct = new CPropertyAction(this, &TIRF::OnVersion);
-    CreateProperty("Version", "", MM::String, true, pAct);
+    CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
 
     pAct = new CPropertyAction(this, &TIRF::OnCompileDate);
     CreateProperty("CompileDate", "", MM::String, true, pAct);

--- a/DeviceAdapters/ASIStage/ASITurret.cpp
+++ b/DeviceAdapters/ASIStage/ASITurret.cpp
@@ -75,8 +75,11 @@ int AZ100Turret::Initialize()
 		return ret;
 	}
 
+   ret = GetVersion(version_);
+   if (ret != DEVICE_OK)
+       return ret;
 	pAct = new CPropertyAction(this, &AZ100Turret::OnVersion);
-	CreateProperty("Version", "", MM::String, true, pAct);
+	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
 
 	pAct = new CPropertyAction(this, &AZ100Turret::OnCompileDate);
 	CreateProperty("CompileDate", "", MM::String, true, pAct);

--- a/DeviceAdapters/ASIStage/ASIXYStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIXYStage.cpp
@@ -130,16 +130,22 @@ int XYStage::Initialize()
 	// Wait cycles
 	if (hasCommand("WT X?"))
 	{
+		ret = GetWaitCycles(waitCycles_);
+		if (ret != DEVICE_OK)
+			return ret;
 		pAct = new CPropertyAction(this, &XYStage::OnWait);
-		CreateProperty("Wait_Cycles", "5", MM::Integer, false, pAct);
+		CreateProperty("Wait_Cycles", std::to_string(waitCycles_).c_str(), MM::Integer, false, pAct);
 		// SetPropertyLimits("Wait_Cycles", 0, 255);  // don't artificially restrict range
 	}
 
 	// Speed (sets both x and y)
 	if (hasCommand("S " + axisletterX_ + "?"))
 	{
+		ret = GetSpeed(speed_);
+		if (ret != DEVICE_OK)
+			return ret;
 		pAct = new CPropertyAction(this, &XYStage::OnSpeed);
-		CreateProperty("Speed-S", "1", MM::Float, false, pAct);
+		CreateProperty("Speed-S", std::to_string(speed_).c_str(), MM::Float, false, pAct);
 		// Maximum Speed that can be set in Speed-S property
 		char max_speed[MM::MaxStrLength];
 		GetMaxSpeed(max_speed);
@@ -149,23 +155,29 @@ int XYStage::Initialize()
 	// Backlash (sets both x and y)
 	if (hasCommand("B " + axisletterX_ + "?"))
 	{
+		ret = GetBacklash(backlash_);
+		if (ret != DEVICE_OK)
+			return ret;
 		pAct = new CPropertyAction(this, &XYStage::OnBacklash);
-		CreateProperty("Backlash-B", "0", MM::Float, false, pAct);
+		CreateProperty("Backlash-B", std::to_string(backlash_).c_str(), MM::Float, false, pAct);
 	}
 	
 	// Error (sets both x and y)
 	if (hasCommand("E " + axisletterX_ + "?"))
 	{
+		ret = GetError(error_);
+		if (ret != DEVICE_OK)
+			return ret;
 		pAct = new CPropertyAction(this, &XYStage::OnError);
-		CreateProperty("Error-E(nm)", "0", MM::Float, false, pAct);
+		CreateProperty("Error-E(nm)", std::to_string(error_).c_str(), MM::Float, false, pAct);
 	}
 	
 	// acceleration (sets both x and y)
-	ret = GetAcceleration(acceleration_);
-	if (ret != DEVICE_OK)
-		return ret;
 	if (hasCommand("AC " + axisletterX_ + "?"))
 	{
+      ret = GetAcceleration(acceleration_);
+      if (ret != DEVICE_OK)
+         return ret;
 		pAct = new CPropertyAction(this, &XYStage::OnAcceleration);
 		CreateProperty("Acceleration-AC(ms)", std::to_string(acceleration_).c_str(), MM::Integer, false, pAct);
 	}
@@ -173,6 +185,9 @@ int XYStage::Initialize()
 	// Finish Error (sets both x and y)
 	if (hasCommand("PC " + axisletterX_ + "?"))
 	{
+		ret = GetFinishError(finishError_);
+      if (ret != DEVICE_OK)
+         return ret;
 		pAct = new CPropertyAction(this, &XYStage::OnFinishError);
 		CreateProperty("FinishError-PCROS(nm)", "0", MM::Float, false, pAct);
 	}
@@ -180,6 +195,9 @@ int XYStage::Initialize()
 	// OverShoot (sets both x and y)
 	if (hasCommand("OS " + axisletterX_ + "?"))
 	{
+		ret = GetOverShoot(overShoot_);
+      if (ret != DEVICE_OK)
+         return ret;
 		pAct = new CPropertyAction(this, &XYStage::OnOverShoot);
 		CreateProperty("OverShoot(um)", "0", MM::Float, false, pAct);
 	}
@@ -723,36 +741,35 @@ int XYStage::OnNrMoveRepetitions(MM::PropertyBase* pProp, MM::ActionType eAct)
 	return DEVICE_OK;
 }
 
-// This sets the number of waitcycles
+int XYStage::GetWaitCycles(long& waitCycles)
+{
+   // To simplify our life we only read out waitcycles for the X axis, but set for both
+   std::ostringstream command;
+   command << "WT " + axisletterX_ + "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":X") == 0)
+   {
+      return ParseResponseAfterPosition(answer, 3, waitCycles);
+   }
+   // deal with error later
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
+}
+
 int XYStage::OnWait(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		// To simplify our life we only read out waitcycles for the X axis, but set for both
-		std::ostringstream command;
-		command << "WT " + axisletterX_ + "?";
-		std::string answer;
-		// query command
-		int ret = QueryCommand(command.str().c_str(), answer);
-		if (ret != DEVICE_OK)
-		{
-			return ret;
-		}
-
-		if (answer.substr(0, 2).compare(":X") == 0)
-		{
-			long waitCycles = 0;
-			const int code = ParseResponseAfterPosition(answer, 3, waitCycles);
-			pProp->Set(waitCycles);
-			return code;
-		}
-		// deal with error later
-		else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-		{
-			int errNo = atoi(answer.substr(3).c_str());
-			return ERR_OFFSET + errNo;
-		}
-		return ERR_UNRECOGNIZED_ANSWER;
+		pProp->Set(waitCycles_);
 	}
 	else if (eAct == MM::AfterSet)
 	{
@@ -786,43 +803,47 @@ int XYStage::OnWait(MM::PropertyBase* pProp, MM::ActionType eAct)
 		// query command
 		int ret = QueryCommand(command.str().c_str(), answer);
 		if (ret != DEVICE_OK)
-		{
 			return ret;
-		}
-		return ResponseStartsWithColonA(answer);
+		ret = ResponseStartsWithColonA(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+		waitCycles_ = waitCycles;
 	}
 	return DEVICE_OK;
 }
+
+int XYStage::GetBacklash(double& backlash)
+{
+   // To simplify our life we only read out waitcycles for the X axis, but set for both
+   std::ostringstream command;
+   command << "B " << axisletterX_ << "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+   {
+      return ret;
+   }
+
+   if (answer.substr(0, 2).compare(":X") == 0)
+   {
+      return ParseResponseAfterPosition(answer, 3, 8, backlash);
+   }
+   // deal with error later
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
+}
+
 
 int XYStage::OnBacklash(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		// To simplify our life we only read out waitcycles for the X axis, but set for both
-		std::ostringstream command;
-		command << "B " << axisletterX_ << "?";
-		std::string answer;
-		// query command
-		int ret = QueryCommand(command.str().c_str(), answer);
-		if (ret != DEVICE_OK)
-		{
-			return ret;
-		}
-
-		if (answer.substr(0, 2).compare(":X") == 0)
-		{
-			double speed = 0.0;
-			const int code = ParseResponseAfterPosition(answer, 3, 8, speed);
-			pProp->Set(speed);
-			return code;
-		}
-		// deal with error later
-		else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-		{
-			int errNo = atoi(answer.substr(3).c_str());
-			return ERR_OFFSET + errNo;
-		}
-		return ERR_UNRECOGNIZED_ANSWER;
+		pProp->Set(backlash_);
 	}
 	else if (eAct == MM::AfterSet)
 	{
@@ -839,61 +860,65 @@ int XYStage::OnBacklash(MM::PropertyBase* pProp, MM::ActionType eAct)
 		// query command
 		int ret = QueryCommand(command.str().c_str(), answer);
 		if (ret != DEVICE_OK)
-		{
 			return ret;
-		}
-		return ResponseStartsWithColonA(answer);
+		ret = ResponseStartsWithColonA(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+		backlash_ = backlash;
 	}
 	return DEVICE_OK;
+}
+
+int XYStage::GetFinishError(double& finishError)
+{
+   // To simplify our life we only read out waitcycles for the X axis, but set for both
+   std::ostringstream command;
+   command << "PC " << axisletterX_ << "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":X") == 0)
+   {
+      double tmp = 0.0;
+      const int code = ParseResponseAfterPosition(answer, 3, 8, tmp);
+      finishError = 1000000 * tmp;
+      return code;
+   }
+   if (answer.substr(0, 2).compare(":A") == 0)
+   {
+      // Answer is of the form :A X=0.00003
+      double tmp = 0.0;
+      const int code = ParseResponseAfterPosition(answer, 5, 8, tmp);
+      finishError = 1000000 * tmp;
+      return code;
+   }
+   // deal with error later
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
 }
 
 int XYStage::OnFinishError(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		// To simplify our life we only read out waitcycles for the X axis, but set for both
-		std::ostringstream command;
-		command << "PC " << axisletterX_ << "?";
-		std::string answer;
-		// query command
-		int ret = QueryCommand(command.str().c_str(), answer);
-		if (ret != DEVICE_OK)
-		{
-			return ret;
-		}
-
-		if (answer.substr(0, 2).compare(":X") == 0)
-		{
-			double finishError = 0.0;
-			const int code = ParseResponseAfterPosition(answer, 3, 8, finishError);
-			pProp->Set(1000000 * finishError);
-			return code;
-		}
-		if (answer.substr(0, 2).compare(":A") == 0)
-		{
-			// Answer is of the form :A X=0.00003
-			double finishError = 0.0;
-			const int code = ParseResponseAfterPosition(answer, 5, 8, finishError);
-			pProp->Set(1000000 * finishError);
-			return code;
-		}
-		// deal with error later
-		else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-		{
-			int errNo = atoi(answer.substr(3).c_str());
-			return ERR_OFFSET + errNo;
-		}
-		return ERR_UNRECOGNIZED_ANSWER;
+		pProp->Set(finishError_);
 	}
 	else if (eAct == MM::AfterSet)
 	{
-		double error;
-		pProp->Get(error);
-		if (error < 0.0)
+		double finishError;
+		pProp->Get(finishError);
+		if (finishError < 0.0)
 		{
-			error = 0.0;
+			finishError = 0.0;
 		}
-		error = error / 1000000;
+		double error = finishError / 1000000;
 		std::ostringstream command;
 		command << "PC " << axisletterX_ << "=" << error << " " << axisletterY_ << "=" << error;
 		std::string answer;
@@ -901,15 +926,16 @@ int XYStage::OnFinishError(MM::PropertyBase* pProp, MM::ActionType eAct)
 		// query command
 		int ret = QueryCommand(command.str().c_str(), answer);
 		if (ret != DEVICE_OK)
-		{
 			return ret;
-		}
-		return ResponseStartsWithColonA(answer);
+		ret = ResponseStartsWithColonA(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+		finishError_ = finishError;
 	}
 	return DEVICE_OK;
 }
 
-int XYStage::GetAcceleration(double& acceleration)
+int XYStage::GetAcceleration(long& acceleration)
 {
    // To simplify our life we only read out acceleration for the X axis, but set for both
    std::ostringstream command;
@@ -925,7 +951,11 @@ int XYStage::GetAcceleration(double& acceleration)
 
    if (answer.substr(0, 2).compare(":X") == 0)
    {
-      return ParseResponseAfterPosition(answer, 3, 8, acceleration);
+		double tmp = 0.0;
+      ret = ParseResponseAfterPosition(answer, 3, 8, tmp);
+		if (ret != DEVICE_OK)
+			return ret;
+		acceleration = (long)tmp;
    }
    // deal with error later
    else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
@@ -944,11 +974,11 @@ int XYStage::OnAcceleration(MM::PropertyBase* pProp, MM::ActionType eAct)
 	}
 	else if (eAct == MM::AfterSet)
 	{
-		double accel;
+		long accel;
 		pProp->Get(accel);
-		if (accel < 0.0)
+		if (accel < 0)
 		{
-			accel = 0.0;
+			accel = 0;
 		}
 		std::ostringstream command;
 		command << "AC " << axisletterX_ << "=" << accel << " " << axisletterY_ << "=" << accel;
@@ -967,36 +997,38 @@ int XYStage::OnAcceleration(MM::PropertyBase* pProp, MM::ActionType eAct)
 	return DEVICE_OK;
 }
 
+int XYStage::GetOverShoot(double& overshoot)
+{
+   // To simplify our life we only read out overshootfor the X axis, but set for both
+   std::ostringstream command;
+   command << "OS " << axisletterX_ << "?";
+   std::string answer;
+
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":A") == 0)
+   {
+      double tmp = 0.0;
+      const int code = ParseResponseAfterPosition(answer, 5, 8, tmp);
+      overshoot = tmp * 1000.0;
+      return code;
+   }
+   // deal with error later
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
+}
+
 int XYStage::OnOverShoot(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		// To simplify our life we only read out waitcycles for the X axis, but set for both
-		std::ostringstream command;
-		command << "OS " << axisletterX_ << "?";
-		std::string answer;
-
-		// query command
-		int ret = QueryCommand(command.str().c_str(), answer);
-		if (ret != DEVICE_OK)
-		{
-			return ret;
-		}
-
-		if (answer.substr(0, 2).compare(":A") == 0)
-		{
-			double overshoot = 0.0;
-			const int code = ParseResponseAfterPosition(answer, 5, 8, overshoot);
-			pProp->Set(overshoot * 1000.0);
-			return code;
-		}
-		// deal with error later
-		else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-		{
-			int errNo = atoi(answer.substr(3).c_str());
-			return ERR_OFFSET + errNo;
-		}
-		return ERR_UNRECOGNIZED_ANSWER;
 	}
 	else if (eAct == MM::AfterSet)
 	{
@@ -1006,51 +1038,55 @@ int XYStage::OnOverShoot(MM::PropertyBase* pProp, MM::ActionType eAct)
 		{
 			overShoot = 0.0;
 		}
-		overShoot = overShoot / 1000.0;
+		double tmp = overShoot / 1000.0;
 		std::ostringstream command;
-		command << std::fixed << "OS " << axisletterX_ << "=" << overShoot << " " << axisletterY_ << "=" << overShoot;
+		command << std::fixed << "OS " << axisletterX_ << "=" << tmp << " " << axisletterY_ << "=" << tmp;
 		std::string answer;
 
 		// query the device
 		int ret = QueryCommand(command.str().c_str(), answer);
 		if (ret != DEVICE_OK)
-		{
 			return ret;
-		}
-		return ResponseStartsWithColonA(answer);
+		ret = ResponseStartsWithColonA(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+		overShoot_ = overShoot;
 	}
 	return DEVICE_OK;
+}
+
+int XYStage::GetError(double& error)
+{
+   // To simplify our life we only read out error for the X axis, but set for both
+   std::ostringstream command;
+   command << "E " << axisletterX_ << "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":X") == 0)
+   {
+      double tmp = 0.0;
+      const int code = ParseResponseAfterPosition(answer, 3, 8, tmp);
+      error  = tmp * 1000000.0;
+      return code;
+   }
+   // deal with error
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
 }
 
 int XYStage::OnError(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		// To simplify our life we only read out waitcycles for the X axis, but set for both
-		std::ostringstream command;
-		command << "E " << axisletterX_ << "?";
-		std::string answer;
-		// query command
-		int ret = QueryCommand(command.str().c_str(), answer);
-		if (ret != DEVICE_OK)
-		{
-			return ret;
-		}
-
-		if (answer.substr(0, 2).compare(":X") == 0)
-		{
-			double error = 0.0;
-			const int code = ParseResponseAfterPosition(answer, 3, 8, error);
-			pProp->Set(error * 1000000.0);
-			return code;
-		}
-		// deal with error later
-		else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-		{
-			int errNo = atoi(answer.substr(3).c_str());
-			return ERR_OFFSET + errNo;
-		}
-		return ERR_UNRECOGNIZED_ANSWER;
+		pProp->Set(error_);
 	}
 	else if (eAct == MM::AfterSet)
 	{
@@ -1060,18 +1096,20 @@ int XYStage::OnError(MM::PropertyBase* pProp, MM::ActionType eAct)
 		{
 			error = 0.0;
 		}
-		error = error / 1000000.0;
+		double tmp = error / 1000000.0;
 		std::ostringstream command;
-		command << std::fixed << "E " << axisletterX_ << "=" << error << " " << axisletterY_ << "=" << error;
+		command << std::fixed << "E " << axisletterX_ << "=" << tmp << " " << axisletterY_ << "=" << tmp;
 		std::string answer;
 
 		// query the device
 		int ret = QueryCommand(command.str().c_str(), answer);
 		if (ret != DEVICE_OK)
-		{
 			return ret;
-		}
-		return ResponseStartsWithColonA(answer);
+		ret = ResponseStartsWithColonA(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+      // cache the value we read
+		error_ = error;
 	}
 	return DEVICE_OK;
 }
@@ -1105,35 +1143,35 @@ int XYStage::GetMaxSpeed(char* maxSpeedStr)
 	return DEVICE_OK;
 }
 
+int XYStage::GetSpeed(double& speed)
+{
+   // To simplify our life we only read out speed for the X axis, but set for both
+   std::ostringstream command;
+   command << "S " << axisletterX_ << "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":A") == 0)
+   {
+      return ParseResponseAfterPosition(answer, 5, speed);
+   }
+   // deal with error later
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
+}
+
 int XYStage::OnSpeed(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		// To simplify our life we only read out waitcycles for the X axis, but set for both
-		std::ostringstream command;
-		command << "S " << axisletterX_ << "?";
-		std::string answer;
-		// query command
-		int ret = QueryCommand(command.str().c_str(), answer);
-		if (ret != DEVICE_OK)
-		{
-			return ret;
-		}
-
-		if (answer.substr(0, 2).compare(":A") == 0)
-		{
-			double speed = 0.0;
-			const int code = ParseResponseAfterPosition(answer, 5, speed);
-			pProp->Set(speed);
-			return code;
-		}
-		// deal with error later
-		else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-		{
-			int errNo = atoi(answer.substr(3).c_str());
-			return ERR_OFFSET + errNo;
-		}
-		return ERR_UNRECOGNIZED_ANSWER;
+		pProp->Set(speed_);
 	}
 	else if (eAct == MM::AfterSet)
 	{
@@ -1154,10 +1192,12 @@ int XYStage::OnSpeed(MM::PropertyBase* pProp, MM::ActionType eAct)
 		// query the device
 		int ret = QueryCommand(command.str().c_str(), answer);
 		if (ret != DEVICE_OK)
-		{
 			return ret;
-		}
-		return ResponseStartsWithColonA(answer);
+		ret = ResponseStartsWithColonA(answer);
+		if (ret != DEVICE_OK)
+			return ret;
+		speed_ = speed;
+
 	}
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/ASIStage/ASIXYStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIXYStage.cpp
@@ -72,11 +72,14 @@ int XYStage::Initialize()
 	// empty the Rx serial buffer before sending command
 	ClearPort();
 
+   int ret = GetVersion(version_);
+   if (ret != DEVICE_OK)
+       return ret;
 	CPropertyAction* pAct = new CPropertyAction(this, &XYStage::OnVersion);
-	CreateProperty("Version", "", MM::String, true, pAct);
+	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
 
 	// check status first (test for communication protocol)
-	int ret = CheckDeviceStatus();
+	ret = CheckDeviceStatus();
 	if (ret != DEVICE_OK)
 	{
 		return ret;

--- a/DeviceAdapters/ASIStage/ASIXYStage.h
+++ b/DeviceAdapters/ASIStage/ASIXYStage.h
@@ -50,6 +50,7 @@ public:
 
 private:
 	int OnAcceleration(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetAcceleration(double& acceleration);
 	int OnBacklash(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnFinishError(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnError(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -95,6 +96,7 @@ private:
 	bool stopSignal_;
 	bool serialOnlySendChanged_; // if true the serial command is only sent when it has changed
 	std::string manualSerialAnswer_; // last answer received when the SerialCommand property was used
+	double acceleration_;
 	bool advancedPropsEnabled_;
 	std::string axisletterX_;
 	std::string axisletterY_;

--- a/DeviceAdapters/ASIStage/ASIXYStage.h
+++ b/DeviceAdapters/ASIStage/ASIXYStage.h
@@ -50,13 +50,19 @@ public:
 
 private:
 	int OnAcceleration(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int GetAcceleration(double& acceleration);
+	int GetAcceleration(long& acceleration);
 	int OnBacklash(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetBacklash(double& backlash);
 	int OnFinishError(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetFinishError(double& finishError);
 	int OnError(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetError(double& error);
 	int OnOverShoot(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetOverShoot(double& overShoot);
 	int OnWait(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetWaitCycles(long& waitCycles);
 	int OnSpeed(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetSpeed(double& speed_);
 	int GetMaxSpeed(char* maxSpeedStr);
 	int OnMotorCtrl(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnNrMoveRepetitions(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -96,7 +102,13 @@ private:
 	bool stopSignal_;
 	bool serialOnlySendChanged_; // if true the serial command is only sent when it has changed
 	std::string manualSerialAnswer_; // last answer received when the SerialCommand property was used
-	double acceleration_;
+	long acceleration_;
+	long waitCycles_;
+	double speed_;
+	double backlash_;
+	double error_;
+	double finishError_;
+	double overShoot_;
 	bool advancedPropsEnabled_;
 	std::string axisletterX_;
 	std::string axisletterY_;

--- a/DeviceAdapters/ASIStage/ASIZStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIZStage.cpp
@@ -162,47 +162,65 @@ int ZStage::Initialize()
     // Speed (sets both x and y)
     if (HasCommand("S " + axis_ + "?"))
     {
-        pAct = new CPropertyAction(this, &ZStage::OnSpeed);
-        CreateProperty("Speed-S", "1", MM::Float, false, pAct);
-        // Maximum Speed that can be set in Speed-S property
-        char max_speed[MM::MaxStrLength];
-        GetMaxSpeed(max_speed);
-        CreateProperty("Maximum Speed (Do Not Change)", max_speed, MM::Float, true);
+       ret = GetSpeed(speed_);
+       if (ret != DEVICE_OK)
+          return ret;
+       pAct = new CPropertyAction(this, &ZStage::OnSpeed);
+       CreateProperty("Speed-S", std::to_string(speed_).c_str(), MM::Float, false, pAct);
+       // Maximum Speed that can be set in Speed-S property
+       char max_speed[MM::MaxStrLength];
+       GetMaxSpeed(max_speed);
+       CreateProperty("Maximum Speed (Do Not Change)", max_speed, MM::Float, true);
     }
 
     // Backlash (sets both x and y)
     if (HasCommand("B " + axis_ + "?"))
     {
+        ret = GetBacklash(backlash_);
+        if (ret != DEVICE_OK)
+           return ret;
         pAct = new CPropertyAction(this, &ZStage::OnBacklash);
-        CreateProperty("Backlash-B", "0", MM::Float, false, pAct);
+        CreateProperty("Backlash-B", std::to_string(backlash_).c_str(), MM::Float, false, pAct);
     }
 
     // Error (sets both x and y)
     if (HasCommand("E " + axis_ + "?"))
     {
-        pAct = new CPropertyAction(this, &ZStage::OnError);
-        CreateProperty("Error-E(nm)", "0", MM::Float, false, pAct);
+       ret = GetError(error_);
+       if (ret != DEVICE_OK)
+          return ret;
+       pAct = new CPropertyAction(this, &ZStage::OnError);
+       CreateProperty("Error-E(nm)", std::to_string(error_).c_str(), MM::Float, false, pAct);
     }
 
     // acceleration (sets both x and y)
     if (HasCommand("AC " + axis_ + "?"))
     {
-        pAct = new CPropertyAction(this, &ZStage::OnAcceleration);
-        CreateProperty("Acceleration-AC(ms)", "0", MM::Integer, false, pAct);
+       ret = GetAcceleration(acceleration_);
+       if (ret != DEVICE_OK)
+          return ret;
+       pAct = new CPropertyAction(this, &ZStage::OnAcceleration);
+       CreateProperty("Acceleration-AC(ms)", std::to_string(acceleration_).c_str(), MM::Integer, false, pAct);
     }
 
     // Finish Error (sets both x and y)
     if (HasCommand("PC " + axis_ + "?"))
     {
-        pAct = new CPropertyAction(this, &ZStage::OnFinishError);
-        CreateProperty("FinishError-PCROS(nm)", "0", MM::Float, false, pAct);
+       ret = GetFinishError(finishError_);
+       if (ret != DEVICE_OK)
+          return ret;
+       pAct = new CPropertyAction(this, &ZStage::OnFinishError);
+       CreateProperty("FinishError-PCROS(nm)", std::to_string(finishError_).c_str(), MM::Float, false, pAct);
     }
 
     // OverShoot (sets both x and y)
     if (HasCommand("OS " + axis_ + "?"))
     {
-        pAct = new CPropertyAction(this, &ZStage::OnOverShoot);
-        CreateProperty("OverShoot(um)", "0", MM::Float, false, pAct);
+       ret = GetOverShoot(overShoot_);
+       if (ret != DEVICE_OK)
+          return ret;
+       pAct = new CPropertyAction(this, &ZStage::OnOverShoot);
+       CreateProperty("OverShoot(um)", std::to_string(overShoot_).c_str(), MM::Float, false, pAct);
     }
 
     // MotorCtrl (works on both x and y)
@@ -214,8 +232,12 @@ int ZStage::Initialize()
     // Wait cycles
     if (HasCommand("WT " + axis_ + "?"))
     {
-        pAct = new CPropertyAction(this, &ZStage::OnWait);
-        CreateProperty("Wait_Cycles", "5", MM::Integer, false, pAct);
+
+       ret = GetWait(waitCycles_);
+       if (ret != DEVICE_OK)
+          return ret;
+       pAct = new CPropertyAction(this, &ZStage::OnWait);
+       CreateProperty("Wait_Cycles", std::to_string(waitCycles_).c_str(), MM::Integer, false, pAct);
         // SetPropertyLimits("Wait_Cycles", 0, 255);  // don't artificially restrict range
     }
 
@@ -975,36 +997,36 @@ int ZStage::OnLinearSequenceTimeout(MM::PropertyBase* pProp, MM::ActionType eAct
     return DEVICE_OK;
 }
 
+int ZStage::GetWait(long& waitCycles)
+{
+   // To simplify our life we only read out waitcycles for the X axis, but set for both
+   std::ostringstream command;
+   command << "WT " << axis_ << "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":" + axis_) == 0)
+   {
+      return ParseResponseAfterPosition(answer, 3, waitCycles);
+   }
+   // deal with error later
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
+}
+
 // This sets the number of waitcycles
 int ZStage::OnWait(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
     if (eAct == MM::BeforeGet)
     {
-        // To simplify our life we only read out waitcycles for the X axis, but set for both
-        std::ostringstream command;
-        command << "WT " << axis_ << "?";
-        std::string answer;
-        // query command
-        int ret = QueryCommand(command.str().c_str(), answer);
-        if (ret != DEVICE_OK)
-        {
-            return ret;
-        }
-
-        if (answer.substr(0, 2).compare(":" + axis_) == 0)
-        {
-            long waitCycles = 0;
-            const int code = ParseResponseAfterPosition(answer, 3, waitCycles);
-            pProp->Set(waitCycles);
-            return code;
-        }
-        // deal with error later
-        else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-        {
-            int errNo = atoi(answer.substr(3).c_str());
-            return ERR_OFFSET + errNo;
-        }
-        return ERR_UNRECOGNIZED_ANSWER;
+       pProp->Set(waitCycles_);
     }
     else if (eAct == MM::AfterSet)
     {
@@ -1039,43 +1061,44 @@ int ZStage::OnWait(MM::PropertyBase* pProp, MM::ActionType eAct)
         // query command
         int ret = QueryCommand(command.str().c_str(), answer);
         if (ret != DEVICE_OK)
-        {
             return ret;
-        }
-        return ResponseStartsWithColonA(answer);
+        ret = ResponseStartsWithColonA(answer);
+        if (ret != DEVICE_OK)
+            return ret;
+        waitCycles_ = waitCycles;
     }
     return DEVICE_OK;
+}
+
+int ZStage::GetBacklash(double& backlash)
+{
+   // To simplify our life we only read out waitcycles for the X axis, but set for both
+   std::ostringstream command;
+   command << "B " << axis_ << "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":" + axis_) == 0)
+   {
+      return ParseResponseAfterPosition(answer, 3, 8, backlash);
+   }
+   // deal with error later
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
 }
 
 int ZStage::OnBacklash(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
     if (eAct == MM::BeforeGet)
     {
-        // To simplify our life we only read out waitcycles for the X axis, but set for both
-        std::ostringstream command;
-        command << "B " << axis_ << "?";
-        std::string answer;
-        // query command
-        int ret = QueryCommand(command.str().c_str(), answer);
-        if (ret != DEVICE_OK)
-        {
-            return ret;
-        }
-
-        if (answer.substr(0, 2).compare(":" + axis_) == 0)
-        {
-            double speed = 0.0;
-            const int code = ParseResponseAfterPosition(answer, 3, 8, speed);
-            pProp->Set(speed);
-            return code;
-        }
-        // deal with error later
-        else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-        {
-            int errNo = atoi(answer.substr(3).c_str());
-            return ERR_OFFSET + errNo;
-        }
-        return ERR_UNRECOGNIZED_ANSWER;
+       pProp->Set(backlash_);
     }
     else if (eAct == MM::AfterSet)
     {
@@ -1091,51 +1114,55 @@ int ZStage::OnBacklash(MM::PropertyBase* pProp, MM::ActionType eAct)
         // query command
         int ret = QueryCommand(command.str().c_str(), answer);
         if (ret != DEVICE_OK)
-        {
             return ret;
-        }
-        return ResponseStartsWithColonA(answer);
+        ret = ResponseStartsWithColonA(answer);
+        if (ret != DEVICE_OK)
+            return ret;
+        backlash_ = backlash;
     }
     return DEVICE_OK;
+}
+
+int ZStage::GetFinishError(double& finishError)
+{
+   // To simplify our life we only read out waitcycles for the X axis, but set for both
+   std::ostringstream command;
+   command << "PC " << axis_ << "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":" + axis_) == 0)
+   {
+      double tmp = 0.0;
+      const int code = ParseResponseAfterPosition(answer, 3, 8, tmp);
+      finishError = 1000000 * tmp;
+      return code;
+  }
+  if (answer.substr(0, 2).compare(":A") == 0)
+  {
+      // Answer is of the form :A X=0.00003
+      double tmp = 0.0;
+      const int code = ParseResponseAfterPosition(answer, 5, 8, tmp);
+      finishError = 1000000 * tmp;
+      return code;
+  }
+  // deal with error later
+  else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+  {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+  }
+  return ERR_UNRECOGNIZED_ANSWER;
 }
 
 int ZStage::OnFinishError(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
     if (eAct == MM::BeforeGet)
     {
-        // To simplify our life we only read out waitcycles for the X axis, but set for both
-        std::ostringstream command;
-        command << "PC " << axis_ << "?";
-        std::string answer;
-        // query command
-        int ret = QueryCommand(command.str().c_str(), answer);
-        if (ret != DEVICE_OK)
-        {
-            return ret;
-        }
-
-        if (answer.substr(0, 2).compare(":" + axis_) == 0)
-        {
-            double finishError = 0.0;
-            const int code = ParseResponseAfterPosition(answer, 3, 8, finishError);
-            pProp->Set(1000000 * finishError);
-            return code;
-        }
-        if (answer.substr(0, 2).compare(":A") == 0)
-        {
-            // Answer is of the form :A X=0.00003
-            double finishError = 0.0;
-            const int code = ParseResponseAfterPosition(answer, 5, 8, finishError);
-            pProp->Set(1000000 * finishError);
-            return code;
-        }
-        // deal with error later
-        else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-        {
-            int errNo = atoi(answer.substr(3).c_str());
-            return ERR_OFFSET + errNo;
-        }
-        return ERR_UNRECOGNIZED_ANSWER;
+       pProp->Set(finishError_);
     }
     else if (eAct == MM::AfterSet)
     {
@@ -1145,59 +1172,64 @@ int ZStage::OnFinishError(MM::PropertyBase* pProp, MM::ActionType eAct)
         {
             error = 0.0;
         }
-        error = error / 1000000;
+        double tmp = error / 1000000;
         std::ostringstream command;
-        command << "PC " << axis_ << "=" << error;
+        command << "PC " << axis_ << "=" << tmp;
         std::string answer;
         // query command
         int ret = QueryCommand(command.str().c_str(), answer);
         if (ret != DEVICE_OK)
-        {
             return ret;
-        }
-        return ResponseStartsWithColonA(answer);
+        ret = ResponseStartsWithColonA(answer);
+        if (ret != DEVICE_OK)
+            return ret;
     }
     return DEVICE_OK;
+}
+
+int ZStage::GetAcceleration(long& acceleration)
+{
+   // To simplify our life we only read out acceleration for the X axis, but set for both
+   std::ostringstream command;
+   command << "AC " + axis_ + "?";
+   std::string answer;
+
+  // query command
+  int ret = QueryCommand(command.str().c_str(), answer);
+  if (ret != DEVICE_OK)
+  {
+      return ret;
+  }
+
+  if (answer.substr(0, 2).compare(":" + axis_) == 0)
+  {
+      double tmp = 0.0;
+      const int code = ParseResponseAfterPosition(answer, 3, 8, tmp);
+      acceleration = (long) tmp;
+      return code;
+  }
+  // deal with error later
+  else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+  {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+  }
+  return ERR_UNRECOGNIZED_ANSWER;
 }
 
 int ZStage::OnAcceleration(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
     if (eAct == MM::BeforeGet)
     {
-        // To simplify our life we only read out acceleration for the X axis, but set for both
-        std::ostringstream command;
-        command << "AC " + axis_ + "?";
-        std::string answer;
-
-        // query command
-        int ret = QueryCommand(command.str().c_str(), answer);
-        if (ret != DEVICE_OK)
-        {
-            return ret;
-        }
-
-        if (answer.substr(0, 2).compare(":" + axis_) == 0)
-        {
-            double speed = 0.0;
-            const int code = ParseResponseAfterPosition(answer, 3, 8, speed);
-            pProp->Set(speed);
-            return code;
-        }
-        // deal with error later
-        else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-        {
-            int errNo = atoi(answer.substr(3).c_str());
-            return ERR_OFFSET + errNo;
-        }
-        return ERR_UNRECOGNIZED_ANSWER;
+       pProp->Set(acceleration_);
     }
     else if (eAct == MM::AfterSet)
     {
-        double accel;
+        long accel;
         pProp->Get(accel);
-        if (accel < 0.0)
+        if (accel < 0)
         {
-            accel = 0.0;
+            accel = 0;
         }
         std::ostringstream command;
         command << "AC " << axis_ << "=" << accel;
@@ -1205,43 +1237,44 @@ int ZStage::OnAcceleration(MM::PropertyBase* pProp, MM::ActionType eAct)
         // query command
         int ret = QueryCommand(command.str().c_str(), answer);
         if (ret != DEVICE_OK)
-        {
             return ret;
-        }
-        return ResponseStartsWithColonA(answer);
+        ret = ResponseStartsWithColonA(answer);
+        if (ret != DEVICE_OK)
+            return ret;
+        acceleration_ = accel;
     }
+
     return DEVICE_OK;
+}
+
+int ZStage::GetOverShoot(double& overShoot)
+{
+   std::ostringstream command;
+   command << "OS " + axis_ + "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":A") == 0)
+   {
+      return ParseResponseAfterPosition(answer, 5, 8, overShoot);
+   }
+   // deal with error herer
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+       int errNo = atoi(answer.substr(3).c_str());
+       return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
 }
 
 int ZStage::OnOverShoot(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
     if (eAct == MM::BeforeGet)
     {
-        // To simplify our life we only read out waitcycles for the X axis, but set for both
-        std::ostringstream command;
-        command << "OS " + axis_ + "?";
-        std::string answer;
-        // query command
-        int ret = QueryCommand(command.str().c_str(), answer);
-        if (ret != DEVICE_OK)
-        {
-            return ret;
-        }
-
-        if (answer.substr(0, 2).compare(":A") == 0)
-        {
-            double overshoot = 0.0;
-            const int code = ParseResponseAfterPosition(answer, 5, 8, overshoot);
-            pProp->Set(overshoot * 1000.0);
-            return code;
-        }
-        // deal with error later
-        else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-        {
-            int errNo = atoi(answer.substr(3).c_str());
-            return ERR_OFFSET + errNo;
-        }
-        return ERR_UNRECOGNIZED_ANSWER;
+       pProp->Set(overShoot_);
     }
     else if (eAct == MM::AfterSet)
     {
@@ -1258,43 +1291,47 @@ int ZStage::OnOverShoot(MM::PropertyBase* pProp, MM::ActionType eAct)
         // query the device
         int ret = QueryCommand(command.str().c_str(), answer);
         if (ret != DEVICE_OK)
-        {
             return ret;
-        }
-        return ResponseStartsWithColonA(answer);
+        ret = ResponseStartsWithColonA(answer);
+        if (ret != DEVICE_OK)
+            return ret;
+        overShoot_ = overShoot;
     }
     return DEVICE_OK;
+}
+
+int ZStage::GetError(double& error)
+{
+   // To simplify our life we only read out waitcycles for the X axis, but set for both
+   std::ostringstream command;
+   command << "E " + axis_ + "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+       return ret;
+
+   if (answer.substr(0, 2).compare(":" + axis_) == 0)
+   {
+       double tmp = 0.0;
+       const int code = ParseResponseAfterPosition(answer, 3, 8, tmp);
+       error  = tmp * 1000000.0;
+       return code;
+   }
+   // deal with error later
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
 }
 
 int ZStage::OnError(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
     if (eAct == MM::BeforeGet)
     {
-        // To simplify our life we only read out waitcycles for the X axis, but set for both
-        std::ostringstream command;
-        command << "E " + axis_ + "?";
-        std::string answer;
-        // query command
-        int ret = QueryCommand(command.str().c_str(), answer);
-        if (ret != DEVICE_OK)
-        {
-            return ret;
-        }
-
-        if (answer.substr(0, 2).compare(":" + axis_) == 0)
-        {
-            double error = 0.0;
-            const int code = ParseResponseAfterPosition(answer, 3, 8, error);
-            pProp->Set(error * 1000000.0);
-            return code;
-        }
-        // deal with error later
-        else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-        {
-            int errNo = atoi(answer.substr(3).c_str());
-            return ERR_OFFSET + errNo;
-        }
-        return ERR_UNRECOGNIZED_ANSWER;
+       pProp->Set(error_);
     }
     else if (eAct == MM::AfterSet)
     {
@@ -1304,17 +1341,18 @@ int ZStage::OnError(MM::PropertyBase* pProp, MM::ActionType eAct)
         {
             error = 0.0;
         }
-        error = error / 1000000.0;
+        double tmp = error / 1000000.0;
         std::ostringstream command;
-        command << std::fixed << "E " << axis_ << "=" << error;
+        command << std::fixed << "E " << axis_ << "=" << tmp;
         std::string answer;
         // query the device
         int ret = QueryCommand(command.str().c_str(), answer);
         if (ret != DEVICE_OK)
-        {
             return ret;
-        }
-        return ResponseStartsWithColonA(answer);
+        ret = ResponseStartsWithColonA(answer);
+        if (ret != DEVICE_OK)
+            return ret;
+        error_ = error;
     }
     return DEVICE_OK;
 }
@@ -1344,35 +1382,35 @@ int ZStage::GetMaxSpeed(char* maxSpeedStr)
     return DEVICE_OK;
 }
 
+int ZStage::GetSpeed(double& speed)
+{
+   // To simplify our life we only read out waitcycles for the X axis, but set for both
+   std::ostringstream command;
+   command << "S " + axis_ + "?";
+   std::string answer;
+   // query command
+   int ret = QueryCommand(command.str().c_str(), answer);
+   if (ret != DEVICE_OK)
+      return ret;
+
+   if (answer.substr(0, 2).compare(":A") == 0)
+   {
+      return ParseResponseAfterPosition(answer, 5, speed);
+   }
+   // deal with error later
+   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   {
+      int errNo = atoi(answer.substr(3).c_str());
+      return ERR_OFFSET + errNo;
+   }
+   return ERR_UNRECOGNIZED_ANSWER;
+}
+
 int ZStage::OnSpeed(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
     if (eAct == MM::BeforeGet)
     {
-        // To simplify our life we only read out waitcycles for the X axis, but set for both
-        std::ostringstream command;
-        command << "S " + axis_ + "?";
-        std::string answer;
-        // query command
-        int ret = QueryCommand(command.str().c_str(), answer);
-        if (ret != DEVICE_OK)
-        {
-            return ret;
-        }
-
-        if (answer.substr(0, 2).compare(":A") == 0)
-        {
-            double speed = 0.0;
-            const int code = ParseResponseAfterPosition(answer, 5, speed);
-            pProp->Set(speed);
-            return code;
-        }
-        // deal with error later
-        else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
-        {
-            int errNo = atoi(answer.substr(3).c_str());
-            return ERR_OFFSET + errNo;
-        }
-        return ERR_UNRECOGNIZED_ANSWER;
+       pProp->Set(speed_);
     }
     else if (eAct == MM::AfterSet)
     {
@@ -1393,10 +1431,11 @@ int ZStage::OnSpeed(MM::PropertyBase* pProp, MM::ActionType eAct)
         // query the device
         int ret = QueryCommand(command.str().c_str(), answer);
         if (ret != DEVICE_OK)
-        {
             return ret;
-        }
-        return ResponseStartsWithColonA(answer);
+        ret = ResponseStartsWithColonA(answer);
+        if (ret != DEVICE_OK)
+            return ret;
+        speed_ = speed;
     }
     return DEVICE_OK;
 }

--- a/DeviceAdapters/ASIStage/ASIZStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIZStage.cpp
@@ -95,8 +95,11 @@ int ZStage::Initialize()
         ret = GetPositionSteps(curSteps_);
     }
 
+    ret = GetVersion(version_);
+    if (ret != DEVICE_OK)
+       return ret;
     CPropertyAction* pAct = new CPropertyAction(this, &ZStage::OnVersion);
-    CreateProperty("Version", "", MM::String, true, pAct);
+    CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
 
     pAct = new CPropertyAction(this, &ZStage::OnCompileDate);
     CreateProperty("CompileDate", "", MM::String, true, pAct);

--- a/DeviceAdapters/ASIStage/ASIZStage.h
+++ b/DeviceAdapters/ASIStage/ASIZStage.h
@@ -63,12 +63,19 @@ public:
 
 private:
 	int OnAcceleration(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetAcceleration(long& acceleration);
 	int OnBacklash(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetBacklash(double& backlash);
 	int OnFinishError(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetFinishError(double& finishError);
 	int OnError(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetError(double& error);
 	int OnOverShoot(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetOverShoot(double& overShoot);
 	int OnWait(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetWait(long& waitCycles);
 	int OnSpeed(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int GetSpeed(double& speed);
 	int GetMaxSpeed(char* maxSpeedStr);
 	int OnMotorCtrl(MM::PropertyBase* pProp, MM::ActionType eAct);
 	bool HasRingBuffer();
@@ -92,6 +99,13 @@ private:
 	double linearSequenceIntervalUm_;
 	long linearSequenceLength_;
 	long linearSequenceTimeoutMs_;
+	double speed_;
+	long waitCycles_;
+	double backlash_;
+	double error_;
+	long acceleration_;
+	double finishError_;
+	double overShoot_;
 };
 
 #endif // ASIZSTAGE_H


### PR DESCRIPTION
On some older microscope systems, I noted that much of the lag in the software is caused by the System updating its cache, which caused the core to ask each device for the value of all of its properties.  The reason for doing is that properties can be changed as a side effect of changing another property, or, more often, there is another interface to the device (such as buttons or a joystick) that also can change these properties.  

Nevertheless, there are also many properties that can be efficiently cached within the device adapter.  If only the device adapter can change these values, and if they do not change as a side effect of changing some other property of the device, then it is fine to read the value of the property on startup and use that cached value (updating the cached value whenever the property is changed by MMCore).  

This PR caches the Version of the controller (which certainly never changes) and also the Acceleration property of the XY Stage.  If this looks good, I am happy to use the same procedure with other properties (XY stage position and Z stage position are obviously not to be cached, are there other properties that should always be read from the device)?  Let me know if this looks like the right approach!