### PR TITLE
Pump device fixes

### DIFF
--- a/MMCore/Devices/PressurePumpInstance.cpp
+++ b/MMCore/Devices/PressurePumpInstance.cpp
@@ -23,8 +23,8 @@
 #include "../../MMDevice/MMDeviceConstants.h"
 
 // General pump functions
-int PressurePumpInstance::Stop() { return GetImpl()->Stop(); }
-int PressurePumpInstance::Calibrate() { return GetImpl()->Calibrate(); }
-bool PressurePumpInstance::RequiresCalibration() { return GetImpl()->RequiresCalibration(); }
-int PressurePumpInstance::SetPressureKPa(double pressure) { return GetImpl()->SetPressureKPa(pressure); }
-int PressurePumpInstance::GetPressureKPa(double& pressure) { return GetImpl()->GetPressureKPa(pressure); }
+int PressurePumpInstance::Stop() { RequireInitialized(__func__); return GetImpl()->Stop(); }
+int PressurePumpInstance::Calibrate() { RequireInitialized(__func__); return GetImpl()->Calibrate(); }
+bool PressurePumpInstance::RequiresCalibration() { RequireInitialized(__func__); return GetImpl()->RequiresCalibration(); }
+int PressurePumpInstance::SetPressureKPa(double pressure) { RequireInitialized(__func__); return GetImpl()->SetPressureKPa(pressure); }
+int PressurePumpInstance::GetPressureKPa(double& pressure) { RequireInitialized(__func__); return GetImpl()->GetPressureKPa(pressure); }

--- a/MMCore/Devices/PressurePumpInstance.cpp
+++ b/MMCore/Devices/PressurePumpInstance.cpp
@@ -26,5 +26,5 @@
 int PressurePumpInstance::Stop() { return GetImpl()->Stop(); }
 int PressurePumpInstance::Calibrate() { return GetImpl()->Calibrate(); }
 bool PressurePumpInstance::RequiresCalibration() { return GetImpl()->RequiresCalibration(); }
-int PressurePumpInstance::SetPressure(double pressure) { return GetImpl()->SetPressure(pressure); }
-int PressurePumpInstance::GetPressure(double& pressure) { return GetImpl()->GetPressure(pressure); }
+int PressurePumpInstance::SetPressureKPa(double pressure) { return GetImpl()->SetPressureKPa(pressure); }
+int PressurePumpInstance::GetPressureKPa(double& pressure) { return GetImpl()->GetPressureKPa(pressure); }

--- a/MMCore/Devices/PressurePumpInstance.cpp
+++ b/MMCore/Devices/PressurePumpInstance.cpp
@@ -25,6 +25,6 @@
 // General pump functions
 int PressurePumpInstance::Stop() { return GetImpl()->Stop(); }
 int PressurePumpInstance::Calibrate() { return GetImpl()->Calibrate(); }
-bool PressurePumpInstance::requiresCalibration() { return GetImpl()->RequiresCalibration(); }
-int PressurePumpInstance::setPressure(double pressure) { return GetImpl()->SetPressure(pressure); }
-int PressurePumpInstance::getPressure(double& pressure) { return GetImpl()->GetPressure(pressure); }
+bool PressurePumpInstance::RequiresCalibration() { return GetImpl()->RequiresCalibration(); }
+int PressurePumpInstance::SetPressure(double pressure) { return GetImpl()->SetPressure(pressure); }
+int PressurePumpInstance::GetPressure(double& pressure) { return GetImpl()->GetPressure(pressure); }

--- a/MMCore/Devices/PressurePumpInstance.h
+++ b/MMCore/Devices/PressurePumpInstance.h
@@ -39,7 +39,7 @@ public:
 
     int Calibrate();
     int Stop();
-    bool requiresCalibration();
-    int setPressure(double pressure);
-    int getPressure(double& pressure);
+    bool RequiresCalibration();
+    int SetPressure(double pressure);
+    int GetPressure(double& pressure);
 };

--- a/MMCore/Devices/PressurePumpInstance.h
+++ b/MMCore/Devices/PressurePumpInstance.h
@@ -40,6 +40,6 @@ public:
     int Calibrate();
     int Stop();
     bool RequiresCalibration();
-    int SetPressure(double pressure);
-    int GetPressure(double& pressure);
+    int SetPressureKPa(double pressure);
+    int GetPressureKPa(double& pressure);
 };

--- a/MMCore/Devices/VolumetricPumpInstance.cpp
+++ b/MMCore/Devices/VolumetricPumpInstance.cpp
@@ -32,8 +32,8 @@ int VolumetricPumpInstance::SetVolumeUl(double volume) { return GetImpl()->SetVo
 int VolumetricPumpInstance::GetVolumeUl(double& volume) { return GetImpl()->GetVolumeUl(volume); }
 int VolumetricPumpInstance::SetMaxVolumeUl(double volume) { return GetImpl()->SetMaxVolumeUl(volume); }
 int VolumetricPumpInstance::GetMaxVolumeUl(double& volume) { return GetImpl()->GetMaxVolumeUl(volume); }
-int VolumetricPumpInstance::SetFlowrateUlPerSec(double flowrate) { return GetImpl()->SetFlowrateUlPerSecond(flowrate); }
-int VolumetricPumpInstance::GetFlowrateUlPerSec(double& flowrate) { return GetImpl()->GetFlowrateUlPerSecond(flowrate); }
+int VolumetricPumpInstance::SetFlowrateUlPerSecond(double flowrate) { return GetImpl()->SetFlowrateUlPerSecond(flowrate); }
+int VolumetricPumpInstance::GetFlowrateUlPerSecond(double& flowrate) { return GetImpl()->GetFlowrateUlPerSecond(flowrate); }
 int VolumetricPumpInstance::Start() { return GetImpl()->Start(); }
 int VolumetricPumpInstance::DispenseDurationSeconds(double durSec) { return GetImpl()->DispenseDurationSeconds(durSec); }
 int VolumetricPumpInstance::DispenseVolumeUl(double volUl) { return GetImpl()->DispenseVolumeUl(volUl); }

--- a/MMCore/Devices/VolumetricPumpInstance.cpp
+++ b/MMCore/Devices/VolumetricPumpInstance.cpp
@@ -25,15 +25,15 @@
 // Volume controlled pump functions
 int VolumetricPumpInstance::Home() { return GetImpl()->Home(); }
 int VolumetricPumpInstance::Stop() { return GetImpl()->Stop(); }
-bool VolumetricPumpInstance::requiresHoming() { return GetImpl()->RequiresHoming(); }
-int VolumetricPumpInstance::invertDirection(bool state) { return GetImpl()->InvertDirection(state); }
-int VolumetricPumpInstance::isDirectionInverted(bool& state) { return GetImpl()->IsDirectionInverted(state); }
-int VolumetricPumpInstance::setVolumeUl(double volume) { return GetImpl()->SetVolumeUl(volume); }
-int VolumetricPumpInstance::getVolumeUl(double& volume) { return GetImpl()->GetVolumeUl(volume); }
-int VolumetricPumpInstance::setMaxVolumeUl(double volume) { return GetImpl()->SetMaxVolumeUl(volume); }
-int VolumetricPumpInstance::getMaxVolumeUl(double& volume) { return GetImpl()->GetMaxVolumeUl(volume); }
-int VolumetricPumpInstance::setFlowrateUlPerSec(double flowrate) { return GetImpl()->SetFlowrateUlPerSecond(flowrate); }
-int VolumetricPumpInstance::getFlowrateUlPerSec(double& flowrate) { return GetImpl()->GetFlowrateUlPerSecond(flowrate); }
+bool VolumetricPumpInstance::RequiresHoming() { return GetImpl()->RequiresHoming(); }
+int VolumetricPumpInstance::InvertDirection(bool state) { return GetImpl()->InvertDirection(state); }
+int VolumetricPumpInstance::IsDirectionInverted(bool& state) { return GetImpl()->IsDirectionInverted(state); }
+int VolumetricPumpInstance::SetVolumeUl(double volume) { return GetImpl()->SetVolumeUl(volume); }
+int VolumetricPumpInstance::GetVolumeUl(double& volume) { return GetImpl()->GetVolumeUl(volume); }
+int VolumetricPumpInstance::SetMaxVolumeUl(double volume) { return GetImpl()->SetMaxVolumeUl(volume); }
+int VolumetricPumpInstance::GetMaxVolumeUl(double& volume) { return GetImpl()->GetMaxVolumeUl(volume); }
+int VolumetricPumpInstance::SetFlowrateUlPerSec(double flowrate) { return GetImpl()->SetFlowrateUlPerSecond(flowrate); }
+int VolumetricPumpInstance::GetFlowrateUlPerSec(double& flowrate) { return GetImpl()->GetFlowrateUlPerSecond(flowrate); }
 int VolumetricPumpInstance::Start() { return GetImpl()->Start(); }
 int VolumetricPumpInstance::DispenseDuration(double durSec) { return GetImpl()->DispenseDuration(durSec); }
 int VolumetricPumpInstance::DispenseVolume(double volUl) { return GetImpl()->DispenseVolume(volUl); }

--- a/MMCore/Devices/VolumetricPumpInstance.cpp
+++ b/MMCore/Devices/VolumetricPumpInstance.cpp
@@ -23,17 +23,17 @@
 #include "../../MMDevice/MMDeviceConstants.h"
 
 // Volume controlled pump functions
-int VolumetricPumpInstance::Home() { return GetImpl()->Home(); }
-int VolumetricPumpInstance::Stop() { return GetImpl()->Stop(); }
-bool VolumetricPumpInstance::RequiresHoming() { return GetImpl()->RequiresHoming(); }
-int VolumetricPumpInstance::InvertDirection(bool state) { return GetImpl()->InvertDirection(state); }
-int VolumetricPumpInstance::IsDirectionInverted(bool& state) { return GetImpl()->IsDirectionInverted(state); }
-int VolumetricPumpInstance::SetVolumeUl(double volume) { return GetImpl()->SetVolumeUl(volume); }
-int VolumetricPumpInstance::GetVolumeUl(double& volume) { return GetImpl()->GetVolumeUl(volume); }
-int VolumetricPumpInstance::SetMaxVolumeUl(double volume) { return GetImpl()->SetMaxVolumeUl(volume); }
-int VolumetricPumpInstance::GetMaxVolumeUl(double& volume) { return GetImpl()->GetMaxVolumeUl(volume); }
-int VolumetricPumpInstance::SetFlowrateUlPerSecond(double flowrate) { return GetImpl()->SetFlowrateUlPerSecond(flowrate); }
-int VolumetricPumpInstance::GetFlowrateUlPerSecond(double& flowrate) { return GetImpl()->GetFlowrateUlPerSecond(flowrate); }
-int VolumetricPumpInstance::Start() { return GetImpl()->Start(); }
-int VolumetricPumpInstance::DispenseDurationSeconds(double durSec) { return GetImpl()->DispenseDurationSeconds(durSec); }
-int VolumetricPumpInstance::DispenseVolumeUl(double volUl) { return GetImpl()->DispenseVolumeUl(volUl); }
+int VolumetricPumpInstance::Home() { RequireInitialized(__func__); return GetImpl()->Home(); }
+int VolumetricPumpInstance::Stop() { RequireInitialized(__func__); return GetImpl()->Stop(); }
+bool VolumetricPumpInstance::RequiresHoming() { RequireInitialized(__func__); return GetImpl()->RequiresHoming(); }
+int VolumetricPumpInstance::InvertDirection(bool state) { RequireInitialized(__func__); return GetImpl()->InvertDirection(state); }
+int VolumetricPumpInstance::IsDirectionInverted(bool& state) { RequireInitialized(__func__); return GetImpl()->IsDirectionInverted(state); }
+int VolumetricPumpInstance::SetVolumeUl(double volume) { RequireInitialized(__func__); return GetImpl()->SetVolumeUl(volume); }
+int VolumetricPumpInstance::GetVolumeUl(double& volume) { RequireInitialized(__func__); return GetImpl()->GetVolumeUl(volume); }
+int VolumetricPumpInstance::SetMaxVolumeUl(double volume) { RequireInitialized(__func__); return GetImpl()->SetMaxVolumeUl(volume); }
+int VolumetricPumpInstance::GetMaxVolumeUl(double& volume) { RequireInitialized(__func__); return GetImpl()->GetMaxVolumeUl(volume); }
+int VolumetricPumpInstance::SetFlowrateUlPerSecond(double flowrate) { RequireInitialized(__func__); return GetImpl()->SetFlowrateUlPerSecond(flowrate); }
+int VolumetricPumpInstance::GetFlowrateUlPerSecond(double& flowrate) { RequireInitialized(__func__); return GetImpl()->GetFlowrateUlPerSecond(flowrate); }
+int VolumetricPumpInstance::Start() { RequireInitialized(__func__); return GetImpl()->Start(); }
+int VolumetricPumpInstance::DispenseDurationSeconds(double durSec) { RequireInitialized(__func__); return GetImpl()->DispenseDurationSeconds(durSec); }
+int VolumetricPumpInstance::DispenseVolumeUl(double volUl) { RequireInitialized(__func__); return GetImpl()->DispenseVolumeUl(volUl); }

--- a/MMCore/Devices/VolumetricPumpInstance.cpp
+++ b/MMCore/Devices/VolumetricPumpInstance.cpp
@@ -35,5 +35,5 @@ int VolumetricPumpInstance::GetMaxVolumeUl(double& volume) { return GetImpl()->G
 int VolumetricPumpInstance::SetFlowrateUlPerSec(double flowrate) { return GetImpl()->SetFlowrateUlPerSecond(flowrate); }
 int VolumetricPumpInstance::GetFlowrateUlPerSec(double& flowrate) { return GetImpl()->GetFlowrateUlPerSecond(flowrate); }
 int VolumetricPumpInstance::Start() { return GetImpl()->Start(); }
-int VolumetricPumpInstance::DispenseDuration(double durSec) { return GetImpl()->DispenseDuration(durSec); }
-int VolumetricPumpInstance::DispenseVolume(double volUl) { return GetImpl()->DispenseVolume(volUl); }
+int VolumetricPumpInstance::DispenseDurationSeconds(double durSec) { return GetImpl()->DispenseDurationSeconds(durSec); }
+int VolumetricPumpInstance::DispenseVolumeUl(double volUl) { return GetImpl()->DispenseVolumeUl(volUl); }

--- a/MMCore/Devices/VolumetricPumpInstance.h
+++ b/MMCore/Devices/VolumetricPumpInstance.h
@@ -48,6 +48,6 @@ public:
     int SetFlowrateUlPerSec(double flowrate);
     int GetFlowrateUlPerSec(double& flowrate);
     int Start();
-    int DispenseDuration(double durSec);
-    int DispenseVolume(double volUl);
+    int DispenseDurationSeconds(double durSec);
+    int DispenseVolumeUl(double volUl);
 };

--- a/MMCore/Devices/VolumetricPumpInstance.h
+++ b/MMCore/Devices/VolumetricPumpInstance.h
@@ -38,15 +38,15 @@ public:
 
     int Home();
     int Stop();
-    bool requiresHoming();
-    int invertDirection(bool state);
-    int isDirectionInverted(bool& state);
-    int setVolumeUl(double volUl);
-    int getVolumeUl(double& volUl);
-    int setMaxVolumeUl(double volUl);
-    int getMaxVolumeUl(double& volUl);
-    int setFlowrateUlPerSec(double flowrate);
-    int getFlowrateUlPerSec(double& flowrate);
+    bool RequiresHoming();
+    int InvertDirection(bool state);
+    int IsDirectionInverted(bool& state);
+    int SetVolumeUl(double volUl);
+    int GetVolumeUl(double& volUl);
+    int SetMaxVolumeUl(double volUl);
+    int GetMaxVolumeUl(double& volUl);
+    int SetFlowrateUlPerSec(double flowrate);
+    int GetFlowrateUlPerSec(double& flowrate);
     int Start();
     int DispenseDuration(double durSec);
     int DispenseVolume(double volUl);

--- a/MMCore/Devices/VolumetricPumpInstance.h
+++ b/MMCore/Devices/VolumetricPumpInstance.h
@@ -45,8 +45,8 @@ public:
     int GetVolumeUl(double& volUl);
     int SetMaxVolumeUl(double volUl);
     int GetMaxVolumeUl(double& volUl);
-    int SetFlowrateUlPerSec(double flowrate);
-    int GetFlowrateUlPerSec(double& flowrate);
+    int SetFlowrateUlPerSecond(double flowrate);
+    int GetFlowrateUlPerSecond(double& flowrate);
     int Start();
     int DispenseDurationSeconds(double durSec);
     int DispenseVolumeUl(double volUl);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -6704,7 +6704,7 @@ double CMMCore::getPumpPressureKPa(const char* deviceLabel) throw (CMMError)
     mm::DeviceModuleLockGuard guard(pPump);
 
     double pressurekPa = 0;
-    int ret = pPump->GetPressure(pressurekPa);
+    int ret = pPump->GetPressureKPa(pressurekPa);
 
     if (ret != DEVICE_OK)
     {
@@ -6723,7 +6723,7 @@ void CMMCore::setPumpPressureKPa(const char* deviceLabel, double pressurekPa) th
         deviceManager_->GetDeviceOfType<PressurePumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    int ret = pPump->SetPressure(pressurekPa);
+    int ret = pPump->SetPressureKPa(pressurekPa);
 
     if (ret != DEVICE_OK)
     {
@@ -6958,7 +6958,7 @@ void CMMCore::pumpDispenseDurationSeconds(const char* deviceLabel, double second
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    int ret = pPump->DispenseDuration(seconds);
+    int ret = pPump->DispenseDurationSeconds(seconds);
 
     if (ret != DEVICE_OK)
     {
@@ -6976,7 +6976,7 @@ void CMMCore::pumpDispenseVolumeUl(const char* deviceLabel, double microLiter) t
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    int ret = pPump->DispenseVolume(microLiter);
+    int ret = pPump->DispenseVolumeUl(microLiter);
 
     if (ret != DEVICE_OK)
     {

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -6901,7 +6901,7 @@ void CMMCore::setPumpFlowrate(const char* deviceLabel, double UlperSec) throw (C
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    int ret = pPump->SetFlowrateUlPerSec(UlperSec);
+    int ret = pPump->SetFlowrateUlPerSecond(UlperSec);
 
     if (ret != DEVICE_OK)
     {
@@ -6920,7 +6920,7 @@ double CMMCore::getPumpFlowrate(const char* deviceLabel) throw (CMMError)
     mm::DeviceModuleLockGuard guard(pPump);
 
     double UlperSec = 0;
-    int ret = pPump->GetFlowrateUlPerSec(UlperSec);
+    int ret = pPump->GetFlowrateUlPerSecond(UlperSec);
 
     if (ret != DEVICE_OK)
     {

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -6691,7 +6691,7 @@ bool CMMCore::pressurePumpRequiresCalibration(const char* deviceLabel) throw (CM
         deviceManager_->GetDeviceOfType<PressurePumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    return pPump->requiresCalibration();
+    return pPump->RequiresCalibration();
 }
 
 /**
@@ -6704,7 +6704,7 @@ double CMMCore::getPumpPressureKPa(const char* deviceLabel) throw (CMMError)
     mm::DeviceModuleLockGuard guard(pPump);
 
     double pressurekPa = 0;
-    int ret = pPump->getPressure(pressurekPa);
+    int ret = pPump->GetPressure(pressurekPa);
 
     if (ret != DEVICE_OK)
     {
@@ -6723,7 +6723,7 @@ void CMMCore::setPumpPressureKPa(const char* deviceLabel, double pressurekPa) th
         deviceManager_->GetDeviceOfType<PressurePumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    int ret = pPump->setPressure(pressurekPa);
+    int ret = pPump->SetPressure(pressurekPa);
 
     if (ret != DEVICE_OK)
     {
@@ -6774,7 +6774,7 @@ bool CMMCore::volumetricPumpRequiresHoming(const char* deviceLabel) throw (CMMEr
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    return pPump->requiresHoming();
+    return pPump->RequiresHoming();
 }
 
 /**
@@ -6786,7 +6786,7 @@ void CMMCore::invertPumpDirection(const char* deviceLabel, bool invert) throw (C
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    int ret = pPump->invertDirection(invert);
+    int ret = pPump->InvertDirection(invert);
 
     if (ret != DEVICE_OK)
     {
@@ -6805,7 +6805,7 @@ bool CMMCore::isPumpDirectionInverted(const char* deviceLabel) throw (CMMError)
     mm::DeviceModuleLockGuard guard(pPump);
 
     bool invert = false;
-    int ret = pPump->isDirectionInverted(invert);
+    int ret = pPump->IsDirectionInverted(invert);
 
     if (ret != DEVICE_OK)
     {
@@ -6825,7 +6825,7 @@ void CMMCore::setPumpVolume(const char* deviceLabel, double volUl) throw (CMMErr
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    int ret = pPump->setVolumeUl(volUl);
+    int ret = pPump->SetVolumeUl(volUl);
 
     if (ret != DEVICE_OK)
     {
@@ -6844,7 +6844,7 @@ double CMMCore::getPumpVolume(const char* deviceLabel) throw (CMMError)
     mm::DeviceModuleLockGuard guard(pPump);
 
     double volUl = 0;
-    int ret = pPump->getVolumeUl(volUl);
+    int ret = pPump->GetVolumeUl(volUl);
 
     if (ret != DEVICE_OK)
     {
@@ -6863,7 +6863,7 @@ void CMMCore::setPumpMaxVolume(const char* deviceLabel, double volUl) throw (CMM
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    int ret = pPump->setMaxVolumeUl(volUl);
+    int ret = pPump->SetMaxVolumeUl(volUl);
 
     if (ret != DEVICE_OK)
     {
@@ -6882,7 +6882,7 @@ double CMMCore::getPumpMaxVolume(const char* deviceLabel) throw (CMMError)
     mm::DeviceModuleLockGuard guard(pPump);
 
     double volUl = 0;
-    int ret = pPump->getMaxVolumeUl(volUl);
+    int ret = pPump->GetMaxVolumeUl(volUl);
 
     if (ret != DEVICE_OK)
     {
@@ -6901,7 +6901,7 @@ void CMMCore::setPumpFlowrate(const char* deviceLabel, double UlperSec) throw (C
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
     mm::DeviceModuleLockGuard guard(pPump);
 
-    int ret = pPump->setFlowrateUlPerSec(UlperSec);
+    int ret = pPump->SetFlowrateUlPerSec(UlperSec);
 
     if (ret != DEVICE_OK)
     {
@@ -6920,7 +6920,7 @@ double CMMCore::getPumpFlowrate(const char* deviceLabel) throw (CMMError)
     mm::DeviceModuleLockGuard guard(pPump);
 
     double UlperSec = 0;
-    int ret = pPump->getFlowrateUlPerSec(UlperSec);
+    int ret = pPump->GetFlowrateUlPerSec(UlperSec);
 
     if (ret != DEVICE_OK)
     {

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -2536,12 +2536,12 @@ class CVolumetricPumpBase : public CDeviceBase<MM::VolumetricPump, U>
         return DEVICE_UNSUPPORTED_COMMAND;
     }
 
-    int DispenseDuration(double /*durSec*/)
+    int DispenseDurationSeconds(double /*durSec*/)
     {
         return DEVICE_UNSUPPORTED_COMMAND;
     }
 
-    int DispenseVolume(double /*volUl*/)
+    int DispenseVolumeUl(double /*volUl*/)
     {
         return DEVICE_UNSUPPORTED_COMMAND;
     }
@@ -2558,12 +2558,12 @@ class CPressurePumpBase : public CDeviceBase<MM::PressurePump, U>
         return DEVICE_UNSUPPORTED_COMMAND;
     }
 
-    int SetPressure(double /*pressure*/)
+    int SetPressureKPa(double /*pressureKPa*/)
     {
         return DEVICE_UNSUPPORTED_COMMAND;
     }
 
-    int GetPressure(double& /*pressure*/)
+    int GetPressureKPa(double& /*pressureKPa*/)
     {
         return DEVICE_UNSUPPORTED_COMMAND;
     }

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -28,7 +28,7 @@
 // Header version
 // If any of the class definitions changes, the interface version
 // must be incremented
-#define DEVICE_INTERFACE_VERSION 72
+#define DEVICE_INTERFACE_VERSION 73
 ///////////////////////////////////////////////////////////////////////////////
 
 // N.B.
@@ -1337,7 +1337,7 @@ namespace MM {
         *
         * Optional function of MMPump API (only required for pressure controllers)
         */
-       virtual int SetPressure(double pressure) = 0;
+       virtual int SetPressureKPa(double pressureKPa) = 0;
 
        /**
         * Gets the pressure of the pressure controller. The returned value
@@ -1346,7 +1346,7 @@ namespace MM {
         *
         * Optional function of MMPump API (only required for pressure controllers)
         */
-       virtual int GetPressure(double& pressure) = 0;
+       virtual int GetPressureKPa(double& pressureKPa) = 0;
    };
 
    /**
@@ -1476,7 +1476,7 @@ namespace MM {
         *
         * Optional function of MMPump API (only required for volumetric pumps)
         */
-       virtual int DispenseDuration(double durSec) = 0;
+       virtual int DispenseDurationSeconds(double durSec) = 0;
 
        /**
         * Dispenses/withdraws the provided volume.
@@ -1493,7 +1493,7 @@ namespace MM {
         *
         * Optional function of MMPump API (only required for volumetric pumps)
         */
-       virtual int DispenseVolume(double volUl) = 0;
+       virtual int DispenseVolumeUl(double volUl) = 0;
    };
 
 

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1293,8 +1293,8 @@ namespace MM {
    };
 
    /**
-   * Pressure Pump API
-   */
+    * Pressure Pump API
+    */
    class PressurePump : public Device
    {
    public:
@@ -1306,52 +1306,52 @@ namespace MM {
        static const DeviceType Type;
 
        /**
-* Stops the pump. The implementation should halt any dispensing/withdrawal,
-* and make the pump available again (make Busy() return false).
-*
-* Required by MMPump API
-*/
+        * Stops the pump. The implementation should halt any dispensing/withdrawal,
+        * and make the pump available again (make Busy() return false).
+        *
+        * Required by MMPump API
+        */
        virtual int Stop() = 0;
 
        /**
-       * Calibrates the pressure controller. If no internal calibration is
-       * supported, just return DEVICE_OK.
-       *
-       * Optional function of MMPump API (only required for pressure controllers)
-       */
+        * Calibrates the pressure controller. If no internal calibration is
+        * supported, just return DEVICE_OK.
+        *
+        * Optional function of MMPump API (only required for pressure controllers)
+        */
        virtual int Calibrate() = 0;
 
        /**
-       * Returns whether the pressure controller is functional before calibration,
-       * or it needs to undergo internal calibration before any commands can be
-       * executed.
-       *
-       * Required by MMPump API.
-       */
+        * Returns whether the pressure controller is functional before calibration,
+        * or it needs to undergo internal calibration before any commands can be
+        * executed.
+        *
+        * Required by MMPump API.
+        */
        virtual bool RequiresCalibration() = 0;
 
        /**
-       * Sets the pressure of the pressure controller. The provided value will
-       * be in kPa. The implementation should convert the unit from kPa to the
-       * desired unit by the device.
-       *
-       * Optional function of MMPump API (only required for pressure controllers)
-       */
+        * Sets the pressure of the pressure controller. The provided value will
+        * be in kPa. The implementation should convert the unit from kPa to the
+        * desired unit by the device.
+        *
+        * Optional function of MMPump API (only required for pressure controllers)
+        */
        virtual int SetPressure(double pressure) = 0;
 
        /**
-       * Gets the pressure of the pressure controller. The returned value
-       * has to be in kPa. The implementation, therefore, should convert the
-       * value provided by the pressure controller to kPa.
-       *
-       * Optional function of MMPump API (only required for pressure controllers)
-       */
+        * Gets the pressure of the pressure controller. The returned value
+        * has to be in kPa. The implementation, therefore, should convert the
+        * value provided by the pressure controller to kPa.
+        *
+        * Optional function of MMPump API (only required for pressure controllers)
+        */
        virtual int GetPressure(double& pressure) = 0;
    };
 
    /**
-   * Volumetric Pump API
-   */
+    * Volumetric Pump API
+    */
    class VolumetricPump : public Device
    {
    public:
@@ -1363,71 +1363,71 @@ namespace MM {
        static const DeviceType Type;
 
        /**
-       * Homes the pump. If no homing is supported, just return DEVICE_OK
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Homes the pump. If no homing is supported, just return DEVICE_OK
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual int Home() = 0;
 
        /**
-       * Stops the pump. The implementation should halt any dispensing/withdrawal,
-       * and make the pump available again (make Busy() return false).
-       *
-       * Required by MMPump API
-       */
+        * Stops the pump. The implementation should halt any dispensing/withdrawal,
+        * and make the pump available again (make Busy() return false).
+        *
+        * Required by MMPump API
+        */
        virtual int Stop() = 0;
 
        /**
-       * Flag to check whether the pump requires homing before being operational
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Flag to check whether the pump requires homing before being operational
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual bool RequiresHoming() = 0;
 
        /**
-       * Sets the direction of the pump. Certain pump
-       * (e.g. peristaltic and DC pumps) don't have an apriori forward-reverse direction,
-       * as it depends on how it is connected. This function allows you to switch
-       * forward and reverse.
-       *
-       * The implementation of this function should allow two values, 1 and -1,
-       * and should ignore all other values, where 1 indicates that the direction
-       * is left as-is, and -1 indicates that the direction should be reversed. If
-       * the pump is uni-directional, this function does not need to be
-       * implemented.
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
+        * Sets the direction of the pump. Certain pump
+        * (e.g. peristaltic and DC pumps) don't have an apriori forward-reverse direction,
+        * as it depends on how it is connected. This function allows you to switch
+        * forward and reverse.
+        *
+        * The implementation of this function should allow two values, 1 and -1,
+        * and should ignore all other values, where 1 indicates that the direction
+        * is left as-is, and -1 indicates that the direction should be reversed. If
+        * the pump is uni-directional, this function does not need to be
+        * implemented.
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
        */
        virtual int InvertDirection(bool inverted) = 0;
 
        /**
-       * Sets the direction of the pump. Certain pump
-       * (e.g. peristaltic and DC pumps) don't have an apriori forward-reverse direction,
-       * as it depends on how it is connected. This function allows you to switch
-       * forward and reverse.
-       *
-       * The implementation of this function should allow two values, [1] and [-1],
-       * and should ignore all other values, where [1] indicates that the direction
-       * is left as-is, and [-1] indicates that the direction should be reversed.
-       * When the pump is uni-directional, the function should always assign [1] to
-       * [direction]
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
+        * Sets the direction of the pump. Certain pump
+        * (e.g. peristaltic and DC pumps) don't have an apriori forward-reverse direction,
+        * as it depends on how it is connected. This function allows you to switch
+        * forward and reverse.
+        *
+        * The implementation of this function should allow two values, [1] and [-1],
+        * and should ignore all other values, where [1] indicates that the direction
+        * is left as-is, and [-1] indicates that the direction should be reversed.
+        * When the pump is uni-directional, the function should always assign [1] to
+        * [direction]
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
        */
        virtual int IsDirectionInverted(bool& inverted) = 0;
 
        /**
-       * Sets the current volume of the pump in microliters (uL).
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Sets the current volume of the pump in microliters (uL).
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual int SetVolumeUl(double volUl) = 0;
 
        /**
-       * Gets the current volume of the pump in microliters (uL).
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Gets the current volume of the pump in microliters (uL).
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual int GetVolumeUl(double& volUl) = 0;
 
        /**
@@ -1438,61 +1438,61 @@ namespace MM {
        virtual int SetMaxVolumeUl(double volUl) = 0;
 
        /**
-       * Gets the maximum volume of the pump in microliters (uL).
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Gets the maximum volume of the pump in microliters (uL).
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual int GetMaxVolumeUl(double& volUl) = 0;
 
        /**
-       * Sets the flowrate in microliter (uL) per second. The implementation
-       * should convert the provided flowrate to whichever unit the pump desires
-       * (steps/s, mL/h, V).
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Sets the flowrate in microliter (uL) per second. The implementation
+        * should convert the provided flowrate to whichever unit the pump desires
+        * (steps/s, mL/h, V).
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual int SetFlowrateUlPerSecond(double flowrate) = 0;
 
        /**
-       * Gets the flowrate in microliter (uL) per second.
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Gets the flowrate in microliter (uL) per second.
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual int GetFlowrateUlPerSecond(double& flowrate) = 0;
 
        /**
-       * Dispenses/withdraws until the minimum or maximum volume has been
-       * reached, or the pumping is manually stopped
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Dispenses/withdraws until the minimum or maximum volume has been
+        * reached, or the pumping is manually stopped
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual int Start() = 0;
 
        /**
-       * Dispenses/withdraws for the provided time, with the flowrate provided
-       * by GetFlowrate_uLperMin
-       * Dispensing for an undetermined amount of time can be done with DBL_MAX
-       * During the dispensing/withdrawal, Busy() should return "true".
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Dispenses/withdraws for the provided time, with the flowrate provided
+        * by GetFlowrate_uLperMin
+        * Dispensing for an undetermined amount of time can be done with DBL_MAX
+        * During the dispensing/withdrawal, Busy() should return "true".
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual int DispenseDuration(double durSec) = 0;
 
        /**
-       * Dispenses/withdraws the provided volume.
-       *
-       * The implementation should cause positive volumes to be dispensed, whereas
-       * negative volumes should be withdrawn. The implementation should prevent
-       * the volume to go negative (i.e. stop the pump once the syringe is empty),
-       * or to go over the maximum volume (i.e. stop the pump once it is full).
-       * This automatically allows for dispensing/withdrawal for an undetermined
-       * amount of time by providing DBL_MAX for dispense, and DBL_MIN for
-       * withdraw.
-       *
-       * During the dispensing/withdrawal, Busy() should return "true".
-       *
-       * Optional function of MMPump API (only required for volumetric pumps)
-       */
+        * Dispenses/withdraws the provided volume.
+        *
+        * The implementation should cause positive volumes to be dispensed, whereas
+        * negative volumes should be withdrawn. The implementation should prevent
+        * the volume to go negative (i.e. stop the pump once the syringe is empty),
+        * or to go over the maximum volume (i.e. stop the pump once it is full).
+        * This automatically allows for dispensing/withdrawal for an undetermined
+        * amount of time by providing DBL_MAX for dispense, and DBL_MIN for
+        * withdraw.
+        *
+        * During the dispensing/withdrawal, Busy() should return "true".
+        *
+        * Optional function of MMPump API (only required for volumetric pumps)
+        */
        virtual int DispenseVolume(double volUl) = 0;
    };
 


### PR DESCRIPTION
This is a followup to #462.

The device interface version is further bumped 72 -> 73 because the device member functions are renamed to consistently include the units.

Cc: @Lars-Kool.