### PR TITLE
MMDevice: Depercate unsafe overloads of InsertImage()

### DIFF
--- a/DeviceAdapters/PICAM/PICAMUniversal.cpp
+++ b/DeviceAdapters/PICAM/PICAMUniversal.cpp
@@ -2556,24 +2556,22 @@ int Universal::PushImage(const unsigned char* pixBuffer, Metadata* pMd )
    int nRet = DEVICE_ERR;
    MM::Core* pCore = GetCoreCallback();
    // This method inserts a new image into the circular buffer (residing in MMCore)
-   nRet = pCore->InsertMultiChannel(this,
+   nRet = pCore->InsertImage(this,
          pixBuffer,
-         1,
          GetImageWidth(),
          GetImageHeight(),
          GetImageBytesPerPixel(),
-         pMd); // Inserting the md causes crash in debug builds
+         pMd->Serialize().c_str());
    if (!stopOnOverflow_ && nRet == DEVICE_BUFFER_OVERFLOW)
    {
       // do not stop on overflow - just reset the buffer
       pCore->ClearImageBuffer(this);
-      nRet = pCore->InsertMultiChannel(this,
+      nRet = pCore->InsertImage(this,
             pixBuffer,
-            1,
             GetImageWidth(),
             GetImageHeight(),
             GetImageBytesPerPixel(),
-            pMd);
+            pMd->Serialize().c_str());
    }
 
    return nRet;

--- a/DeviceAdapters/TwainCamera/TwainCamera.cpp
+++ b/DeviceAdapters/TwainCamera/TwainCamera.cpp
@@ -1268,13 +1268,13 @@ int TwainCamera::PushImage()
    GetImageBuffer(); // this effectively copies images to rawBuffer_
 
    // insert all three channels at once
-   int ret = GetCoreCallback()->InsertMultiChannel(this, rawBuffer_, 1, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
+   int ret = GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
    if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
    {
       // do not stop on overflow - just reset the buffer
       GetCoreCallback()->ClearImageBuffer(this);
       // repeat the insert
-      return GetCoreCallback()->InsertMultiChannel(this, rawBuffer_, 1, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
+      return GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
    } else
       return ret;
 }
@@ -1302,13 +1302,13 @@ int TwainCamera::ThreadRun()
 		return DEVICE_ERR;
 
 	// insert all three channels at once
-   ret = GetCoreCallback()->InsertMultiChannel(this, rawBuffer_, 1, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
+   ret = GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
    if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
    {
       // do not stop on overflow - just reset the buffer
       GetCoreCallback()->ClearImageBuffer(this);
       // repeat the insert
-      return GetCoreCallback()->InsertMultiChannel(this, rawBuffer_, 1, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
+      return GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
    } else
       return ret;
 

--- a/MMDevice/ImageMetadata.h
+++ b/MMDevice/ImageMetadata.h
@@ -434,6 +434,10 @@ public:
    bool Restore(const char* stream)
    {
       Clear();
+      if (stream == nullptr)
+      {
+         return true;
+      }
 
       std::istringstream is(stream);
 

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1389,6 +1389,9 @@ namespace MM {
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const char* serializedMetadata, const bool doProcess = true) = 0;
       /// \deprecated Use the other forms instead.
       MM_DEPRECATED(virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const Metadata* md = 0, const bool doProcess = true)) = 0;
+      // TODO Upon removing the above deprecated overload, add a default
+      // argument `= nullptr` to `serializedMetadata` in the following
+      // overload. That allows existing device adapters to compile.
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess = true) = 0;
       virtual void ClearImageBuffer(const Device* caller) = 0;
       virtual bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth) = 0;

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1384,18 +1384,49 @@ namespace MM {
       // sequence acquisition
       virtual int AcqFinished(const Device* caller, int statusCode) = 0;
       virtual int PrepareForAcq(const Device* caller) = 0;
-      /// \deprecated Use the other forms instead.
+
+      /// \deprecated Use the other overloads instead.
       MM_DEPRECATED(virtual int InsertImage(const Device* caller, const ImgBuffer& buf)) = 0;
+
+      /**
+       * Cameras must call this function during sequence acquisition to send
+       * each frame to the Core.
+       *
+       * byteDepth: 1 or 2 for grayscale images; 4 for BGR_
+       *
+       * nComponents: 1 for grayscale; 4 for BGR_ (_: unused component)
+       *
+       * serializedMetadata: must be the result of md.serialize().c_str() (md
+       *                     being an instance of Metadata)
+       *
+       * doProcess: must normally be true, except for the case mentioned below
+       *
+       * If the sequence acquisition was started with stopOnOverflow = true
+       * _and_ the return value of InsertImage() is DEVICE_BUFFER_OVERFLOW,
+       * ClearImageBuffer() should be called and the call to InsertImage()
+       * should then be repeated with doProcess set to false. Otherwise, if the
+       * return value is not DEVICE_OK, or the second call failed (with any
+       * code), acquisition should stop.
+       */
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const char* serializedMetadata, const bool doProcess = true) = 0;
-      /// \deprecated Use the other forms instead.
+
+      /// \deprecated Use the other overloads instead.
       MM_DEPRECATED(virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const Metadata* md = 0, const bool doProcess = true)) = 0;
       // TODO Upon removing the above deprecated overload, add a default
       // argument `= nullptr` to `serializedMetadata` in the following
       // overload. That allows existing device adapters to compile.
+
+      /**
+       * Same as the overload with the added nComponents parameter.
+       *
+       * Assumes nComponents == 1 (grayscale).
+       */
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess = true) = 0;
+
       virtual void ClearImageBuffer(const Device* caller) = 0;
       virtual bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth) = 0;
-      /// \deprecated Use the other forms instead.
+
+      /// \deprecated Use InsertImage() instead.
       MM_DEPRECATED(virtual int InsertMultiChannel(const Device* caller, const unsigned char* buf, unsigned numChannels, unsigned width, unsigned height, unsigned byteDepth, Metadata* md = 0)) = 0;
 
       // Formerly intended for use by autofocus

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1384,15 +1384,16 @@ namespace MM {
       // sequence acquisition
       virtual int AcqFinished(const Device* caller, int statusCode) = 0;
       virtual int PrepareForAcq(const Device* caller) = 0;
-      virtual int InsertImage(const Device* caller, const ImgBuffer& buf) = 0;
-      virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const char* serializedMetadata, const bool doProcess = true) = 0;
-      virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const Metadata* md = 0, const bool doProcess = true) = 0;
       /// \deprecated Use the other forms instead.
+      MM_DEPRECATED(virtual int InsertImage(const Device* caller, const ImgBuffer& buf)) = 0;
+      virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const char* serializedMetadata, const bool doProcess = true) = 0;
+      /// \deprecated Use the other forms instead.
+      MM_DEPRECATED(virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const Metadata* md = 0, const bool doProcess = true)) = 0;
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess = true) = 0;
       virtual void ClearImageBuffer(const Device* caller) = 0;
       virtual bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth) = 0;
       /// \deprecated Use the other forms instead.
-      virtual int InsertMultiChannel(const Device* caller, const unsigned char* buf, unsigned numChannels, unsigned width, unsigned height, unsigned byteDepth, Metadata* md = 0) = 0;
+      MM_DEPRECATED(virtual int InsertMultiChannel(const Device* caller, const unsigned char* buf, unsigned numChannels, unsigned width, unsigned height, unsigned byteDepth, Metadata* md = 0)) = 0;
 
       // Formerly intended for use by autofocus
       MM_DEPRECATED(virtual const char* GetImage()) = 0;


### PR DESCRIPTION
In MMDevice we avoid passing nontrivial C++ objects because they are not always compatible between different types of builds (e.g., MMCore built in Release mode and device adapter built in Debug mode using MSVC). A couple of functions have been violating this rule by passing `ImgBuffer` or `Metadata`. Deprecate these.

Newly deprecate `InsertImage(const Device*, const ImgBuffer&)`.

Newly deprecate `InsertImage(const Device*, const unsigned char*, unsigned, unsigned, unsigned, const Metadata*, bool)`.

Add deprecation warnings for the newly and previously deprecated overloads.

However, **undeprecate** `InsertImage(const Device*, const unsigned char*, unsigned, unsigned, unsigned, const char*, bool)` because it is widely used and reasonable for monochrome-only cameras.

This leaves just 2 overloads of `InsertImage()` undeprecated, one with `nComponents` and one without.

@henrypinkard I don't think this conflicts with #570 (which changes the implementations of these functions), but let me know if you have any concerns.