### PR TITLE
MMCore: Disallow loading a device with label Core

### DIFF
--- a/MMCore/DeviceManager.cpp
+++ b/MMCore/DeviceManager.cpp
@@ -41,13 +41,14 @@ DeviceManager::LoadDevice(std::shared_ptr<LoadedDeviceAdapter> module,
       mm::logging::Logger deviceLogger,
       mm::logging::Logger coreLogger)
 {
-   for (DeviceConstIterator it = devices_.begin(), end = devices_.end(); it != end; ++it)
+   // For now, "Core" (which always exists) is not a real-enough device to be
+   // in 'devices_'; check as a special case.
+   if (std::find_if(devices_.begin(), devices_.end(),
+         [&](const auto& p) { return p.first == label; }) != devices_.end() ||
+      label == MM::g_Keyword_CoreDevice)
    {
-      if (it->first == label)
-      {
-         throw CMMError("The specified device label " + ToQuotedString(label) +
-               " is already in use", MMERR_DuplicateLabel);
-      }
+      throw CMMError("The specified device label " + ToQuotedString(label) +
+         " is already in use", MMERR_DuplicateLabel);
    }
 
    std::shared_ptr<DeviceInstance> device = module->LoadDevice(core,

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -688,21 +688,12 @@ void CMMCore::loadDevice(const char* label, const char* moduleName, const char* 
    LOG_DEBUG(coreLogger_) << "Will load device " << deviceName <<
       " from " << moduleName;
 
-   try
-   {
-      std::shared_ptr<LoadedDeviceAdapter> module =
-         pluginManager_->GetDeviceAdapter(moduleName);
-      std::shared_ptr<DeviceInstance> pDevice =
-         deviceManager_->LoadDevice(module, deviceName, label, this,
-               deviceLogger, coreLogger);
-      pDevice->SetCallback(callback_);
-   }
-   catch (const CMMError& e)
-   {
-      throw CMMError("Failed to load device " + ToQuotedString(deviceName) +
-            " from adapter module " + ToQuotedString(moduleName),
-            e);
-   }
+   std::shared_ptr<LoadedDeviceAdapter> module =
+      pluginManager_->GetDeviceAdapter(moduleName);
+   std::shared_ptr<DeviceInstance> pDevice =
+      deviceManager_->LoadDevice(module, deviceName, label, this,
+            deviceLogger, coreLogger);
+   pDevice->SetCallback(callback_);
 
    LOG_INFO(coreLogger_) << "Did load device " << deviceName <<
       " from " << moduleName << "; label = " << label;

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -112,7 +112,7 @@
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 11, MMCore_versionMinor = 4, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 11, MMCore_versionMinor = 4, MMCore_versionPatch = 1;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -766,6 +766,12 @@ void CMMCore::assignDefaultRole(std::shared_ptr<DeviceInstance> pDevice)
 void CMMCore::unloadDevice(const char* label///< the name of the device to unload
                            ) throw (CMMError)
 {
+   // "Core" cannot be unloaded.
+   if (label != nullptr && std::string(label) == MM::g_Keyword_CoreDevice)
+   {
+      throw CMMError("Cannot unload " + ToQuotedString("Core"));
+   }
+
    std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
    try {


### PR DESCRIPTION
And improve the error message when attempting to unload "Core" (previously it said no such device).

Closes #564.