### PR TITLE
MMCore: Better error message on bad device version

### DIFF
--- a/MMCore/LoadableModules/LoadedDeviceAdapter.cpp
+++ b/MMCore/LoadableModules/LoadedDeviceAdapter.cpp
@@ -223,14 +223,14 @@ LoadedDeviceAdapter::CheckInterfaceVersion() const
    }
 
    if (moduleInterfaceVersion != MODULE_INTERFACE_VERSION)
-      throw CMMError("Incompatible module interface version (required = " +
+      throw CMMError("Incompatible module interface version (MMCore requires " +
             ToString(MODULE_INTERFACE_VERSION) +
-            "; found = " + ToString(moduleInterfaceVersion) + ")");
+            "; device adapter has " + ToString(moduleInterfaceVersion) + ")");
 
    if (deviceInterfaceVersion != DEVICE_INTERFACE_VERSION)
-      throw CMMError("Incompatible device interface version (required = " +
+      throw CMMError("Incompatible device interface version (MMCore requires " +
             ToString(DEVICE_INTERFACE_VERSION) +
-            "; found = " + ToString(deviceInterfaceVersion) + ")");
+            "; device adapter has " + ToString(deviceInterfaceVersion) + ")");
 }
 
 


### PR DESCRIPTION
@gselzer pointed out that the error message could be misinterpreted, depending on perspective, so make it clear.