### PR TITLE
ASIStage: support 19200 baud rate in ASIDetectDevice()

### DIFF
--- a/DeviceAdapters/ASIStage/ASIBase.cpp
+++ b/DeviceAdapters/ASIStage/ASIBase.cpp
@@ -96,7 +96,7 @@ int ASIBase::QueryCommandACK(const char* command) const
 		return ret;
 	}
 	// the controller only acknowledges receipt of the command
-	if (answer.substr(0, 2) != ":A")
+	if (answer.compare(0, 2, ":A") != 0)
 	{
 		return ERR_UNRECOGNIZED_ANSWER;
 	}
@@ -151,7 +151,7 @@ VersionData ASIBase::ParseVersionString(const std::string& version) const
 	return VersionData(major, minor, revision);
 }
 
-int ASIBase::GetVersion(std::string& version)
+int ASIBase::GetVersion(std::string& version) const
 {
    std::string answer;
    int ret = QueryCommand("V", answer);
@@ -159,7 +159,7 @@ int ASIBase::GetVersion(std::string& version)
    {
       return ret;
    }
-   if (answer.substr(0, 2).compare(":A") == 0)
+   if (answer.compare(0, 2, ":A") == 0)
    {
 		version = answer.substr(3);
 		return DEVICE_OK;
@@ -177,7 +177,7 @@ int ASIBase::OnVersion(MM::PropertyBase* pProp, MM::ActionType eAct)
 	return DEVICE_OK;
 }
 
-int ASIBase::GetBuildName(std::string& buildName)
+int ASIBase::GetBuildName(std::string& buildName) const
 {
 	std::string answer;
 	int ret = QueryCommand("BU", answer);
@@ -199,7 +199,7 @@ int ASIBase::OnBuildName(MM::PropertyBase* pProp, MM::ActionType eAct)
 	return DEVICE_OK;
 }
 
-int ASIBase::GetCompileDate(std::string& buildName)
+int ASIBase::GetCompileDate(std::string& buildName) const
 {
 	std::string answer;
 	int ret = QueryCommand("CD", answer);
@@ -264,11 +264,11 @@ int ASIBase::ResponseStartsWithColonA(const std::string& answer) const
 	{
 		return ERR_UNRECOGNIZED_ANSWER;
 	}
-	if (answer.substr(0, 2).compare(":A") == 0)
+	if (answer.compare(0, 2, ":A") == 0)
 	{
 		return DEVICE_OK;
 	}
-	else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+	else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 	{
 		const int errorNumber = atoi(answer.substr(3).c_str());
 		return ERR_OFFSET + errorNumber;

--- a/DeviceAdapters/ASIStage/ASIBase.h
+++ b/DeviceAdapters/ASIStage/ASIBase.h
@@ -77,9 +77,9 @@ protected:
 	int OnVersion(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnBuildName(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnCompileDate(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int GetVersion(std::string& version);
-	int GetBuildName(std::string& buildName);
-	int GetCompileDate(std::string& compileDate);
+	int GetVersion(std::string& version) const;
+	int GetBuildName(std::string& buildName) const;
+	int GetCompileDate(std::string& compileDate) const;
 
 	bool oldstage_;
 	bool initialized_;

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -584,7 +584,7 @@ int CRISP::GetValue(const std::string& cmd, float& val)
 		return ret;
 	}
 
-	if (answer.length() > 2 && answer.substr(0, 2).compare(":N") == 0)
+	if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 	{
 		int errNo = atoi(answer.substr(2).c_str());
 		return ERR_OFFSET + errNo;
@@ -618,14 +618,14 @@ int CRISP::SetCommand(const std::string& cmd)
 	{
 		return ret;
 	}
-	if (answer.length() > 2 && answer.substr(0, 2).compare(":N") == 0)
+	if (answer.compare(0, 2, ":A") == 0)
+	{
+		return DEVICE_OK;
+	}
+	if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 	{
 		int errNo = atoi(answer.substr(2).c_str());
 		return ERR_OFFSET + errNo;
-	}
-	if (answer.substr(0, 2) == ":A")
-	{
-		return DEVICE_OK;
 	}
 	return ERR_UNRECOGNIZED_ANSWER;
 }

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -18,6 +18,7 @@ CRISP::CRISP() :
 	ledIntensity_(0),
 	numAverages_(0),
 	numSkips_(0),
+	calibrationRange_(0),
 	inFocusRange_(0),
 	lockRange_(0),
 	objectiveNA_(0)
@@ -66,7 +67,7 @@ bool CRISP::SupportsDeviceDetection()
 
 MM::DeviceDetectionStatus CRISP::DetectDevice()
 {
-	return ASICheckSerialPort(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
+	return ASIDetectDevice(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
 }
 
 int CRISP::Initialize()

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -268,15 +268,16 @@ int CRISP::Initialize()
 		CreateProperty(g_CRISPSumPropertyName, "", MM::Integer, true, pAct);
 	}
 
-	// LK M requires 9.2n firmware
+	// LK M requires firmware version 9.2n or higher.
+	// Enable these properties as a group to modify calibration settings.
 	if (versionData_.IsVersionAtLeast(9, 2, 'n'))
 	{
 		pAct = new CPropertyAction(this, &CRISP::OnSetLogAmpAGC);
 		CreateProperty("Set LogAmpAGC (Advanced Users Only)", "0", MM::Integer, false, pAct);
-	}
 
-	pAct = new CPropertyAction(this, &CRISP::OnSetLockOffset);
-	CreateProperty("Set Lock Offset (Advanced Users Only)", "0", MM::Integer, false, pAct);
+		pAct = new CPropertyAction(this, &CRISP::OnSetLockOffset);
+		CreateProperty("Set Lock Offset (Advanced Users Only)", "0", MM::Integer, false, pAct);
+	}
 
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/ASIStage/ASILED.cpp
+++ b/DeviceAdapters/ASIStage/ASILED.cpp
@@ -234,7 +234,7 @@ int LED::SetOpen(bool open)
 		return DEVICE_OK;
 	}
 	// deal with error later
-	else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+	else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 	{
 		int errNo = atoi(answer.substr(4).c_str());
 		return ERR_OFFSET + errNo;
@@ -277,7 +277,7 @@ int LED::IsOpen(bool* open)
 				*open = false;
 			}
 		}
-		else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+		else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 		{
 			int errNo = atoi(answer.substr(4).c_str());
 			return ERR_OFFSET + errNo;
@@ -401,7 +401,7 @@ int LED::OnIntensity(MM::PropertyBase* pProp, MM::ActionType eAct)
 			std::istringstream is(answer);
 			std::string tok;
 			is >> tok;
-			if (tok.substr(0, 2).compare(":N") == 0 && tok.length() > 2)
+			if (tok.compare(0, 2, ":N") == 0 && tok.length() > 2)
 			{
 				int errNo = atoi(tok.substr(4).c_str());
 				return ERR_OFFSET + errNo;

--- a/DeviceAdapters/ASIStage/ASILED.cpp
+++ b/DeviceAdapters/ASIStage/ASILED.cpp
@@ -301,7 +301,7 @@ int LED::IsOpen(bool* open)
 			if (answer.substr(2, 1) == "0")
 				*open = false;
 		}
-		else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+		else if (answer.compare(0, 2, ":N") == 0 && answer.length() > 2)
 		{
 			int errNo = atoi(answer.substr(4).c_str());
 			return ERR_OFFSET + errNo;
@@ -357,7 +357,7 @@ int LED::CurrentIntensity(long* intensity)
 	{
 		*intensity = atoi(tok.substr(2).c_str());
 	}
-	else if (tok.substr(0, 2).compare(":N") == 0 && tok.length() > 2)
+	else if (tok.length() > 2 && tok.compare(0, 2, ":N") == 0)
 	{
 		int errNo = atoi(tok.substr(4).c_str());
 		return ERR_OFFSET + errNo;
@@ -370,9 +370,7 @@ int LED::Fire(double)
 	return DEVICE_OK;
 }
 
-/////////////////////////////////////////////////////////////////////////////////
-//// Action handlers
-/////////////////////////////////////////////////////////////////////////////////
+// Action handlers
 
 int LED::OnIntensity(MM::PropertyBase* pProp, MM::ActionType eAct)
 {

--- a/DeviceAdapters/ASIStage/ASILED.cpp
+++ b/DeviceAdapters/ASIStage/ASILED.cpp
@@ -228,7 +228,7 @@ int LED::SetOpen(bool open)
 		return ret;
 	}
 
-	if ((answer.substr(0, 2).compare(":A") == 0) || (answer.substr(1, 2).compare(":A") == 0))
+	if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
 	{
 		open_ = open;
 		return DEVICE_OK;
@@ -270,9 +270,9 @@ int LED::IsOpen(bool* open)
 			return ret;
 		}
 
-		if ((answer.substr(0, 2).compare(":A") == 0) || (answer.substr(1, 2).compare(":A") == 0))
+		if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
 		{
-			if (answer.substr(2, 1) == "0")
+			if (answer.compare(2, 1, "0") == 0)
 			{
 				*open = false;
 			}
@@ -297,8 +297,8 @@ int LED::IsOpen(bool* open)
 			return ret;
 
 		// Command "LED X?" return "X=0 :A"
-		if (answer.substr(0, 1)[0]==channelAxisChar_) {
-			if (answer.substr(2, 1) == "0")
+		if (answer[0]==channelAxisChar_) {
+			if (answer.compare(2, 1, "0") == 0)
 				*open = false;
 		}
 		else if (answer.compare(0, 2, ":N") == 0 && answer.length() > 2)
@@ -353,7 +353,7 @@ int LED::CurrentIntensity(long* intensity)
 	std::string tok2;
 	is >> tok;
 	is >> tok2;
-	if ((tok2.substr(0, 2).compare(":A") == 0) || (tok2.substr(1, 2).compare(":A") == 0))
+	if (tok2.compare(0, 2, ":A") == 0 || tok2.compare(1, 2, ":A") == 0)
 	{
 		*intensity = atoi(tok.substr(2).c_str());
 	}

--- a/DeviceAdapters/ASIStage/ASILED.cpp
+++ b/DeviceAdapters/ASIStage/ASILED.cpp
@@ -59,7 +59,7 @@ bool LED::SupportsDeviceDetection()
 
 MM::DeviceDetectionStatus LED::DetectDevice()
 {
-	return ASICheckSerialPort(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
+	return ASIDetectDevice(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
 }
 
 int LED::Initialize()

--- a/DeviceAdapters/ASIStage/ASIMagnifier.cpp
+++ b/DeviceAdapters/ASIStage/ASIMagnifier.cpp
@@ -136,7 +136,7 @@ int Magnifier::SetMagnification(double mag)
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         return DEVICE_OK;
     }

--- a/DeviceAdapters/ASIStage/ASIMagnifier.cpp
+++ b/DeviceAdapters/ASIStage/ASIMagnifier.cpp
@@ -50,7 +50,7 @@ bool Magnifier::SupportsDeviceDetection()
 
 MM::DeviceDetectionStatus Magnifier::DetectDevice()
 {
-    return ASICheckSerialPort(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
+    return ASIDetectDevice(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
 }
 
 int Magnifier::Initialize()

--- a/DeviceAdapters/ASIStage/ASIMagnifier.cpp
+++ b/DeviceAdapters/ASIStage/ASIMagnifier.cpp
@@ -141,7 +141,7 @@ int Magnifier::SetMagnification(double mag)
         return DEVICE_OK;
     }
     // deal with error later
-    else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+    else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(4).c_str());
         return ERR_OFFSET + errNo;
@@ -166,7 +166,7 @@ double Magnifier::GetMagnification()
         return ret;
     }
 
-    if (answer.length() > 2 && answer.substr(0, 2).compare(":N") == 0)
+    if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(2).c_str());
         return ERR_OFFSET + errNo;

--- a/DeviceAdapters/ASIStage/ASIMagnifier.cpp
+++ b/DeviceAdapters/ASIStage/ASIMagnifier.cpp
@@ -196,28 +196,10 @@ bool Magnifier::Busy()
         return false;
     }
 
-    if (answer.length() >= 1)
-    {
-        if (answer.substr(0, 1) == "B")
-        {
-            return true;
-        }
-        else if (answer.substr(0, 1) == "N")
-        {
-            return false;
-        }
-        else
-        {
-            return false;
-        }
-    }
-
-    return false;
+    return !answer.empty() && answer.front() == 'B';
 }
 
-///////////////////////////////////////////////////////////////////////////////
 // Action handlers
-///////////////////////////////////////////////////////////////////////////////
 
 int Magnifier::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct)
 {

--- a/DeviceAdapters/ASIStage/ASIStage.h
+++ b/DeviceAdapters/ASIStage/ASIStage.h
@@ -85,6 +85,7 @@ const char* const g_CRISPSumPropertyName = "Sum";
 const char* const g_CRISPDitherErrorPropertyName = "Dither Error";
 const char* const g_CRISPStatePropertyName = "CRISP State Character";
 
-MM::DeviceDetectionStatus ASICheckSerialPort(MM::Device& device, MM::Core& core, std::string portToCheck, double answerTimeoutMs);
+MM::DeviceDetectionStatus ASIDetectDevice(MM::Device& device, MM::Core& core, const std::string& portToCheck, double answerTimeoutMs);
+void LogDeviceError(MM::Device& device, MM::Core& core, int errorCode);
 
 #endif // ASISTAGE_H

--- a/DeviceAdapters/ASIStage/ASIStateDevice.cpp
+++ b/DeviceAdapters/ASIStage/ASIStateDevice.cpp
@@ -166,22 +166,7 @@ bool StateDevice::Busy()
 		return false;
 	}
 
-	if (answer.length() >= 1)
-	{
-		if (answer.substr(0, 1) == "B")
-		{
-			return true;
-		}
-		else if (answer.substr(0, 1) == "N")
-		{
-			return false;
-		}
-		else
-		{
-			return false;
-		}
-	}
-	return false;
+	return !answer.empty() && answer.front() == 'B';
 }
 
 int StateDevice::UpdateCurrentPosition()

--- a/DeviceAdapters/ASIStage/ASIStateDevice.cpp
+++ b/DeviceAdapters/ASIStage/ASIStateDevice.cpp
@@ -58,7 +58,7 @@ bool StateDevice::SupportsDeviceDetection()
 
 MM::DeviceDetectionStatus StateDevice::DetectDevice()
 {
-	return ASICheckSerialPort(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
+	return ASIDetectDevice(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
 }
 
 int StateDevice::Initialize()

--- a/DeviceAdapters/ASIStage/ASIStateDevice.cpp
+++ b/DeviceAdapters/ASIStage/ASIStateDevice.cpp
@@ -198,13 +198,13 @@ int StateDevice::UpdateCurrentPosition()
 		return ret;
 	}
 
-	if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+	else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 	{
 		int errNo = atoi(answer.substr(2, 4).c_str());
 		return ERR_OFFSET + errNo;
 	}
 
-	if (answer.substr(0, 2) == ":A")
+	if (answer.compare(0, 2, ":A") == 0)
 	{
 		position_ = (long)atoi(answer.substr(3, 2).c_str()) - 1;
 	}
@@ -216,9 +216,7 @@ int StateDevice::UpdateCurrentPosition()
 	return DEVICE_OK;
 }
 
-/////////////////////////////////////////////////////////////////////////////////
-//// Action handlers
-/////////////////////////////////////////////////////////////////////////////////
+// Action handlers
 
 int StateDevice::OnNumPositions(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
@@ -287,13 +285,13 @@ int StateDevice::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 			return ret;
 		}
 
-		if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+		else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 		{
 			int errNo = atoi(answer.substr(2, 4).c_str());
 			return ERR_OFFSET + errNo;
 		}
 
-		if (answer.substr(0, 2) == ":A")
+		if (answer.compare(0, 2, ":A") == 0)
 		{
 			position_ = position;
 		}

--- a/DeviceAdapters/ASIStage/ASITIRF.cpp
+++ b/DeviceAdapters/ASIStage/ASITIRF.cpp
@@ -191,7 +191,7 @@ int TIRF::SetAngle(double angle)
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         return DEVICE_OK;
     }

--- a/DeviceAdapters/ASIStage/ASITIRF.cpp
+++ b/DeviceAdapters/ASIStage/ASITIRF.cpp
@@ -58,7 +58,7 @@ bool TIRF::SupportsDeviceDetection()
 
 MM::DeviceDetectionStatus TIRF::DetectDevice()
 {
-    return ASICheckSerialPort(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
+    return ASIDetectDevice(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
 }
 
 int TIRF::Initialize()

--- a/DeviceAdapters/ASIStage/ASITIRF.cpp
+++ b/DeviceAdapters/ASIStage/ASITIRF.cpp
@@ -125,37 +125,20 @@ int TIRF::Shutdown()
     return DEVICE_OK;
 }
 
-
 bool TIRF::Busy()
 {
     // empty the Rx serial buffer before sending command
     ClearPort();
 
-    const char* command = "/";
+    // send status command
     std::string answer;
-    // query command
-    int ret = QueryCommand(command, answer);
+    int ret = QueryCommand("/", answer);
     if (ret != DEVICE_OK)
     {
         return false;
     }
 
-    if (answer.length() >= 1)
-    {
-        if (answer.substr(0, 1) == "B")
-        {
-            return true;
-        }
-        else if (answer.substr(0, 1) == "N")
-        {
-            return false;
-        }
-        else
-        {
-            return false;
-        }
-    }
-    return false;
+    return !answer.empty() && answer.front() == 'B';
 }
 
 double TIRF::GetAngle()
@@ -174,7 +157,7 @@ double TIRF::GetAngle()
         return ret;
     }
 
-    if (answer.length() > 2 && answer.substr(0, 2).compare(":N") == 0)
+    if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(2).c_str());
         return ERR_OFFSET + errNo;
@@ -213,7 +196,7 @@ int TIRF::SetAngle(double angle)
         return DEVICE_OK;
     }
     // deal with error later
-    else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+    else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(4).c_str());
         return ERR_OFFSET + errNo;

--- a/DeviceAdapters/ASIStage/ASITurret.cpp
+++ b/DeviceAdapters/ASIStage/ASITurret.cpp
@@ -42,8 +42,6 @@ int AZ100Turret::Initialize()
 {
 	core_ = GetCoreCallback();
 
-	// 
-
 	CPropertyAction* pAct = new CPropertyAction(this, &AZ100Turret::OnState);
 	int ret = CreateProperty(MM::g_Keyword_State, "0", MM::Integer, false, pAct);
 	if (ret != DEVICE_OK)
@@ -145,9 +143,7 @@ bool AZ100Turret::Busy()
 	return false;
 }
 
-/////////////////////////////////////////////////////////////////////////////////
-//// Action handlers
-/////////////////////////////////////////////////////////////////////////////////
+// Action handlers
 
 int AZ100Turret::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct)
 {

--- a/DeviceAdapters/ASIStage/ASITurret.cpp
+++ b/DeviceAdapters/ASIStage/ASITurret.cpp
@@ -190,13 +190,13 @@ int AZ100Turret::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 			return ret;
 		}
 
-		if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+		if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 		{
 			int errNo = atoi(answer.substr(2, 4).c_str());
 			return ERR_OFFSET + errNo;
 		}
 
-		if (answer.substr(0, 2) == ":A")
+		if (answer.compare(0, 2, ":A") == 0)
 		{
 			position_ = position;
 		}

--- a/DeviceAdapters/ASIStage/ASIXYStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIXYStage.cpp
@@ -1293,10 +1293,6 @@ int XYStage::OnJSMirror(MM::PropertyBase* pProp, MM::ActionType eAct)
 		{
 			return DEVICE_OK;
 		}
-		else if (answer.substr(answer.length(), 1) == "A")
-		{
-			return DEVICE_OK;
-		}
 		else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 		{
 			int errNo = atoi(answer.substr(3).c_str());
@@ -1347,10 +1343,6 @@ int XYStage::OnJSFastSpeed(MM::PropertyBase* pProp, MM::ActionType eAct)
 		{
 			return DEVICE_OK;
 		}
-		else if (answer.substr(answer.length(), 1) == "A")
-		{
-			return DEVICE_OK;
-		}
 		else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
 		{
 			int errNo = atoi(answer.substr(3).c_str());
@@ -1396,10 +1388,6 @@ int XYStage::OnJSSlowSpeed(MM::PropertyBase* pProp, MM::ActionType eAct)
 		}
 
 		if (answer.compare(0, 2, ":A") == 0)
-		{
-			return DEVICE_OK;
-		}
-		else if (answer.substr(answer.length(), 1) == "A")
 		{
 			return DEVICE_OK;
 		}

--- a/DeviceAdapters/ASIStage/ASIXYStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIXYStage.cpp
@@ -323,7 +323,7 @@ int XYStage::SetPositionSteps(long x, long y)
 		return ret;
 	}
 
-	if ((answer.substr(0, 2).compare(":A") == 0) || (answer.substr(1, 2).compare(":A") == 0))
+	if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
 	{
 		return DEVICE_OK;
 	}
@@ -363,7 +363,7 @@ int XYStage::SetRelativePositionSteps(long x, long y)
 		return ret;
 	}
 
-	if ((answer.substr(0, 2).compare(":A") == 0) || (answer.substr(1, 2).compare(":A") == 0))
+	if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
 	{
 		return DEVICE_OK;
 	}
@@ -425,7 +425,7 @@ int XYStage::SetOrigin()
 		return ret;
 	}
 
-	if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+	if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
 	{
 		return DEVICE_OK;
 	}
@@ -444,20 +444,19 @@ void XYStage::Wait()
 
 	// if (stopSignal_) return DEVICE_OK;
 	bool busy = true;
-	const char* command = "/";
-	std::string answer = "";
+	std::string answer;
 
 	// query the device
-	QueryCommand(command, answer);
+	QueryCommand("/", answer);
 	// if (ret != DEVICE_OK)
 	//     return ret;
 
 	// block/wait for acknowledge, or until we time out;
-	if (answer.substr(0, 1) == "B")
+	if (answer.compare(0, 1, "B") == 0)
 	{
 		busy = true;
 	}
-	else if (answer.substr(0, 1) == "N")
+	else if (answer.compare(0, 1, "N") == 0)
 	{
 		busy = false;
 	}
@@ -477,15 +476,15 @@ void XYStage::Wait()
 		totaltime += intervalMs;
 
 		// query the device
-		QueryCommand(command, answer);
+		QueryCommand("/", answer);
 		// if (ret != DEVICE_OK)
 		//     return ret;
 
-		if (answer.substr(0, 1) == "B")
+		if (answer.compare(0, 1, "B") == 0)
 		{
 			busy = true;
 		}
-		else if (answer.substr(0, 1) == "N")
+		else if (answer.compare(0, 1, "N") == 0)
 		{
 			busy = false;
 		}
@@ -517,7 +516,7 @@ int XYStage::Home()
 		return ret;
 	}
 
-	if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+	if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
 	{
 		// do nothing
 	}
@@ -561,7 +560,7 @@ int XYStage::Calibrate() {
 	if (ret != DEVICE_OK)
 		return ret;
 
-	if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+	if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
 	{
 		// do nothing
 	}
@@ -594,7 +593,7 @@ int XYStage::Stop()
 		return ret;
 	}
 
-	if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+	if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
 	{
 		return DEVICE_OK;
 	}
@@ -1913,8 +1912,8 @@ int XYStage::OnVectorGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const
 			return ret;
 		}
 
-		// if (answer.substr(0,2).compare(":" + axisLetter) == 0)
-		if (answer.substr(0, 5).compare(":A " + axisLetter + "=") == 0)
+		// if (answer.compare(0, 2, ":" + axisLetter) == 0)
+		if (answer.compare(0, 5, ":A " + axisLetter + "=") == 0)
 		{
 			double speed = 0.0;
 			const int code = ParseResponseAfterPosition(answer, 6, 13, speed);

--- a/DeviceAdapters/ASIStage/ASIXYStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIXYStage.cpp
@@ -70,7 +70,7 @@ bool XYStage::SupportsDeviceDetection()
 
 MM::DeviceDetectionStatus XYStage::DetectDevice()
 {
-	return ASICheckSerialPort(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
+	return ASIDetectDevice(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
 }
 
 int XYStage::Initialize()

--- a/DeviceAdapters/ASIStage/ASIXYStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIXYStage.cpp
@@ -140,7 +140,7 @@ int XYStage::Initialize()
 	CreateProperty("StepSizeY_um", "0.0", MM::Float, true, pAct);
 
 	// Wait cycles
-	if (hasCommand("WT X?"))
+	if (HasCommand("WT X?"))
 	{
 		ret = GetWaitCycles(waitCycles_);
 		if (ret != DEVICE_OK)
@@ -151,7 +151,7 @@ int XYStage::Initialize()
 	}
 
 	// Speed (sets both x and y)
-	if (hasCommand("S " + axisletterX_ + "?"))
+	if (HasCommand("S " + axisletterX_ + "?"))
 	{
 		ret = GetSpeed(speed_);
 		if (ret != DEVICE_OK)
@@ -165,7 +165,7 @@ int XYStage::Initialize()
 	}
 
 	// Backlash (sets both x and y)
-	if (hasCommand("B " + axisletterX_ + "?"))
+	if (HasCommand("B " + axisletterX_ + "?"))
 	{
 		ret = GetBacklash(backlash_);
 		if (ret != DEVICE_OK)
@@ -175,7 +175,7 @@ int XYStage::Initialize()
 	}
 	
 	// Error (sets both x and y)
-	if (hasCommand("E " + axisletterX_ + "?"))
+	if (HasCommand("E " + axisletterX_ + "?"))
 	{
 		ret = GetError(error_);
 		if (ret != DEVICE_OK)
@@ -185,7 +185,7 @@ int XYStage::Initialize()
 	}
 	
 	// acceleration (sets both x and y)
-	if (hasCommand("AC " + axisletterX_ + "?"))
+	if (HasCommand("AC " + axisletterX_ + "?"))
 	{
       ret = GetAcceleration(acceleration_);
       if (ret != DEVICE_OK)
@@ -195,7 +195,7 @@ int XYStage::Initialize()
 	}
 	
 	// Finish Error (sets both x and y)
-	if (hasCommand("PC " + axisletterX_ + "?"))
+	if (HasCommand("PC " + axisletterX_ + "?"))
 	{
 		ret = GetFinishError(finishError_);
       if (ret != DEVICE_OK)
@@ -205,7 +205,7 @@ int XYStage::Initialize()
 	}
 	
 	// OverShoot (sets both x and y)
-	if (hasCommand("OS " + axisletterX_ + "?"))
+	if (HasCommand("OS " + axisletterX_ + "?"))
 	{
 		ret = GetOverShoot(overShoot_);
       if (ret != DEVICE_OK)
@@ -256,7 +256,7 @@ int XYStage::Initialize()
 	AddAllowedValue("EnableAdvancedProperties", "No");
 	AddAllowedValue("EnableAdvancedProperties", "Yes");
 	
-	if (hasCommand("VE " + axisletterX_ + "=0")) {
+	if (HasCommand("VE " + axisletterX_ + "=0")) {
 		char orig_speed[MM::MaxStrLength];
 		ret = GetProperty("Speed-S", orig_speed);
 		double mspeed;
@@ -624,7 +624,7 @@ int XYStage::GetStepLimits(long& /*xMin*/, long& /*xMax*/, long& /*yMin*/, long&
 	return DEVICE_UNSUPPORTED_COMMAND;
 }
 
-bool XYStage::hasCommand(std::string command)
+bool XYStage::HasCommand(const std::string& command)
 {
 	std::string answer;
 
@@ -1516,28 +1516,28 @@ int XYStage::OnAdvancedProperties(MM::PropertyBase* pProp, MM::ActionType eAct)
 			// overshoot (OS)  // in Nico's original
 
 			// servo integral term (KI)
-			if (hasCommand("KI " + axisletterX_ + "?"))
+			if (HasCommand("KI " + axisletterX_ + "?"))
 			{
 				pAct = new CPropertyAction(this, &XYStage::OnKIntegral);
 				CreateProperty("ServoIntegral-KI", "0", MM::Integer, false, pAct);
 			}
 
 			// servo proportional term (KP)
-			if (hasCommand("KP " + axisletterX_ + "?"))
+			if (HasCommand("KP " + axisletterX_ + "?"))
 			{
 				pAct = new CPropertyAction(this, &XYStage::OnKProportional);
 				CreateProperty("ServoProportional-KP", "0", MM::Integer, false, pAct);
 			}
 
 			// servo derivative term (KD)
-			if (hasCommand("KD " + axisletterX_ + "?"))
+			if (HasCommand("KD " + axisletterX_ + "?"))
 			{
 				pAct = new CPropertyAction(this, &XYStage::OnKDerivative);
 				CreateProperty("ServoIntegral-KD", "0", MM::Integer, false, pAct);
 			}
 
 			// Align calibration/setting for pot in drive electronics (AA)
-			if (hasCommand("AA " + axisletterX_ + "?"))
+			if (HasCommand("AA " + axisletterX_ + "?"))
 			{
 				pAct = new CPropertyAction(this, &XYStage::OnAAlign);
 				CreateProperty("MotorAlign-AA", "0", MM::Integer, false, pAct);
@@ -1785,7 +1785,7 @@ int XYStage::SetAxisDirection()
 }
 
 // based on similar function in FreeSerialPort.cpp
-std::string XYStage::EscapeControlCharacters(const std::string v)
+std::string XYStage::EscapeControlCharacters(const std::string& v)
 {
 	std::ostringstream mess;
 	mess.str("");
@@ -1816,7 +1816,7 @@ std::string XYStage::EscapeControlCharacters(const std::string v)
 }
 
 // based on similar function in FreeSerialPort.cpp
-std::string XYStage::UnescapeControlCharacters(const std::string v0)
+std::string XYStage::UnescapeControlCharacters(const std::string& v0)
 {
 	// the string input from the GUI can contain escaped control characters, currently these are always preceded with \ (0x5C)
 	// and always assumed to be decimal or C style, not hex
@@ -1900,7 +1900,7 @@ std::string XYStage::UnescapeControlCharacters(const std::string v0)
 	return detokenized;
 }
 
-int XYStage::OnVectorGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, std::string axisLetter) {
+int XYStage::OnVectorGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter) {
 	if (eAct == MM::BeforeGet)
 	{
 		std::ostringstream command;

--- a/DeviceAdapters/ASIStage/ASIXYStage.h
+++ b/DeviceAdapters/ASIStage/ASIXYStage.h
@@ -80,11 +80,11 @@ private:
 	int OnAAlign(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int GetPositionStepsSingle(char axis, long& steps);
 	int SetAxisDirection();
-	bool hasCommand(std::string command);
+	bool HasCommand(const std::string& command);
 	void Wait();
-	static std::string EscapeControlCharacters(const std::string v);
-	static std::string UnescapeControlCharacters(const std::string v0);
-	int OnVectorGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, std::string axisLetter);
+	static std::string EscapeControlCharacters(const std::string& v);
+	static std::string UnescapeControlCharacters(const std::string& v0);
+	int OnVectorGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
 	int OnVectorX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnVectorGeneric(pProp, eAct, axisletterX_); }
 	int OnVectorY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnVectorGeneric(pProp, eAct, axisletterY_); }
 

--- a/DeviceAdapters/ASIStage/ASIZStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIZStage.cpp
@@ -303,22 +303,7 @@ bool ZStage::Busy()
         return false;
     }
 
-    if (answer.length() >= 1)
-    {
-        if (answer.substr(0, 1) == "B")
-        {
-            return true;
-        }
-        else if (answer.substr(0, 1) == "N")
-        {
-            return false;
-        }
-        else
-        {
-            return false;
-        }
-    }
-    return false;
+    return !answer.empty() && answer.front() == 'B';
 }
 
 int ZStage::SetPositionUm(double pos)
@@ -348,7 +333,7 @@ int ZStage::SetPositionUm(double pos)
         return DEVICE_OK;
     }
     // deal with error later
-    else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+    else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(4).c_str());
         return ERR_OFFSET + errNo;
@@ -370,7 +355,7 @@ int ZStage::GetPositionUm(double& pos)
     if (ret != DEVICE_OK)
         return ret;
 
-    if (answer.length() > 2 && answer.substr(0, 2).compare(":N") == 0)
+    if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(2).c_str());
         return ERR_OFFSET + errNo;
@@ -419,7 +404,7 @@ int ZStage::SetRelativePositionUm(double d)
         return DEVICE_OK;
     }
     // deal with error later
-    else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+    else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(4).c_str());
         return ERR_OFFSET + errNo;
@@ -450,7 +435,7 @@ int ZStage::SetPositionSteps(long pos)
         return DEVICE_OK;
     }
     // deal with error later
-    else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+    else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(4).c_str());
         return ERR_OFFSET + errNo;
@@ -474,7 +459,7 @@ int ZStage::GetPositionSteps(long& steps)
         return ret;
     }
 
-    if (answer.length() > 2 && answer.substr(0, 2).compare(":N") == 0)
+    if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(2).c_str());
         return ERR_OFFSET + errNo;
@@ -515,7 +500,7 @@ int ZStage::SetOrigin()
     {
         return DEVICE_OK;
     }
-    else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+    else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
     {
         int errNo = atoi(answer.substr(2, 4).c_str());
         return ERR_OFFSET + errNo;
@@ -818,12 +803,12 @@ bool ZStage::HasCommand(std::string command) {
         return false;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0)
     {
         return true;
     }
 
-    if (answer.substr(0, 4).compare(":N-1") == 0)
+    if (answer.compare(0, 4, ":N-1") == 0)
     {
         return false;
     }
@@ -997,7 +982,7 @@ int ZStage::GetWait(long& waitCycles)
       return ParseResponseAfterPosition(answer, 3, waitCycles);
    }
    // deal with error later
-   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
    {
       int errNo = atoi(answer.substr(3).c_str());
       return ERR_OFFSET + errNo;
@@ -1072,7 +1057,7 @@ int ZStage::GetBacklash(double& backlash)
       return ParseResponseAfterPosition(answer, 3, 8, backlash);
    }
    // deal with error later
-   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
    {
       int errNo = atoi(answer.substr(3).c_str());
       return ERR_OFFSET + errNo;
@@ -1127,7 +1112,7 @@ int ZStage::GetFinishError(double& finishError)
       finishError = 1000000 * tmp;
       return code;
   }
-  if (answer.substr(0, 2).compare(":A") == 0)
+  if (answer.compare(0, 2, ":A") == 0)
   {
       // Answer is of the form :A X=0.00003
       double tmp = 0.0;
@@ -1136,7 +1121,7 @@ int ZStage::GetFinishError(double& finishError)
       return code;
   }
   // deal with error later
-  else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+  else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
   {
       int errNo = atoi(answer.substr(3).c_str());
       return ERR_OFFSET + errNo;
@@ -1195,7 +1180,7 @@ int ZStage::GetAcceleration(long& acceleration)
       return code;
   }
   // deal with error later
-  else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+  else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
   {
       int errNo = atoi(answer.substr(3).c_str());
       return ERR_OFFSET + errNo;
@@ -1243,12 +1228,12 @@ int ZStage::GetOverShoot(double& overShoot)
    if (ret != DEVICE_OK)
       return ret;
 
-   if (answer.substr(0, 2).compare(":A") == 0)
+   if (answer.compare(0, 2, ":A") == 0)
    {
       return ParseResponseAfterPosition(answer, 5, 8, overShoot);
    }
    // deal with error herer
-   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
    {
        int errNo = atoi(answer.substr(3).c_str());
        return ERR_OFFSET + errNo;
@@ -1305,7 +1290,7 @@ int ZStage::GetError(double& error)
        return code;
    }
    // deal with error later
-   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
    {
       int errNo = atoi(answer.substr(3).c_str());
       return ERR_OFFSET + errNo;
@@ -1379,12 +1364,12 @@ int ZStage::GetSpeed(double& speed)
    if (ret != DEVICE_OK)
       return ret;
 
-   if (answer.substr(0, 2).compare(":A") == 0)
+   if (answer.compare(0, 2, ":A") == 0)
    {
       return ParseResponseAfterPosition(answer, 5, speed);
    }
    // deal with error later
-   else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+   else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
    {
       int errNo = atoi(answer.substr(3).c_str());
       return ERR_OFFSET + errNo;
@@ -1496,7 +1481,7 @@ int ZStage::OnVector(MM::PropertyBase* pProp, MM::ActionType eAct)
             return code;
         }
         // deal with error later
-        else if (answer.substr(0, 2).compare(":N") == 0 && answer.length() > 2)
+        else if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
         {
             int errNo = atoi(answer.substr(3).c_str());
             return ERR_OFFSET + errNo;

--- a/DeviceAdapters/ASIStage/ASIZStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIZStage.cpp
@@ -327,7 +327,7 @@ int ZStage::SetPositionUm(double pos)
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         this->OnStagePositionChanged(pos);
         return DEVICE_OK;
@@ -397,7 +397,7 @@ int ZStage::SetRelativePositionUm(double d)
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         // we don't know the updated position to call this
         //this->OnStagePositionChanged(pos);
@@ -430,7 +430,7 @@ int ZStage::SetPositionSteps(long pos)
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         return DEVICE_OK;
     }
@@ -474,7 +474,6 @@ int ZStage::GetPositionSteps(long& steps)
 
         steps = (long)zz;
         curSteps_ = (long)steps;
-
         return DEVICE_OK;
     }
     return ERR_UNRECOGNIZED_ANSWER;
@@ -496,7 +495,7 @@ int ZStage::SetOrigin()
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         return DEVICE_OK;
     }
@@ -544,7 +543,7 @@ int ZStage::StartStageSequence()
         {
             return ret;
         }
-        if (answer.substr(0, 2) != ":A" && answer.substr(1, 2) != ":A")
+        if (answer.compare(0, 2, ":A") != 0 || answer.compare(1, 2, ":A") != 0)
         {
             return ERR_UNRECOGNIZED_ANSWER;
         }
@@ -554,7 +553,7 @@ int ZStage::StartStageSequence()
         {
             return ret;
         }
-        if (answer.substr(0, 2) != ":A" && answer.substr(1, 2) != ":A")
+        if (answer.compare(0, 2, ":A") != 0 || answer.compare(1, 2, ":A") != 0)
         {
             return ERR_UNRECOGNIZED_ANSWER;
         }
@@ -572,7 +571,7 @@ int ZStage::StartStageSequence()
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         ret = QueryCommand("TTL X=1", answer); // switches on TTL triggering
         if (ret != DEVICE_OK)
@@ -580,7 +579,7 @@ int ZStage::StartStageSequence()
             return ret;
         }
 
-        if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+        if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
         {
             return DEVICE_OK;
         }
@@ -602,7 +601,7 @@ int ZStage::StopStageSequence()
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         return DEVICE_OK;
     }
@@ -624,7 +623,7 @@ int ZStage::SendStageSequence()
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         for (unsigned i = 0; i < sequence_.size(); i++)
         {
@@ -654,7 +653,7 @@ int ZStage::SendStageSequence()
                 }
 
                 // the answer will also have a :N-1 in it, ignore.
-                if (!(answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0))
+                if (!(answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0))
                 {
                     return ERR_UNRECOGNIZED_ANSWER;
                 }
@@ -681,7 +680,7 @@ int ZStage::ClearStageSequence()
         return ret;
     }
 
-    if (answer.substr(0, 2).compare(":A") == 0 || answer.substr(1, 2).compare(":A") == 0)
+    if (answer.compare(0, 2, ":A") == 0 || answer.compare(1, 2, ":A") == 0)
     {
         return DEVICE_OK;
     }
@@ -778,14 +777,14 @@ int ZStage::GetControllerInfo()
         return ret;
     }
 
-    if (answer.length() > 5 && answer.substr(0, 5) == ":A F=")
+    if (answer.length() > 5 && answer.compare(0, 5, ":A F=") == 0)
     {
         int focusIndex = atoi(answer.substr(5).c_str());
 
         std::ostringstream cmd;
         cmd << "Z2B " << axis_ << "?";
         ret = QueryCommand(cmd.str().c_str(), answer);
-        if (answer.length() > 5 && answer.substr(0, 3) == ":A ")
+        if (answer.length() > 5 && answer.compare(0, 3, ":A ") == 0)
         {
             int axisIndex = atoi(answer.substr(5).c_str());
             supportsLinearSequence_ = (focusIndex == axisIndex);
@@ -794,7 +793,8 @@ int ZStage::GetControllerInfo()
     return DEVICE_OK;
 }
 
-bool ZStage::HasCommand(const std::string& command) {
+bool ZStage::HasCommand(const std::string& command)
+{
     std::string answer;
     // query the device
     int ret = QueryCommand(command.c_str(), answer);
@@ -975,7 +975,7 @@ int ZStage::GetWait(long& waitCycles)
    if (ret != DEVICE_OK)
       return ret;
 
-   if (answer.substr(0, 2).compare(":" + axis_) == 0)
+   if (answer.compare(0, 2, ":" + axis_) == 0)
    {
       return ParseResponseAfterPosition(answer, 3, waitCycles);
    }
@@ -1050,7 +1050,7 @@ int ZStage::GetBacklash(double& backlash)
    if (ret != DEVICE_OK)
       return ret;
 
-   if (answer.substr(0, 2).compare(":" + axis_) == 0)
+   if (answer.compare(0, 2, ":" + axis_) == 0)
    {
       return ParseResponseAfterPosition(answer, 3, 8, backlash);
    }
@@ -1103,7 +1103,7 @@ int ZStage::GetFinishError(double& finishError)
    if (ret != DEVICE_OK)
       return ret;
 
-   if (answer.substr(0, 2).compare(":" + axis_) == 0)
+   if (answer.compare(0, 2, ":" + axis_) == 0)
    {
       double tmp = 0.0;
       const int code = ParseResponseAfterPosition(answer, 3, 8, tmp);
@@ -1170,7 +1170,7 @@ int ZStage::GetAcceleration(long& acceleration)
       return ret;
   }
 
-  if (answer.substr(0, 2).compare(":" + axis_) == 0)
+  if (answer.compare(0, 2, ":" + axis_) == 0)
   {
       double tmp = 0.0;
       const int code = ParseResponseAfterPosition(answer, 3, 8, tmp);
@@ -1280,7 +1280,7 @@ int ZStage::GetError(double& error)
    if (ret != DEVICE_OK)
        return ret;
 
-   if (answer.substr(0, 2).compare(":" + axis_) == 0)
+   if (answer.compare(0, 2, ":" + axis_) == 0)
    {
        double tmp = 0.0;
        const int code = ParseResponseAfterPosition(answer, 3, 8, tmp);

--- a/DeviceAdapters/ASIStage/ASIZStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIZStage.cpp
@@ -73,7 +73,7 @@ bool ZStage::SupportsDeviceDetection()
 
 MM::DeviceDetectionStatus ZStage::DetectDevice()
 {
-    return ASICheckSerialPort(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
+    return ASIDetectDevice(*this, *GetCoreCallback(), port_, answerTimeoutMs_);
 }
 
 int ZStage::Initialize()

--- a/DeviceAdapters/ASIStage/ASIZStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIZStage.cpp
@@ -794,7 +794,7 @@ int ZStage::GetControllerInfo()
     return DEVICE_OK;
 }
 
-bool ZStage::HasCommand(std::string command) {
+bool ZStage::HasCommand(const std::string& command) {
     std::string answer;
     // query the device
     int ret = QueryCommand(command.c_str(), answer);
@@ -817,9 +817,7 @@ bool ZStage::HasCommand(std::string command) {
     return true;
 }
 
-/////////////////////////////////////////////////////////////////////////////////
-//// Action handlers
-/////////////////////////////////////////////////////////////////////////////////
+// Action handlers
 
 int ZStage::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
@@ -1472,8 +1470,8 @@ int ZStage::OnVector(MM::PropertyBase* pProp, MM::ActionType eAct)
             return ret;
         }
 
-        // if (answer.substr(0,2).compare(":" + axis_) == 0)
-        if (answer.substr(0, 5).compare(":A " + axis_ + "=") == 0)
+        // if (answer.compare(0, 2, ":" + axis_) == 0)
+        if (answer.compare(0, 5, ":A " + axis_ + "=") == 0)
         {
             double speed = 0.0;
             const int code = ParseResponseAfterPosition(answer, 6, 13, speed);

--- a/DeviceAdapters/ASIStage/ASIZStage.h
+++ b/DeviceAdapters/ASIStage/ASIZStage.h
@@ -80,7 +80,7 @@ private:
 	int OnMotorCtrl(MM::PropertyBase* pProp, MM::ActionType eAct);
 	bool HasRingBuffer() const;
 	int GetControllerInfo();
-	bool HasCommand(std::string command);
+	bool HasCommand(const std::string& command);
 	int OnVector(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 	std::vector<double> sequence_;


### PR DESCRIPTION
The MS-2000 set to 19200 baud rate will be detected when you click "Scan Ports" in the Hardware Configuration Wizard.

The advanced properties for saving calibration settings are enabled as a group now (you need all of them for any of them to be useful).

Took care of basic tasks:
- make less copies of `std::string` using overloaded `compare()`
- pass some variables by const reference instead of by value
- simplify `Busy()` functions, etc

