### PR TITLE
Utilities: drop Boost dependency

### DIFF
--- a/DeviceAdapters/Utilities/ComboXYStage.cpp
+++ b/DeviceAdapters/Utilities/ComboXYStage.cpp
@@ -32,7 +32,6 @@
 
 #include "Utilities.h"
 
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
 
 extern const char* g_DeviceNameComboXYStage;
@@ -202,7 +201,7 @@ int ComboXYStage::Home()
 
 int ComboXYStage::SetPositionSteps(long x, long y)
 {
-   LogMessage(("SetPositionSteps(" + boost::lexical_cast<std::string>(x) + ", " + boost::lexical_cast<std::string>(y) + ")").c_str(), true);
+   LogMessage(("SetPositionSteps(" + std::to_string(x) + ", " + std::to_string(y) + ")").c_str(), true);
 
    for (int i = 0; i < 2; ++i)
    {
@@ -250,7 +249,7 @@ int ComboXYStage::GetPositionSteps(long& x, long& y)
       posSteps = Round(logicalPosUm / simulatedStepSizeUm);
    }
 
-   LogMessage(("GetPositionSteps() -> (" + boost::lexical_cast<std::string>(x) + ", " + boost::lexical_cast<std::string>(y) + ")").c_str(), true);
+   LogMessage(("GetPositionSteps() -> (" + std::to_string(x) + ", " + std::to_string(y) + ")").c_str(), true);
    return DEVICE_OK;
 }
 

--- a/DeviceAdapters/Utilities/DATTLStateDevice.cpp
+++ b/DeviceAdapters/Utilities/DATTLStateDevice.cpp
@@ -32,8 +32,6 @@
 
 #include "Utilities.h"
 
-#include <boost/lexical_cast.hpp>
-
 extern const char* g_DeviceNameDATTLStateDevice;
 extern const char* g_normalLogicString;
 extern const char* g_invertedLogicString;
@@ -58,7 +56,7 @@ DATTLStateDevice::DATTLStateDevice() :
       false, pAct, true);
    for (int i = 1; i <= 8; ++i)
    {
-      AddAllowedValue("NumberOfDADevices", boost::lexical_cast<std::string>(i).c_str());
+      AddAllowedValue("NumberOfDADevices", std::to_string(i).c_str());
    }
 
    EnableDelay(true);
@@ -99,8 +97,7 @@ int DATTLStateDevice::Initialize()
 
    for (unsigned int i = 0; i < numberOfDADevices_; ++i)
    {
-      const std::string propName =
-         "DADevice-" + boost::lexical_cast<std::string>(i);
+      const std::string propName = "DADevice-" + std::to_string(i);
       CPropertyActionEx* pAct = new CPropertyActionEx(this,
          &DATTLStateDevice::OnDADevice, i);
       int ret = CreateStringProperty(propName.c_str(), "", false, pAct);
@@ -118,7 +115,7 @@ int DATTLStateDevice::Initialize()
    int numPos = GetNumberOfPositions();
    for (int i = 0; i < numPos; ++i)
    {
-      SetPositionLabel(i, boost::lexical_cast<std::string>(i).c_str());
+      SetPositionLabel(i, std::to_string(i).c_str());
    }
 
    CPropertyAction* pAct = new CPropertyAction(this, &DATTLStateDevice::OnState);
@@ -303,9 +300,13 @@ int DATTLStateDevice::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
       {
          try
          {
-            values.push_back(boost::lexical_cast<long>(*it));
+            values.push_back(std::stol(*it));
          }
-         catch (boost::bad_lexical_cast&)
+         catch (const std::invalid_argument&)
+         {
+            return DEVICE_ERR;
+         }
+         catch (const std::out_of_range&)
          {
             return DEVICE_ERR;
          }

--- a/DeviceAdapters/Utilities/MultiCamera.cpp
+++ b/DeviceAdapters/Utilities/MultiCamera.cpp
@@ -32,7 +32,6 @@
 
 #include "Utilities.h"
 
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
 
 extern const char* g_DeviceNameMultiCamera;

--- a/DeviceAdapters/Utilities/MultiDAStateDevice.cpp
+++ b/DeviceAdapters/Utilities/MultiDAStateDevice.cpp
@@ -32,8 +32,6 @@
 
 #include "Utilities.h"
 
-#include <boost/lexical_cast.hpp>
-
 extern const char* g_DeviceNameMultiDAStateDevice;
 
 
@@ -54,7 +52,7 @@ MultiDAStateDevice::MultiDAStateDevice() :
       false, pAct, true);
    for (int i = 1; i <= 8; ++i)
    {
-      AddAllowedValue("NumberOfDADevices", boost::lexical_cast<std::string>(i).c_str());
+      AddAllowedValue("NumberOfDADevices", std::to_string(i).c_str());
    }
 
    pAct = new CPropertyAction(this, &MultiDAStateDevice::OnMinVoltage);
@@ -102,8 +100,7 @@ int MultiDAStateDevice::Initialize()
 
    for (unsigned int i = 0; i < numberOfDADevices_; ++i)
    {
-      const std::string propName =
-         "DADevice-" + boost::lexical_cast<std::string>(i);
+      const std::string propName = "DADevice-" + std::to_string(i);
       CPropertyActionEx* pAct = new CPropertyActionEx(this,
          &MultiDAStateDevice::OnDADevice, i);
       int ret = CreateStringProperty(propName.c_str(), "", false, pAct);
@@ -121,7 +118,7 @@ int MultiDAStateDevice::Initialize()
    int numPos = GetNumberOfPositions();
    for (int i = 0; i < numPos; ++i)
    {
-      SetPositionLabel(i, boost::lexical_cast<std::string>(i).c_str());
+      SetPositionLabel(i, std::to_string(i).c_str());
    }
 
    if (minVoltage_ > maxVoltage_)
@@ -146,8 +143,7 @@ int MultiDAStateDevice::Initialize()
 
    for (unsigned int i = 0; i < numberOfDADevices_; ++i)
    {
-      const std::string propName =
-         "DADevice-" + boost::lexical_cast<std::string>(i) + "-Voltage";
+      const std::string propName = "DADevice-" + std::to_string(i) + "-Voltage";
       CPropertyActionEx* pActEx = new CPropertyActionEx(this, &MultiDAStateDevice::OnVoltage, i);
       ret = CreateFloatProperty(propName.c_str(), voltages_[i], false, pActEx);
       if (ret != DEVICE_OK)
@@ -343,9 +339,13 @@ int MultiDAStateDevice::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
       {
          try
          {
-            values.push_back(boost::lexical_cast<long>(*it));
+            values.push_back(std::stol(*it));
          }
-         catch (boost::bad_lexical_cast&)
+         catch (const std::invalid_argument&)
+         {
+            return DEVICE_ERR;
+         }
+         catch (const std::out_of_range&)
          {
             return DEVICE_ERR;
          }

--- a/DeviceAdapters/Utilities/MultiShutter.cpp
+++ b/DeviceAdapters/Utilities/MultiShutter.cpp
@@ -33,7 +33,6 @@
 
 #include "Utilities.h"
 
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
 
 extern const char* g_DeviceNameMultiShutter;

--- a/DeviceAdapters/Utilities/MultiStage.cpp
+++ b/DeviceAdapters/Utilities/MultiStage.cpp
@@ -32,7 +32,6 @@
 
 #include "Utilities.h"
 
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
 
 extern const char* g_DeviceNameMultiStage;
@@ -62,8 +61,7 @@ MultiStage::MultiStage() :
       true);
    for (unsigned i = 0; i < 8; ++i)
    {
-      AddAllowedValue("NumberOfPhysicalStages",
-         boost::lexical_cast<std::string>(i + 1).c_str());
+      AddAllowedValue("NumberOfPhysicalStages", std::to_string(i + 1).c_str());
    }
 
    CreateFloatProperty("SimulatedStepSizeUm", simulatedStepSizeUm_, false,
@@ -115,7 +113,7 @@ int MultiStage::Initialize()
 
    for (unsigned i = 0; i < nrPhysicalStages_; ++i)
    {
-      const std::string displayIndex = boost::lexical_cast<std::string>(i + 1);
+      const std::string displayIndex = std::to_string(i + 1);
 
       const std::string propPhysStage("PhysicalStage-" + displayIndex);
       CreateStringProperty(propPhysStage.c_str(), usedStages_[i].c_str(), false,

--- a/DeviceAdapters/Utilities/Utilities.cpp
+++ b/DeviceAdapters/Utilities/Utilities.cpp
@@ -34,8 +34,6 @@
 
 #include "ModuleInterface.h"
 
-#include <boost/lexical_cast.hpp>
-
 #include <algorithm>
 
 


### PR DESCRIPTION
(In the interest of keeping Boost out of our core modules.)

Replace `boost::lexical_cast<std::string>()` with `std::to_string()` (which is exactly equivalent for integer arguments).

Replace `boost::lexical_cast<long>()` with `std::stol()` and handle exceptions accordingly.