### PR TITLE
Automatically clear circular buffer in continuous sequence acquisition

### DIFF
--- a/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.vcxproj
+++ b/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.vcxproj
@@ -74,7 +74,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;ALLIEDVISIONCAMERA_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile />
@@ -90,7 +90,7 @@
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;ALLIEDVISIONCAMERA_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile />

--- a/DeviceAdapters/DahengGalaxy/DahengGalaxy.vcxproj
+++ b/DeviceAdapters/DahengGalaxy/DahengGalaxy.vcxproj
@@ -66,7 +66,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;DAHENGGALAXY_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -88,7 +88,7 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;DAHENGGALAXY_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>

--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -1112,18 +1112,7 @@ int CDemoCamera::InsertImage()
    unsigned int h = GetImageHeight();
    unsigned int b = GetImageBytesPerPixel();
 
-   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, nComponents_, md.Serialize().c_str());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // don't process this same image again...
-      return GetCoreCallback()->InsertImage(this, pI, w, h, b, nComponents_, md.Serialize().c_str(), false);
-   }
-   else
-   {
-      return ret;
-   }
+   return GetCoreCallback()->InsertImage(this, pI, w, h, b, nComponents_, md.Serialize().c_str());
 }
 
 /*
@@ -1157,13 +1146,7 @@ int CDemoCamera::RunSequenceOnThread()
       CDeviceUtils::SleepMs(1);
    }
 
-   ret = InsertImage();
-
-   if (ret != DEVICE_OK)
-   {
-      return ret;
-   }
-   return ret;
+   return InsertImage();
 };
 
 bool CDemoCamera::IsCapturing() {

--- a/DeviceAdapters/IDSPeak/IDSPeak.vcxproj
+++ b/DeviceAdapters/IDSPeak/IDSPeak.vcxproj
@@ -69,7 +69,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;IDSPEAK_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -86,7 +86,7 @@
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;IDSPEAK_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/DeviceAdapters/Lumenera/Lumenera.vcxproj
+++ b/DeviceAdapters/Lumenera/Lumenera.vcxproj
@@ -68,7 +68,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;LUMENERA_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -91,7 +91,7 @@
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;LUMENERA_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/DeviceAdapters/PlayerOne/PlayerOne.vcxproj
+++ b/DeviceAdapters/PlayerOne/PlayerOne.vcxproj
@@ -66,7 +66,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NOMINMAX
 ;WIN32;_DEBUG;PLAYERONE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -85,7 +85,7 @@
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NOMINMAX;
 WIN32;NDEBUG;PLAYERONE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>

--- a/DeviceAdapters/PyDevice/PyDevice.vcxproj
+++ b/DeviceAdapters/PyDevice/PyDevice.vcxproj
@@ -97,7 +97,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;PYDEVICE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -128,7 +128,7 @@
       <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;PYDEVICE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/DeviceAdapters/QSI/QSI.vcxproj
+++ b/DeviceAdapters/QSI/QSI.vcxproj
@@ -69,7 +69,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;QSI_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -89,7 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;QSI_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>

--- a/DeviceAdapters/SequenceTester/SequenceTester.vcxproj
+++ b/DeviceAdapters/SequenceTester/SequenceTester.vcxproj
@@ -77,10 +77,10 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;SEQUENCETESTER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)/msgpack/msgpack-cxx-4.1.3-win/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -92,10 +92,10 @@
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;SEQUENCETESTER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)/msgpack/msgpack-cxx-4.1.3-win/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/DeviceAdapters/SigmaKoki/SigmaKoki.vcxproj
+++ b/DeviceAdapters/SigmaKoki/SigmaKoki.vcxproj
@@ -59,6 +59,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4127;4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\Sentech\StCamUSBPack_EN_220919\2_SDK\StandardSDK(v3.17)\StandardSDK(v3.17)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -70,7 +71,7 @@
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4127;4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\Sentech\StCamUSBPack_EN_220919\2_SDK\StandardSDK(v3.17)\StandardSDK(v3.17)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/DeviceAdapters/Spinnaker/SpinnakerCamera.vcxproj
+++ b/DeviceAdapters/Spinnaker/SpinnakerCamera.vcxproj
@@ -60,7 +60,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>NOMINMAX;_DEBUG;_WINDOWS;_USRDLL;SPINNAKERCAMERA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -74,7 +74,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NOMINMAX;NDEBUG;_WINDOWS;_USRDLL;SPINNAKERCAMERA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/DeviceAdapters/ZWO/ZWO.vcxproj
+++ b/DeviceAdapters/ZWO/ZWO.vcxproj
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;ZWO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\ZWO\ASI_Windows_SDK_V1.28\ASI SDK\include;$(MM_3RDPARTYPRIVATE)\ZWO\EFW_Windows_SDK_V1.7\EFW SDK\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -72,7 +72,7 @@
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;ZWO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(MM_3RDPARTYPRIVATE)\ZWO\ASI_Windows_SDK_V1.28\ASI SDK\include;$(MM_3RDPARTYPRIVATE)\ZWO\EFW_Windows_SDK_V1.7\EFW SDK\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -62,12 +62,19 @@ CircularBuffer::CircularBuffer(unsigned int memorySizeMB) :
    saveIndex_(0), 
    memorySizeMB_(memorySizeMB), 
    overflow_(false),
+   overwriteData_(false),
    threadPool_(std::make_shared<ThreadPool>()),
    tasksMemCopy_(std::make_shared<TaskSet_CopyMemory>(threadPool_))
 {
 }
 
 CircularBuffer::~CircularBuffer() {}
+
+int CircularBuffer::SetOverwriteData(bool overwrite) {
+   MMThreadGuard guard(g_bufferLock);
+   overwriteData_ = overwrite;
+   return DEVICE_OK;
+}
 
 bool CircularBuffer::Initialize(unsigned channels, unsigned int w, unsigned int h, unsigned int pixDepth)
 {
@@ -234,8 +241,12 @@ bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned 
  
        bool overflowed = (insertIndex_ - saveIndex_) >= static_cast<long>(frameArray_.size());
        if (overflowed) {
-          overflow_ = true;
-          return false;
+         if (overwriteData_) {
+            Clear();
+         } else {
+            overflow_ = true;
+            return false;
+         }
        }
     }
  

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -55,6 +55,9 @@ public:
    CircularBuffer(unsigned int memorySizeMB);
    ~CircularBuffer();
 
+   int SetOverwriteData(bool overwrite);
+   bool GetOverwriteData() const { return overwriteData_; }
+
    unsigned GetMemorySizeMB() const { return memorySizeMB_; }
 
    bool Initialize(unsigned channels, unsigned int xSize, unsigned int ySize, unsigned int pixDepth);
@@ -100,6 +103,7 @@ private:
    unsigned long memorySizeMB_;
    unsigned int numChannels_;
    bool overflow_;
+   bool overwriteData_;
    std::vector<mm::FrameBuffer> frameArray_;
 
    std::shared_ptr<ThreadPool> threadPool_;

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -56,7 +56,6 @@ public:
    ~CircularBuffer();
 
    int SetOverwriteData(bool overwrite);
-   bool GetOverwriteData() const { return overwriteData_; }
 
    unsigned GetMemorySizeMB() const { return memorySizeMB_; }
 

--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -93,7 +93,7 @@ public:
    /*Deprecated*/ int InsertMultiChannel(const MM::Device* caller, const unsigned char* buf, unsigned numChannels, unsigned width, unsigned height, unsigned byteDepth, Metadata* pMd = 0);
   
    /*Deprecated*/ void ClearImageBuffer(const MM::Device* caller);
-   /*Deprecated*/ bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth);
+   bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth);
 
    int AcqFinished(const MM::Device* caller, int statusCode);
    int PrepareForAcq(const MM::Device* caller);

--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -91,8 +91,9 @@ public:
    /*Deprecated*/ int InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const Metadata* pMd = 0, const bool doProcess = true);
 
    /*Deprecated*/ int InsertMultiChannel(const MM::Device* caller, const unsigned char* buf, unsigned numChannels, unsigned width, unsigned height, unsigned byteDepth, Metadata* pMd = 0);
-   void ClearImageBuffer(const MM::Device* caller);
-   bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth);
+  
+   /*Deprecated*/ void ClearImageBuffer(const MM::Device* caller);
+   /*Deprecated*/ bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth);
 
    int AcqFinished(const MM::Device* caller, int statusCode);
    int PrepareForAcq(const MM::Device* caller);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -2878,7 +2878,7 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
       throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
    }
    cbuf_->Clear();
-   cbuf_->SetOverwriteData(false);
+   cbuf_->SetOverwriteData(!stopOnOverflow);
    LOG_DEBUG(coreLogger_) <<
       "Will start sequence acquisition from camera " << label;
    int nRet = pCam->StartSequenceAcquisition(numImages, intervalMs, stopOnOverflow);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -2833,7 +2833,7 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
 				throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
 			}
 			cbuf_->Clear();
-         cbuf_->SetOverwriteData(false);
+         cbuf_->SetOverwriteData(!stopOnOverflow);
          mm::DeviceModuleLockGuard guard(camera);
 
          LOG_DEBUG(coreLogger_) << "Will start sequence acquisition from default camera";

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -2833,6 +2833,7 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
 				throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
 			}
 			cbuf_->Clear();
+         cbuf_->SetOverwriteData(false);
          mm::DeviceModuleLockGuard guard(camera);
 
          LOG_DEBUG(coreLogger_) << "Will start sequence acquisition from default camera";
@@ -2877,7 +2878,7 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
       throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
    }
    cbuf_->Clear();
-	
+   cbuf_->SetOverwriteData(false);
    LOG_DEBUG(coreLogger_) <<
       "Will start sequence acquisition from camera " << label;
    int nRet = pCam->StartSequenceAcquisition(numImages, intervalMs, stopOnOverflow);
@@ -2980,6 +2981,7 @@ void CMMCore::startContinuousSequenceAcquisition(double intervalMs) throw (CMMEr
          throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
       }
       cbuf_->Clear();
+      cbuf_->SetOverwriteData(true);
       LOG_DEBUG(coreLogger_) << "Will start continuous sequence acquisition from current camera";
       int nRet = camera->StartSequenceAcquisition(intervalMs);
       if (nRet != DEVICE_OK)

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1423,8 +1423,8 @@ namespace MM {
        */
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess = true) = 0;
 
-      virtual void ClearImageBuffer(const Device* caller) = 0;
-      virtual bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth) = 0;
+      MM_DEPRECATED(virtual void ClearImageBuffer(const Device* caller)) = 0;
+      MM_DEPRECATED(virtual bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth)) = 0;
 
       /// \deprecated Use InsertImage() instead.
       MM_DEPRECATED(virtual int InsertMultiChannel(const Device* caller, const unsigned char* buf, unsigned numChannels, unsigned width, unsigned height, unsigned byteDepth, Metadata* md = 0)) = 0;

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1424,7 +1424,7 @@ namespace MM {
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess = true) = 0;
 
       MM_DEPRECATED(virtual void ClearImageBuffer(const Device* caller)) = 0;
-      MM_DEPRECATED(virtual bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth)) = 0;
+      virtual bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth) = 0;
 
       /// \deprecated Use InsertImage() instead.
       MM_DEPRECATED(virtual int InsertMultiChannel(const Device* caller, const unsigned char* buf, unsigned numChannels, unsigned width, unsigned height, unsigned byteDepth, Metadata* md = 0)) = 0;

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1399,9 +1399,16 @@ namespace MM {
        * serializedMetadata: must be the result of md.serialize().c_str() (md
        *                     being an instance of Metadata)
        *
-       * doProcess: must normally be true, except for the case mentioned below
+       * doProcess: must be true, except for the case mentioned below
        *
-       * If the sequence acquisition was started with stopOnOverflow = true
+       * Legacy note: previously, cameras were required to perform the
+       * following special handling when InsertImage() returns
+       * DEVICE_BUFFER_OVERFLOW. However, InsertImage() no longer ever
+       * returns that particular error when stopOnOverflow = false. So
+       * cameras should always just stop the acquisition if InsertImage()
+       * returns any error.
+       *
+       * If the sequence acquisition was started with stopOnOverflow = false
        * _and_ the return value of InsertImage() is DEVICE_BUFFER_OVERFLOW,
        * ClearImageBuffer() should be called and the call to InsertImage()
        * should then be repeated with doProcess set to false. Otherwise, if the


### PR DESCRIPTION
This adds an overwrite mode to the circular buffer, which means that when an image is inserted and there's no more space, it will automatically clear itself. Currently, most cameras do this manually when there is an error on insert. 

This is motivated by the need to deprecate the ability of devices to clear and allocate the buffer in the core. This should instead be done by higher level application code.

One thing I don't fully understand is the `stopOnOverflow` argument of `startSequenceAcquisition`. Some, but not all, cameras appear to have logic that changes behavior based on this flag, but I'm not aware of any higher level code that ever sets this to `false` when running a finite sequence of N frames. 

Regardless, `stopOnOverflow` shouldn't be an issue for merging this, because the only time we set `overwrite=true` is when calling `startContinuousSequenceAcquisition`, where `stopOnOverflow` is always false