### PR TITLE
Cephla: Adds  pre-init settings to XY and Z stages.

### DIFF
--- a/DeviceAdapters/Cephla/Squid.h
+++ b/DeviceAdapters/Cephla/Squid.h
@@ -268,6 +268,8 @@ private:
    double fullStepsPerRevY_;
    int microSteppingDefaultX_;  // needs to be set as pre-init tied to model
    int microSteppingDefaultY_;  // needs to be set as pre-init tied to model
+   int directionX_; // either 1 or -1
+   int directionY_;
    double posX_um_;
    double posY_um_;
    bool busy_;

--- a/DeviceAdapters/Cephla/Squid.h
+++ b/DeviceAdapters/Cephla/Squid.h
@@ -81,6 +81,8 @@ extern const char* g_Yes;
 extern const char* g_No;
 extern const char* g_Acceleration;
 extern const char* g_Max_Velocity;
+extern const char* g_Positive;
+extern const char* g_Negative;
 
 class SquidMonitoringThread;
 class SquidXYStage;
@@ -329,7 +331,7 @@ private:
    SquidHub* hub_;
    double stepSize_um_;
    double screwPitchZmm_;
-   double microSteppingDefaultZ_; 
+   int microSteppingDefaultZ_; 
    double fullStepsPerRevZ_;
    double maxVelocity_;
    double acceleration_;

--- a/DeviceAdapters/Cephla/SquidZStage.cpp
+++ b/DeviceAdapters/Cephla/SquidZStage.cpp
@@ -2,7 +2,10 @@
 
 
 const char* g_ZStageName = "ZStage";
-
+const char* g_Full_Steps_Per_Rev_Z = "FullStepsPerRevZ";
+const char* g_Screw_Pitch_Mm_Z = "ScrewPitchZmm";
+const char* g_Micro_Stepping_Default_Z = "MicroSteppingDefaultZ";
+const char* g_Direction_Z = "DirectionZ";
 
 
 SquidZStage::SquidZStage() :
@@ -16,6 +19,12 @@ SquidZStage::SquidZStage() :
    initialized_(false),
    cmdNr_(0)
 {
+   CreateFloatProperty(g_Full_Steps_Per_Rev_Z, fullStepsPerRevZ_, false, 0, true);
+   CreateFloatProperty(g_Screw_Pitch_Mm_Z, screwPitchZmm_, false, 0, true);
+   CreateIntegerProperty(g_Micro_Stepping_Default_Z, microSteppingDefaultZ_, false, 0, true);
+   CreateStringProperty(g_Direction_Z, g_Negative, false, 0, true);
+   AddAllowedValue(g_Direction_Z, g_Positive);
+   AddAllowedValue(g_Direction_Z, g_Negative);
 }
 
 
@@ -41,7 +50,17 @@ void SquidZStage::GetName(char* pszName) const
 
 int SquidZStage::Initialize()
 {
-   stepSize_um_ = -1000.0 * screwPitchZmm_ / (microSteppingDefaultZ_ * fullStepsPerRevZ_); 
+
+   GetProperty(g_Full_Steps_Per_Rev_Z, fullStepsPerRevZ_);
+   GetProperty(g_Screw_Pitch_Mm_Z, screwPitchZmm_);
+   long tmp;
+   GetProperty(g_Micro_Stepping_Default_Z, tmp);
+   microSteppingDefaultZ_ = (int) tmp;
+   char dirZ[MM::MaxStrLength];
+   GetProperty(g_Direction_Z, dirZ);
+   int directionZ = strcmp(dirZ, g_Positive) == 0 ? 1 : -1;
+
+   stepSize_um_ = directionZ * 1000.0 * screwPitchZmm_ / (microSteppingDefaultZ_ * fullStepsPerRevZ_); 
 
    hub_ = static_cast<SquidHub*>(GetParentHub());
    if (!hub_ || !hub_->IsPortAvailable()) {


### PR DESCRIPTION
Should enable using the device adapter with older Cephla stages that use non-standard drive.