### PR TITLE
DahengGalaxy: Fixes bugs in ROI setting

### DIFF
--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
@@ -1833,41 +1833,39 @@ int ClassGalaxy::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize)
    int64_t width = m_objFeatureControlPtr->GetIntFeature("Width")->GetValue();
    int64_t height = m_objFeatureControlPtr->GetIntFeature("Height")->GetValue();
 
-    m_objFeatureControlPtr->GetIntFeature("Height")->SetValue(width);
-    m_objFeatureControlPtr->GetIntFeature("Width")->SetValue(height);
+    m_objFeatureControlPtr->GetIntFeature("Height")->SetValue(height);
+    m_objFeatureControlPtr->GetIntFeature("Width")->SetValue(width);
 
-    m_objFeatureControlPtr->GetIntFeature("OffsetY")->SetValue(0);
     m_objFeatureControlPtr->GetIntFeature("OffsetX")->SetValue(0);
-
+    m_objFeatureControlPtr->GetIntFeature("OffsetY")->SetValue(0);
 
 
     int64_t offsetX = m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetValue();
-
     int64_t offsetY = m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetValue();
 
 
-    x -= (x % (unsigned int)m_objFeatureControlPtr->GetFloatFeature("OffsetX")->GetInc());
-    y -= (y % (unsigned int)m_objFeatureControlPtr->GetFloatFeature("OffsetY")->GetInc());
-    xSize -= (xSize % (unsigned int)m_objFeatureControlPtr->GetFloatFeature("Width")->GetInc());
-    ySize -= (ySize % (unsigned int)m_objFeatureControlPtr->GetFloatFeature("Height")->GetInc());
+    x -= (x % (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetInc());
+    y -= (y % (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetInc());
+    xSize -= (xSize % (unsigned int)m_objFeatureControlPtr->GetIntFeature("Width")->GetInc());
+    ySize -= (ySize % (unsigned int)m_objFeatureControlPtr->GetIntFeature("Height")->GetInc());
 
-    if (xSize < (unsigned int)m_objFeatureControlPtr->GetFloatFeature("Width")->GetMin()) {
-        xSize = (unsigned int)m_objFeatureControlPtr->GetFloatFeature("Width")->GetMin();
+    if (xSize < (unsigned int)m_objFeatureControlPtr->GetIntFeature("Width")->GetMin()) {
+        xSize = (unsigned int)m_objFeatureControlPtr->GetIntFeature("Width")->GetMin();
     }
-    if (ySize < (unsigned int)m_objFeatureControlPtr->GetFloatFeature("Height")->GetMin()) {
-        ySize = (unsigned int)m_objFeatureControlPtr->GetFloatFeature("Height")->GetMin();
+    if (ySize < (unsigned int)m_objFeatureControlPtr->GetIntFeature("Height")->GetMin()) {
+        ySize = (unsigned int)m_objFeatureControlPtr->GetIntFeature("Height")->GetMin();
     }	
-    if (x < (unsigned int)m_objFeatureControlPtr->GetFloatFeature("offsetX")->GetMin()) {
-        x = (unsigned int)m_objFeatureControlPtr->GetFloatFeature("offsetX")->GetMin();
+    if (x < (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetMin()) {
+        x = (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetMin();
     }
-    if (y < (unsigned int)m_objFeatureControlPtr->GetFloatFeature("offsetY")->GetMin()) {
-        y = (unsigned int)m_objFeatureControlPtr->GetFloatFeature("offsetY")->GetMin();
+    if (y < (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetMin()) {
+        y = (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetMin();
     }
 
-    m_objFeatureControlPtr->GetIntFeature("Height")->SetValue(xSize);
-    m_objFeatureControlPtr->GetIntFeature("Width")->SetValue(ySize);
-    m_objFeatureControlPtr->GetIntFeature("OffsetY")->SetValue(x);
-    m_objFeatureControlPtr->GetIntFeature("OffsetX")->SetValue(y);
+    m_objFeatureControlPtr->GetIntFeature("Width")->SetValue(xSize);
+    m_objFeatureControlPtr->GetIntFeature("Height")->SetValue(ySize);
+    m_objFeatureControlPtr->GetIntFeature("OffsetX")->SetValue(x);
+    m_objFeatureControlPtr->GetIntFeature("OffsetY")->SetValue(y);
 
     //width->SetValue(xSize);
     //height->SetValue(ySize);
@@ -1893,11 +1891,11 @@ int ClassGalaxy::ClearROI()
     int64_t width = m_objFeatureControlPtr->GetIntFeature("Width")->GetMax();
     int64_t height = m_objFeatureControlPtr->GetIntFeature("Height")->GetMax();
 
+    m_objFeatureControlPtr->GetIntFeature("OffsetY")->SetValue(0);
+    m_objFeatureControlPtr->GetIntFeature("OffsetX")->SetValue(0);
     m_objFeatureControlPtr->GetIntFeature("Height")->SetValue(width);
     m_objFeatureControlPtr->GetIntFeature("Width")->SetValue(height);
 
-    m_objFeatureControlPtr->GetIntFeature("OffsetY")->SetValue(0);
-    m_objFeatureControlPtr->GetIntFeature("OffsetX")->SetValue(0);
     return 0;
 }
 

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
@@ -1828,52 +1828,44 @@ void ClassGalaxy::SetExposure(double exp)
 
 int ClassGalaxy::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize)
 {
+   m_objFeatureControlPtr->GetCommandFeature("AcquisitionStop")->Execute();
+   m_objStreamPtr->StopGrab();
+   
    m_objFeatureControlPtr->GetEnumFeature("RegionSelector")->SetValue("Region0");
 
-   int64_t width = m_objFeatureControlPtr->GetIntFeature("Width")->GetValue();
-   int64_t height = m_objFeatureControlPtr->GetIntFeature("Height")->GetValue();
+   x -= (x % (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetInc());
+   y -= (y % (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetInc());
+   xSize -= (xSize % (unsigned int)m_objFeatureControlPtr->GetIntFeature("Width")->GetInc());
+   ySize -= (ySize % (unsigned int)m_objFeatureControlPtr->GetIntFeature("Height")->GetInc());
 
-    m_objFeatureControlPtr->GetIntFeature("Height")->SetValue(height);
-    m_objFeatureControlPtr->GetIntFeature("Width")->SetValue(width);
+   if (xSize < (unsigned int)m_objFeatureControlPtr->GetIntFeature("Width")->GetMin()) {
+      xSize = (unsigned int)m_objFeatureControlPtr->GetIntFeature("Width")->GetMin();
+   }
+   if (ySize < (unsigned int)m_objFeatureControlPtr->GetIntFeature("Height")->GetMin()) {
+      ySize = (unsigned int)m_objFeatureControlPtr->GetIntFeature("Height")->GetMin();
+   }	
+   if (x < (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetMin()) {
+      x = (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetMin();
+   }
+   if (y < (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetMin()) {
+       y = (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetMin();
+   }
 
-    m_objFeatureControlPtr->GetIntFeature("OffsetX")->SetValue(0);
-    m_objFeatureControlPtr->GetIntFeature("OffsetY")->SetValue(0);
+   // TODO: check if values are too high?
+
+   try {
+      m_objFeatureControlPtr->GetIntFeature("Width")->SetValue(xSize);
+      m_objFeatureControlPtr->GetIntFeature("Height")->SetValue(ySize);
+      m_objFeatureControlPtr->GetIntFeature("OffsetX")->SetValue(x);
+      m_objFeatureControlPtr->GetIntFeature("OffsetY")->SetValue(y);
+   }
+   catch (exception ex) {
+      // TODO: return meaningful Error
+      return 1;
+   }
 
 
-    int64_t offsetX = m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetValue();
-    int64_t offsetY = m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetValue();
-
-
-    x -= (x % (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetInc());
-    y -= (y % (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetInc());
-    xSize -= (xSize % (unsigned int)m_objFeatureControlPtr->GetIntFeature("Width")->GetInc());
-    ySize -= (ySize % (unsigned int)m_objFeatureControlPtr->GetIntFeature("Height")->GetInc());
-
-    if (xSize < (unsigned int)m_objFeatureControlPtr->GetIntFeature("Width")->GetMin()) {
-        xSize = (unsigned int)m_objFeatureControlPtr->GetIntFeature("Width")->GetMin();
-    }
-    if (ySize < (unsigned int)m_objFeatureControlPtr->GetIntFeature("Height")->GetMin()) {
-        ySize = (unsigned int)m_objFeatureControlPtr->GetIntFeature("Height")->GetMin();
-    }	
-    if (x < (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetMin()) {
-        x = (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetX")->GetMin();
-    }
-    if (y < (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetMin()) {
-        y = (unsigned int)m_objFeatureControlPtr->GetIntFeature("OffsetY")->GetMin();
-    }
-
-    m_objFeatureControlPtr->GetIntFeature("Width")->SetValue(xSize);
-    m_objFeatureControlPtr->GetIntFeature("Height")->SetValue(ySize);
-    m_objFeatureControlPtr->GetIntFeature("OffsetX")->SetValue(x);
-    m_objFeatureControlPtr->GetIntFeature("OffsetY")->SetValue(y);
-
-    //width->SetValue(xSize);
-    //height->SetValue(ySize);
-    //offsetX->SetValue(x);
-    //offsetY->SetValue(y);
-
-    return DEVICE_OK;
-
+   return DEVICE_OK;
 }
 
 int ClassGalaxy::GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize)

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.h
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.h
@@ -3,7 +3,6 @@
 #pragma warning( disable : 4251 )
 #define _AFXDLL
 
-#include	"GalaxyException.h"
 #include	"GalaxyIncludes.h"
 
 //---------------------------------------------------------------------------------
@@ -37,7 +36,6 @@ class MODULE_API ClassGalaxy : public CCameraBase<ClassGalaxy>
 public:
 
 	ClassGalaxy();
-	//函数的意义-析构函数 delete时，启用;
 	~ClassGalaxy(void);
 
 	// MMDevice API
@@ -56,8 +54,6 @@ public:
 	unsigned char* GetImageBufferFromCallBack(CImageDataPointer& objCImageDataPointer);
 
 	const unsigned char* GetImageBuffer();
-
-	// void* Buffer4ContinuesShot;
 
 	unsigned GetNumberOfComponents() const;
 	unsigned GetImageWidth() const;
@@ -81,15 +77,11 @@ public:
 
 	void CoverToRGB(GX_PIXEL_FORMAT_ENTRY emDstFormat,void* DstBuffer, CImageDataPointer pObjSrcImageData);
 
-	////int SetProperty(const char* name, const char* value);
 	int CheckForBinningMode(CPropertyAction* pAct);
 	void AddToLog(std::string msg);
 	
 	GX_VALID_BIT_LIST GetBestValudBit(GX_PIXEL_FORMAT_ENTRY emPixelFormatEntry);
 	void CopyToImageBuffer(CImageDataPointer& objImageDataPointer);
-	//CImageFormatConverter* converter;
-	//std::string EnumToString(EDeviceAccessiblityInfo DeviceAccessiblityInfo);
-	//void UpdateTemperature();
 
 	/**
 	* Starts continuous acquisition. live模式，但是以下函数没有写也会开启live模式，开启该函数之后，软件会卡死，内部有函数
@@ -111,10 +103,6 @@ public:
 
 	//// action interface
 	//// ----------------
-	//int OnAcqFramerate(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnAcqFramerateEnable(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnAutoExpore(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnAutoGain(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnBinningMode(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnDeviceLinkThroughputLimit(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -122,16 +110,7 @@ public:
 	int OnGain(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnHeight(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnInterPacketDelay(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnLightSourcePreset(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnOffset(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnPixelType(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnResultingFramerate(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnReverseX(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnReverseY(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnSensorReadoutMode(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnShutterMode(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnTemperature(MM::PropertyBase* pProp, MM::ActionType eAct);
-	//int OnTemperatureState(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnTriggerMode(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnTriggerActivation(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnAdjFrameRateMode(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -160,6 +139,9 @@ public:
 	bool __IsPixelFormat8(GX_PIXEL_FORMAT_ENTRY emPixelFormatEntry);
 
 private:
+	bool StopGrabbing();
+	void StartGrabbing();
+	int HandleError(CGalaxyException cgal);
 	GxIAPICPP::gxdeviceinfo_vector vectorDeviceInfo;
 	int nComponents_;
 	unsigned bitDepth_;

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.h
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.h
@@ -70,7 +70,6 @@ public:
 	int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
 	int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
 	int ClearROI();
-	void ReduceImageSize(int64_t Width, int64_t Height);
 	int GetBinning() const;
 	int SetBinning(int binSize);
 	int IsExposureSequenceable(bool& seq) const { seq = false; return DEVICE_OK; }
@@ -78,7 +77,6 @@ public:
 	void CoverToRGB(GX_PIXEL_FORMAT_ENTRY emDstFormat,void* DstBuffer, CImageDataPointer pObjSrcImageData);
 
 	int CheckForBinningMode(CPropertyAction* pAct);
-	void AddToLog(std::string msg);
 	
 	GX_VALID_BIT_LIST GetBestValudBit(GX_PIXEL_FORMAT_ENTRY emPixelFormatEntry);
 	void CopyToImageBuffer(CImageDataPointer& objImageDataPointer);
@@ -89,7 +87,6 @@ public:
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow) final ;
 	int StartSequenceAcquisition(double interval_ms) final;
 	int StopSequenceAcquisition() final;
-	int PrepareSequenceAcqusition() final;
 
 	///**
 	//* Flag to indicate whether Sequence Acquisition is currently running.


### PR DESCRIPTION
Setting an ROI previously led to a crash (uncaught exception).  Turns out that the camera first has to stop grabbing before one can set the images sizes.  Also fixed a problem with stale width and height that sometimes would cause insertion in the sequence buffer to fail (I am not sure how this CMMError from the circular buffer InsertImage function is handled).

Also cleaned up the code a bit.  Still quite messy.