### PR TITLE
ZeissCAN: when the SystemChache is updated, requests

### DIFF
--- a/DeviceAdapters/ZeissCAN/ZeissCAN.cpp
+++ b/DeviceAdapters/ZeissCAN/ZeissCAN.cpp
@@ -1854,11 +1854,17 @@ int ReflectorTurret::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
    {
-      int pos;
-      int ret = GetTurretPosition(pos);
-      if (ret != DEVICE_OK)
-         return ret;
-      pos_ = pos -1;
+      auto end = std::chrono::high_resolution_clock::now();
+      auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(end - start_);
+      if (elapsed > duration_)
+      {
+         int pos;
+         int ret = GetTurretPosition(pos);
+         if (ret != DEVICE_OK)
+            return ret;
+         pos_ = pos - 1;
+         start_ = end;
+      }
       pProp->Set(pos_);
    }
    else if (eAct == MM::AfterSet)
@@ -2011,11 +2017,17 @@ int SidePortTurret::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
    {
-      int pos;
-      int ret = GetTurretPosition(pos);
-      if (ret != DEVICE_OK)
-         return ret;
-      pos_ = pos -1;
+      auto end = std::chrono::high_resolution_clock::now();
+      auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(end - start_);
+      if (elapsed > duration_)
+      {
+         int pos;
+         int ret = GetTurretPosition(pos);
+         if (ret != DEVICE_OK)
+            return ret;
+         pos_ = pos - 1;
+         start_ = end;
+      }
       pProp->Set(pos_);
    }
    else if (eAct == MM::AfterSet)
@@ -2326,11 +2338,17 @@ int ObjectiveTurret::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
    {
-      int pos;
-      int ret = GetTurretPosition(pos);
-      if (ret != DEVICE_OK)
-         return ret;
-      pos_ = pos -1;
+      auto end = std::chrono::high_resolution_clock::now();
+      auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(end - start_);
+      if (elapsed > duration_)
+      {
+         int pos;
+         int ret = GetTurretPosition(pos);
+         if (ret != DEVICE_OK)
+            return ret;
+         pos_ = pos - 1;
+         start_ = end;
+      }
       pProp->Set(pos_);
    }
    else if (eAct == MM::AfterSet)
@@ -2483,11 +2501,17 @@ int OptovarTurret::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
    {
-      int pos;
-      int ret = GetTurretPosition(pos);
-      if (ret != DEVICE_OK)
-         return ret;
-      pos_ = pos -1;
+      auto end = std::chrono::high_resolution_clock::now();
+      auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(end - start_);
+      if (elapsed > duration_)
+      {
+         int pos;
+         int ret = GetTurretPosition(pos);
+         if (ret != DEVICE_OK)
+            return ret;
+         pos_ = pos - 1;
+         start_ = end;
+      }
       pProp->Set(pos_);
    }
    else if (eAct == MM::AfterSet)
@@ -2640,11 +2664,17 @@ int TubelensTurret::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
    {
-      int pos;
-      int ret = GetTurretPosition(pos);
-      if (ret != DEVICE_OK)
-         return ret;
-      pos_ = pos -1;
+      auto end = std::chrono::high_resolution_clock::now();
+      auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(end - start_);
+      if (elapsed > duration_)
+      {
+         int pos;
+         int ret = GetTurretPosition(pos);
+         if (ret != DEVICE_OK)
+            return ret;
+         pos_ = pos - 1;
+         start_ = end;
+      }
       pProp->Set(pos_);
    }
    else if (eAct == MM::AfterSet)
@@ -2856,11 +2886,17 @@ int CondenserTurret::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
    {
-      int pos;
-      int ret = GetTurretPosition(pos);
-      if (ret != DEVICE_OK)
-         return ret;
-      pos_ = pos -1;
+      auto end = std::chrono::high_resolution_clock::now();
+      auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(end - start_);
+      if (elapsed > duration_)
+      {
+         int pos;
+         int ret = GetTurretPosition(pos);
+         if (ret != DEVICE_OK)
+            return ret;
+         pos_ = pos - 1;
+         start_ = end;
+      }
       pProp->Set(pos_);
    }
    else if (eAct == MM::AfterSet)

--- a/DeviceAdapters/ZeissCAN/ZeissCAN.h
+++ b/DeviceAdapters/ZeissCAN/ZeissCAN.h
@@ -34,6 +34,8 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <chrono>
+
 
 //////////////////////////////////////////////////////////////////////////////
 // Error codes
@@ -252,12 +254,15 @@ public:
 private:
    int SetTurretPosition(int position);
    int GetTurretPosition(int &position);
-   bool GetPresence(bool& present);
+   // bool GetPresence(bool& present);
    bool initialized_;
    std::string name_;
    long pos_;
    int numPos_;
    int turretId_;
+   std::chrono::time_point<std::chrono::high_resolution_clock> start_ 
+      = std::chrono::high_resolution_clock::now() - std::chrono::seconds(20);
+   std::chrono::high_resolution_clock::duration duration_ = std::chrono::seconds(1);
 };
       
 class SidePortTurret : public CStateDeviceBase<SidePortTurret>
@@ -287,6 +292,9 @@ private:
    long pos_;
    int numPos_;
    int turretId_;
+   std::chrono::time_point<std::chrono::high_resolution_clock> start_ 
+      = std::chrono::high_resolution_clock::now() - std::chrono::seconds(20);
+   std::chrono::high_resolution_clock::duration duration_ = std::chrono::seconds(1);
 };
 
 class BasePortSlider : public CStateDeviceBase<BasePortSlider>
@@ -316,6 +324,9 @@ private:
    long pos_;
    int numPos_;
    int turretId_;
+   std::chrono::time_point<std::chrono::high_resolution_clock> start_ 
+      = std::chrono::high_resolution_clock::now() - std::chrono::seconds(20);
+   std::chrono::high_resolution_clock::duration duration_ = std::chrono::seconds(1);
 };
 
 class ObjectiveTurret : public CStateDeviceBase<ObjectiveTurret>
@@ -340,12 +351,14 @@ public:
 private:
    int SetTurretPosition(int position);
    int GetTurretPosition(int &position);
-   bool GetPresence(bool& present);
    bool initialized_;
    std::string name_;
    long pos_;
    int numPos_;
    int turretId_;
+   std::chrono::time_point<std::chrono::high_resolution_clock> start_ 
+      = std::chrono::high_resolution_clock::now() - std::chrono::seconds(20);
+   std::chrono::high_resolution_clock::duration duration_ = std::chrono::seconds(1);
 };
 
 class CondenserTurret : public CStateDeviceBase<CondenserTurret>
@@ -371,7 +384,6 @@ public:
 private:
    int SetTurretPosition(int position);
    int GetTurretPosition(int &position);
-   bool GetPresence(bool& present);
 
    int SetAperture(long aperture);
    int GetAperture(long &aperture);
@@ -382,6 +394,9 @@ private:
    long pos_;
    int numPos_;
    int turretId_;
+   std::chrono::time_point<std::chrono::high_resolution_clock> start_ 
+      = std::chrono::high_resolution_clock::now() - std::chrono::seconds(20);
+   std::chrono::high_resolution_clock::duration duration_ = std::chrono::seconds(1);
    
    MM::MMTime apertureChangingTimeout_;
 };
@@ -408,12 +423,14 @@ public:
 private:
    int SetTurretPosition(int position);
    int GetTurretPosition(int &position);
-   bool GetPresence(bool& present);
    bool initialized_;
    std::string name_;
    long pos_;
    int numPos_;
    int turretId_;
+   std::chrono::time_point<std::chrono::high_resolution_clock> start_ 
+      = std::chrono::high_resolution_clock::now() - std::chrono::seconds(20);
+   std::chrono::high_resolution_clock::duration duration_ = std::chrono::seconds(1);
 };
 
 class TubelensTurret : public CStateDeviceBase<TubelensTurret>
@@ -438,12 +455,14 @@ public:
 private:
    int SetTurretPosition(int position);
    int GetTurretPosition(int &position);
-   bool GetPresence(bool& present);
    bool initialized_;
    std::string name_;
    long pos_;
    int numPos_;
    int turretId_;
+   std::chrono::time_point<std::chrono::high_resolution_clock> start_ 
+      = std::chrono::high_resolution_clock::now() - std::chrono::seconds(20);
+   std::chrono::high_resolution_clock::duration duration_ = std::chrono::seconds(1);
 };
 
 class LampMirror : public CStateDeviceBase<LampMirror>
@@ -468,7 +487,6 @@ public:
 private:
    int SetTurretPosition(int position);
    int GetTurretPosition(int &position);
-   bool GetPresence(bool& present);
    bool initialized_;
    std::string name_;
    long pos_;
@@ -552,7 +570,6 @@ public:
 private:
    int SetTurretPosition(int position);
    int GetTurretPosition(int &position);
-   bool GetPresence(bool& present);
    int wheelNr_;
    bool initialized_;
    std::string name_;


### PR DESCRIPTION
for state and label are send separately.  These results in lengthy communication with the Microscope stand.  By caching the value of the given turret for a specified amount of time (here: 1 second), this PR should speed up the time it takes to update the SystemCache considerably.  Note that the default implementation of GetLabel actually calls the OnState method of the device.