### PR TITLE
Always emit `onSystemConfigurationLoaded` when system configuration changed

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -112,7 +112,7 @@
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 11, MMCore_versionMinor = 5, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 11, MMCore_versionMinor = 5, MMCore_versionPatch = 1;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -7345,9 +7345,20 @@ void CMMCore::loadSystemConfiguration(const char* fileName) throw (CMMError)
             err.getFullMsg();
       }
 
+      if (externalCallback_)
+      {
+         // The config has "changed" even in this case.
+         externalCallback_->onSystemConfigurationLoaded();
+      }
+
       LOG_INFO(coreLogger_) <<
          "Now rethrowing original error from system configuration loading";
       throw;
+   }
+
+   if (externalCallback_)
+   {
+      externalCallback_->onSystemConfigurationLoaded();
    }
 }
 
@@ -7584,8 +7595,6 @@ void CMMCore::loadSystemConfigurationImpl(const char* fileName) throw (CMMError)
          }
          catch (CMMError& err)
          {
-            if (externalCallback_)
-               externalCallback_->onSystemConfigurationLoaded();
             std::ostringstream errorText;
             errorText << "Line " << lineCount << ": " << line << '\n';
             errorText << err.getFullMsg() << "\n\n";
@@ -7609,11 +7618,6 @@ void CMMCore::loadSystemConfigurationImpl(const char* fileName) throw (CMMError)
 
    waitForSystem();
    updateSystemStateCache();
-
-   if (externalCallback_)
-   {
-      externalCallback_->onSystemConfigurationLoaded();
-   }
 }
 
 

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -719,6 +719,10 @@ private:
    MMThreadLock* pPostedErrorsLock_;
    mutable std::deque<std::pair< int, std::string> > postedErrors_;
 
+   // True while interpreting the config file (but not while rolling back on
+   // failure):
+   bool isLoadingSystemConfiguration_ = false;
+
 private:
    void InitializeErrorMessages();
    void CreateCoreProperties();

--- a/MMCore/MMEventCallback.h
+++ b/MMCore/MMEventCallback.h
@@ -50,9 +50,15 @@ public:
       std::cout << "onConfigGroupChanged() " << groupName << " " << newConfigName << '\n';
    }
 
+   /**
+    * \brief Called when the system configuration has changed.
+    * 
+    * "Changed" includes when a configuration was unloaded, for example because
+    * loading a new config file failed.
+    */
    virtual void onSystemConfigurationLoaded()
    {
-      std::cout << "onSystemConfigurationLoaded() \n";
+      std::cout << "onSystemConfigurationLoaded()\n";
    }
 
    virtual void onPixelSizeChanged(double newPixelSizeUm)


### PR DESCRIPTION
Closes #594.

I haven't tested this yet.