### PR TITLE
feat: allow demo xy stage to respond to Stop()

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -3776,20 +3776,15 @@ void CDemoXYStage::CommitCurrentIntermediatePosition_(const MM::MMTime& now)
    {
       // freeze where we *are* now
       ComputeIntermediatePosition(now, posX_um_, posY_um_);
+      (void)OnXYStagePositionChanged(posX_um_, posY_um_);
    }
-   // No active motion → posX/Y already hold the last settled values
-
    // Drop the timer so Busy() instantly goes idle
    delete timeOutTimer_;
    timeOutTimer_ = nullptr;
-
-   // Core listeners expect a position‑changed notification
-   (void)OnXYStagePositionChanged(posX_um_, posY_um_);
 }
 
 int CDemoXYStage::Stop()
 {
-   MMThreadGuard g(this->stopLock_);
    MM::MMTime now = GetCurrentMMTime();
    CommitCurrentIntermediatePosition_(now);
    return DEVICE_OK;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -597,7 +597,6 @@ private:
    bool initialized_;
    double lowerLimit_;
    double upperLimit_;
-   MMThreadLock stopLock_;
 
    void CommitCurrentIntermediatePosition_(const MM::MMTime& now);
    void ComputeIntermediatePosition(const MM::MMTime& currentTime,

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -592,13 +592,14 @@ private:
    double targetPosX_um_, targetPosY_um_;
    MM::MMTime moveStartTime_;     // from GetCurrentMMTime()
    long moveDuration_ms_;         // duration of current move in milliseconds
-   bool busy_;
    MM::TimeoutMs* timeOutTimer_;
    double velocity_;
    bool initialized_;
    double lowerLimit_;
    double upperLimit_;
+   MMThreadLock stopLock_;
 
+   void CommitCurrentIntermediatePosition_(const MM::MMTime& now);
    void ComputeIntermediatePosition(const MM::MMTime& currentTime,
       double& currentPosX,
       double& currentPosY);


### PR DESCRIPTION
currently, stopping the XY demo stage doesn't stop it's virtual motion.

