### PR TITLE
MMCore: Keep channel group choices up to date

### DIFF
--- a/MMCore/ConfigGroup.h
+++ b/MMCore/ConfigGroup.h
@@ -217,11 +217,7 @@ public:
     */
    bool isDefined(const char* groupName)
    {
-      std::map<std::string, ConfigGroup>::iterator it = groups_.find(groupName);
-      if (it == groups_.end())
-         return false;
-      else
-         return true;
+      return groups_.find(groupName) != groups_.end();
    }
 
    /**
@@ -238,16 +234,7 @@ public:
          std::map<std::string, ConfigGroup>::iterator it = groups_.find(groupName);
          if (it == groups_.end())
             return false; // group not found
-         if (it->second.Rename(oldConfigName, newConfigName))
-         {
-            // NOTE: changed to not remove empty groups, N.A. 1.31.2006
-            // check if the config group is empty, and if so remove it
-            //if (it->second.IsEmpty())
-            //groups_.erase(it->first);
-            return true;
-         }
-         else
-            return false; // config not found within a group
+         return it->second.Rename(oldConfigName, newConfigName);
       } else {
          return true;
       }
@@ -265,12 +252,7 @@ public:
       std::map<std::string, ConfigGroup>::iterator it = groups_.find(groupName);
       if (it == groups_.end())
          return false; // group not found
-      if (it->second.Delete(configName, deviceLabel, propName))
-      {
-         return true;
-      }
-      else
-         return false; // config not found within a group
+      return it->second.Delete(configName, deviceLabel, propName);
    }
 
 
@@ -286,16 +268,7 @@ public:
       std::map<std::string, ConfigGroup>::iterator it = groups_.find(groupName);
       if (it == groups_.end())
          return false; // group not found
-      if (it->second.Delete(configName))
-      {
-         // NOTE: changed to not remove empty groups, N.A. 1.31.2006
-         // check if the config group is empty, and if so remove it
-         //if (it->second.IsEmpty())
-            //groups_.erase(it->first);
-         return true;
-      }
-      else
-         return false; // config not found within a group
+      return it->second.Delete(configName);
    }
 
    /**

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -787,9 +787,7 @@ void CMMCore::unloadAllDevices() throw (CMMError)
 {
    try {
       configGroups_->Clear();
-
-      //selected channel group is no longer valid
-      //channelGroup_ = "":
+      updateAllowedChannelGroups();
 
       // clear pixel size configurations
       if (!pixelSizeGroup_->IsEmpty())
@@ -4944,9 +4942,6 @@ void CMMCore::deleteConfigGroup(const char* groupName) throw (CMMError)
       throw CMMError(ToQuotedString(groupName) + ": " + getCoreErrorText(MMERR_NoConfigGroup),
             MMERR_NoConfigGroup);
 
-   if (0 == channelGroup_.compare(groupName))
-      setChannelGroup("");
-
    updateAllowedChannelGroups();
 
    LOG_DEBUG(coreLogger_) << "Deleted config group " << groupName;
@@ -4985,7 +4980,14 @@ void CMMCore::defineConfig(const char* groupName, const char* configName) throw 
    CheckConfigGroupName(groupName);
    CheckConfigPresetName(configName);
 
+   bool groupExisted = configGroups_->isDefined(groupName);
+
    configGroups_->Define(groupName, configName);
+
+   if (!groupExisted)
+   {
+      updateAllowedChannelGroups();
+   }
 
    LOG_DEBUG(coreLogger_) << "Config group " << groupName <<
       ": added preset " << configName;
@@ -5012,7 +5014,14 @@ void CMMCore::defineConfig(const char* groupName, const char* configName, const 
    CheckPropertyName(propName);
    CheckPropertyValue(value);
 
+   bool groupExisted = configGroups_->isDefined(groupName);
+
    configGroups_->Define(groupName, configName, deviceLabel, propName, value);
+
+   if (!groupExisted)
+   {
+      updateAllowedChannelGroups();
+   }
 
    LOG_DEBUG(coreLogger_) << "Config group " << groupName <<
       ": preset " << configName << ": added setting " <<
@@ -7106,7 +7115,6 @@ void CMMCore::loadSystemState(const char* fileName) throw (CMMError)
          }
       }
    }
-   updateAllowedChannelGroups();
 }
 
 
@@ -7616,8 +7624,6 @@ void CMMCore::loadSystemConfigurationImpl(const char* fileName) throw (CMMError)
          }
       }
    }
-
-   updateAllowedChannelGroups();
 
    // file parsing finished, try to set startup configuration
    if (isConfigDefined(MM::g_CFGGroup_System, MM::g_CFGGroup_System_Startup))


### PR DESCRIPTION
They were not correctly updated when

- A config group is created via `defineConfig()` without a call to `defineConfigGroup()`
- All config groups are removed by `unloadAllDevices()`

Also cleaned up some related code.

Closes #631.