### PR TITLE
PlayerOne: Avoid cpu cycling during exposure time

### DIFF
--- a/DeviceAdapters/PlayerOne/POACamera.cpp
+++ b/DeviceAdapters/PlayerOne/POACamera.cpp
@@ -815,6 +815,11 @@ int POACamera::SnapImage()
     }
 
     m_bIsToStopExposure = false;
+
+    if (exp > 20.0)
+    {
+       CDeviceUtils::SleepMs((long) (exp - 10.0));
+    }
     
     do
     {

--- a/DeviceAdapters/PlayerOne/PlayerOne.vcxproj
+++ b/DeviceAdapters/PlayerOne/PlayerOne.vcxproj
@@ -77,7 +77,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)\PlayerOne\FilterWheelSDK\lib\Win\x64;$(MM_3RDPARTYPRIVATE)\PlayerOne\CameraSDK\lib\Win\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)\PlayerOne\FilterWheelSDK\lib\Win\x64;$(MM_3RDPARTYPUBLIC)\PlayerOne\CameraSDK\lib\Win\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>PlayerOneCamera.lib;PlayerOnePW.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Also fixes linking in debug mode.