### PR TITLE
Allow camera device adapters to call `InsertImage` on snap

### DIFF
--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -251,6 +251,18 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
 
 int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const Metadata* pMd, bool doProcess)
 {
+   // Check if the camera is currently snapping an image, if its calling InsertImage,
+   // then its circumventing having its own buffer. This allows camera device adapters to
+   // not have to implement their own buffers, and can instead just copy data in directly.
+    {
+        std::shared_ptr<CameraInstance> camera = std::static_pointer_cast<CameraInstance>(core_->deviceManager_->GetDevice(caller));
+        if (camera->IsSnapping()) {
+            // Don't do any metadata or image processing, for consistency with the existing SnapImage()/GetImage() methods
+            camera->StoreSnappedImage(buf, width, height, byteDepth, 1);
+            return DEVICE_OK;
+        }
+   }
+
    try 
    {
       Metadata md = AddCameraMetadata(caller, pMd);
@@ -283,6 +295,18 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
 
 int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const Metadata* pMd, bool doProcess)
 {
+   // Check if the camera is currently snapping an image, if its calling InsertImage,
+   // then its circumventing having its own buffer. This allows camera device adapters to
+   // not have to implement their own buffers, and can instead just copy data in directly.
+    {
+        std::shared_ptr<CameraInstance> camera = std::static_pointer_cast<CameraInstance>(core_->deviceManager_->GetDevice(caller));
+        if (camera->IsSnapping()) {
+            // Don't do any metadata or image processing, for consistency with the existing SnapImage()/GetImage() methods
+            camera->StoreSnappedImage(buf, width, height, byteDepth, 1);
+            return DEVICE_OK;
+        }
+    }
+   
    try 
    {
       Metadata md = AddCameraMetadata(caller, pMd);

--- a/MMCore/Devices/CameraInstance.h
+++ b/MMCore/Devices/CameraInstance.h
@@ -20,6 +20,10 @@
 #pragma once
 
 #include "DeviceInstanceBase.h"
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include "../FrameBuffer.h"
 
 
 class CameraInstance : public DeviceInstanceBase<MM::Camera>
@@ -82,4 +86,23 @@ public:
    int ClearExposureSequence();
    int AddToExposureSequence(double exposureTime_ms);
    int SendExposureSequence() const;
+
+   /**
+    * Checks if the camera is currently snapping an image.
+    * Thread-safe method that can be called from any thread.
+    * @return true if the camera is currently snapping an image, false otherwise
+    */
+   bool IsSnapping() const;
+   void StoreSnappedImage(const unsigned char* buf, unsigned width, unsigned height, 
+                          unsigned byteDepth, unsigned nComponents);
+
+private:
+   // Atomic flag to track if the camera is currently snapping an image
+   std::atomic<bool> isSnapping_{false};
+   
+   // Frame buffer to store captured images
+   mm::FrameBuffer snappedImage_;
+
+   std::mutex imageMutex_;
+   std::condition_variable imageAvailable_;
 };

--- a/MMCore/Devices/CameraInstance.h
+++ b/MMCore/Devices/CameraInstance.h
@@ -21,8 +21,6 @@
 
 #include "DeviceInstanceBase.h"
 #include <atomic>
-#include <condition_variable>
-#include <mutex>
 #include "../FrameBuffer.h"
 
 
@@ -102,7 +100,4 @@ private:
    
    // Frame buffer to store captured images
    mm::FrameBuffer snappedImage_;
-
-   std::mutex imageMutex_;
-   std::condition_variable imageAvailable_;
 };


### PR DESCRIPTION
(Part of changes needed for the new camera API but should also work with existing camera API. Broken into its own PR for easier review.)

This PR allows camera device adapters, rather than having to maintain their own internal buffer for when `SnapImage()` is called, to instead simply call `InsertImage`. The `CoreCallback` then determines whether the inserted data should be routed to the circular buffer or to an internal buffer maintained in the camera device instance in the core. Higher level code calling `GetImage` should not see any difference in behavior.

This will simplify writing device adapters for both old and new camera APIs, and it has the potential to improve performance, because copying of the snap buffer can use to multi-threaded copying code done used in the circular buffer.

It might be a good addition to deprecate `GetImageBuffer` in the current camera api and make calling `InsertImage` the preferred approach.

One thing that needs to be addressed is that this does not work in its current form with multi-channel cameras, which would expect `InsertImage` to be called multiple times. I think this can be fixed, though in my opinion it might just be simpler to just deprecate multi-channel cameras, since the new data buffer #570 offers a much more flexible and general way to handle non-monochrome image data formats.


