### PR TITLE
ASITiger: the GainMultiplier property should be card addressed

### DIFF
--- a/DeviceAdapters/ASITiger/ASICRISP.cpp
+++ b/DeviceAdapters/ASITiger/ASICRISP.cpp
@@ -155,6 +155,7 @@ int CCRISP::Initialize()
    // new firmware has commands to query the values much faster.
    if (FirmwareVersionAtLeast(3.40))
    {
+       LogMessage("CRISP: firmware >= 3.40; use LK T? and LK Y? for the \"Sum\" and \"Dither Error\" properties.", true);
        pAct = new CPropertyAction(this, &CCRISP::OnSum);
        CreateProperty(g_CRISPSumPropertyName, "", MM::Integer, true, pAct);
        UpdateProperty(g_CRISPSumPropertyName);
@@ -165,6 +166,7 @@ int CCRISP::Initialize()
    }
    else
    {
+       LogMessage("CRISP: firmware < 3.40; use EXTRA X? for both the \"Sum\" and \"Dither Error\" properties.", true);
        pAct = new CPropertyAction(this, &CCRISP::OnSumLegacy);
        CreateProperty(g_CRISPSumPropertyName, "", MM::Integer, true, pAct);
        UpdateProperty(g_CRISPSumPropertyName);

--- a/DeviceAdapters/ASITiger/ASICRISP.cpp
+++ b/DeviceAdapters/ASITiger/ASICRISP.cpp
@@ -58,8 +58,6 @@ int CCRISP::Initialize()
    // call generic Initialize first, this gets hub
    RETURN_ON_MM_ERROR( PeripheralInitialize() );
 
-
-
    // create MM description; this doesn't work during hardware configuration wizard but will work afterwards
    ostringstream command;
    command.str("");
@@ -107,7 +105,7 @@ int CCRISP::Initialize()
    UpdateProperty(g_CRISPLockRangePropertyName);
 
    pAct = new CPropertyAction(this, &CCRISP::OnCalGain);
-   CreateProperty(g_CRISPCalibrationGainPropertyName, "0", MM::Float, false, pAct);
+   CreateProperty(g_CRISPCalibrationGainPropertyName, "0", MM::Integer, false, pAct);
    UpdateProperty(g_CRISPCalibrationGainPropertyName);
 
    pAct = new CPropertyAction(this, &CCRISP::OnLEDIntensity);
@@ -574,7 +572,7 @@ int CCRISP::OnLoopGainMultiplier(MM::PropertyBase* pProp, MM::ActionType eAct)
       {
           return DEVICE_OK;
       }
-      command << "LR T?";
+      command << addressChar_ << "LR T?";
       RETURN_ON_MM_ERROR( hub_->QueryCommandVerify(command.str(), ":A"));
       RETURN_ON_MM_ERROR ( hub_->ParseAnswerAfterEquals(tmp) );
       if (!pProp->Set(tmp))
@@ -585,7 +583,7 @@ int CCRISP::OnLoopGainMultiplier(MM::PropertyBase* pProp, MM::ActionType eAct)
    else if (eAct == MM::AfterSet)
    {
       pProp->Get(tmp);
-      command << "LR T=" << tmp;
+      command << addressChar_ << "LR T=" << tmp;
       RETURN_ON_MM_ERROR( hub_->QueryCommandVerify(command.str(), ":A") );
    }
    return DEVICE_OK;


### PR DESCRIPTION
This fixes a bug when there are multiple CRISP units in a Tiger controller, LR is a card addressed command. The card address needs to be at the start of the serial command to send a command to a specific CRISP device.

LR T? should be 2LR T? if the card address is 2

Also the "Calibration Gain" property was changed to an MM::Integer to reflect it's internal representation in the Tiger Controller. It is not possible to set the value to say, 2.5. It will be rounded to an integer. I think the confusion comes from it being output as a float by the LR command.