### PR TITLE
Upgrade micromanager.sln to VS2022

### DIFF
--- a/micromanager.sln
+++ b/micromanager.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32802.440
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35919.96 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MMCore", "MMCore\MMCore.vcxproj", "{36571628-728C-4ACD-A47F-503BA91C5D43}"
 EndProject


### PR DESCRIPTION
This does not touch the projects (still VS2019) but just updates the header in micromanager.sln.

Since most people are probably now using VS2022, this will avoid having to manually exclude changes when e.g. adding a project.

I don't think this prevents the solution from opening in VS2019 (not sure, but we probably don't care).