### PR TITLE
ASIwptr: format code, and initialize all variables

### DIFF
--- a/DeviceAdapters/ASIWPTR/wptr.cpp
+++ b/DeviceAdapters/ASIWPTR/wptr.cpp
@@ -80,7 +80,7 @@ WPTRobot::WPTRobot() :
 
     InitializeDefaultErrorMessages();
 
-    // Create Pre-Init Properties
+    // Create Preinitialization Properties
 
     // Name
     CreateProperty(MM::g_Keyword_Name, g_WPTRobotName, MM::String, true);
@@ -176,7 +176,7 @@ int WPTRobot::OnCommand(MM::PropertyBase* pProp, MM::ActionType eAct) {
     if (eAct == MM::BeforeGet) {
         pProp->Set(command_.c_str());
     } else if (eAct == MM::AfterSet) {
-        // Read what keyword the user issued, and send the corresponding cmd
+        // Read what keyword the user issued, and send the corresponding command
         pProp->Get(command_);
 
         std::ostringstream os;
@@ -248,7 +248,7 @@ int WPTRobot::OnCommand(MM::PropertyBase* pProp, MM::ActionType eAct) {
         } else if (command_.compare(0, 3, "AES") == 0) {
             // used issued STOP command
 
-            // AES is cmd for emergency stop, stops the robot cold, issue DRT cmd to enable again
+            // AES is command for emergency stop, stops the robot cold, issue DRT command to enable again
             os << "AES";
 
             ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
@@ -270,7 +270,7 @@ int WPTRobot::OnCommand(MM::PropertyBase* pProp, MM::ActionType eAct) {
         } else if (command_.compare(0, 3, "DRT") == 0) {
             // user issued DRT command
 
-            // user to over ride errors
+            // override errors
             os << "DRT";
 
             ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");

--- a/DeviceAdapters/ASIWPTR/wptr.cpp
+++ b/DeviceAdapters/ASIWPTR/wptr.cpp
@@ -6,7 +6,7 @@
 // DESCRIPTION:   RND's WTR controller adapter
 //
 // COPYRIGHT:     Applied Scientific Instrumentation, Eugene OR
-//				  Robots and Design Co, Ltd.	
+//                Robots and Design Co, Ltd.
 //                University of California, San Francisco
 //
 // LICENSE:       This file is distributed under the BSD license.
@@ -24,309 +24,272 @@
 //
 
 #include "wptr.h"
-#include <string>
-#include <math.h>
-#include "ModuleInterface.h"
-#include "DeviceUtils.h"
+
 #include <sstream>
-#include <iostream>
+#include <string>
+
+#include "DeviceUtils.h"
+#include "ModuleInterface.h"
 
 using namespace std;
 
 const char* g_WPTRobotName = "WPTRobot";
 
-
-
-///////////////////////////////////////////////////////////////////////////////
 // Exported MMDevice API
-///////////////////////////////////////////////////////////////////////////////
-MODULE_API void InitializeModuleData()
-{
-   RegisterDevice(g_WPTRobotName, MM::GenericDevice, "WPTRobot");
+MODULE_API void InitializeModuleData() {
+    RegisterDevice(g_WPTRobotName, MM::GenericDevice, "WPTRobot");
 }
 
-MODULE_API MM::Device* CreateDevice(const char* deviceName)
-{
-   if (deviceName == 0)
-      return 0;
+MODULE_API MM::Device* CreateDevice(const char* deviceName) {
+    if (deviceName == 0) {
+        return 0;
+    }
 
-  if (strcmp(deviceName, g_WPTRobotName) == 0)
-   {
-      return  new WPTRobot();
-   }
+    if (strcmp(deviceName, g_WPTRobotName) == 0) {
+        return new WPTRobot();
+    }
 
-   return 0;
+    return 0;
 }
 
-MODULE_API void DeleteDevice(MM::Device* pDevice)
-{
-   delete pDevice;
+MODULE_API void DeleteDevice(MM::Device* pDevice) {
+    delete pDevice;
 }
 
-// General utility function:
-int ClearPort(MM::Device& device, MM::Core& core, std::string port)
-{
-   // Clear contents of serial port 
-   const int bufSize = 255;
-   unsigned char clear[bufSize];                                                        
-   unsigned long read = bufSize;                                               
-   int ret;                                                                    
-   while ((int) read == bufSize)                                                     
-   {                                                                           
-      ret = core.ReadFromSerial(&device, port.c_str(), clear, bufSize, read); 
-      if (ret != DEVICE_OK)                                                    
-         return ret;                                                           
-   }                                                                           
-   return DEVICE_OK;                                                           
-} 
+// Clear contents of serial port
+int ClearPort(MM::Device& device, MM::Core& core, std::string port) {
+    const int bufSize = 255;
+    unsigned char clear[bufSize];
+    unsigned long read = bufSize;
+    int ret;
+    while ((int)read == bufSize) {
+        ret = core.ReadFromSerial(&device, port.c_str(), clear, bufSize, read);
+        if (ret != DEVICE_OK) {
+            return ret;
+        }
+    }
+    return DEVICE_OK;
+}
 
-
-///////////////////////////////////////////////////////////////////////////////
 WPTRobot::WPTRobot() :
-CGenericBase<WPTRobot>(),
-   initialized_(false),
- // port_("Undefined"),
-   stage_(1),
-   slot_(1)
-  
-   
-{
-   InitializeDefaultErrorMessages();
+    CGenericBase<WPTRobot>(),
+    initialized_(false),
+    // port_("Undefined"),
+    stage_(1),
+    slot_(1) {
 
-   // create pre-initialization properties
-   // ------------------------------------
+    InitializeDefaultErrorMessages();
 
-   // Name
-   CreateProperty(MM::g_Keyword_Name, g_WPTRobotName, MM::String, true);
+    // Create Pre-Init Properties
 
-   // Description
-   CreateProperty(MM::g_Keyword_Description, "Wellplate Transfer Robot", MM::String, true);
+    // Name
+    CreateProperty(MM::g_Keyword_Name, g_WPTRobotName, MM::String, true);
 
-   // Port
-   CPropertyAction* pAct = new CPropertyAction (this, &WPTRobot::OnPort);
-   CreateProperty(MM::g_Keyword_Port, "Undefined", MM::String, false, pAct, true);
- 
+    // Description
+    CreateProperty(MM::g_Keyword_Description, "Wellplate Transfer Robot", MM::String, true);
+
+    // Port
+    CPropertyAction* pAct = new CPropertyAction(this, &WPTRobot::OnPort);
+    CreateProperty(MM::g_Keyword_Port, "Undefined", MM::String, false, pAct, true);
 }
 
-WPTRobot::~WPTRobot()
-{
-   Shutdown();
+WPTRobot::~WPTRobot() {
+    Shutdown();
 }
 
-void WPTRobot::GetName(char* Name) const
-{
-   CDeviceUtils::CopyLimitedString(Name, g_WPTRobotName);
+void WPTRobot::GetName(char* name) const {
+    CDeviceUtils::CopyLimitedString(name, g_WPTRobotName);
 }
 
-int WPTRobot::Initialize()
-{
-	  // empty the Rx serial buffer before sending command
-      ClearPort(*this, *GetCoreCallback(), port_.c_str()); 
-	// Stage and Slot passed as properties
-      CPropertyAction* pAct = new CPropertyAction (this, &WPTRobot::OnStage);
-      CreateProperty("Stage", "1", MM::Integer, false, pAct);
-   //   SetPropertyLimits("Stage", 1, 3); //settings limits must be edited again, if set up changed 
+int WPTRobot::Initialize() {
+    // empty the Rx serial buffer before sending command
+    ClearPort(*this, *GetCoreCallback(), port_.c_str());
 
-      pAct = new CPropertyAction (this, &WPTRobot::OnSlot);
-      CreateProperty("Slot", "1", MM::Integer, false, pAct);
-   //   SetPropertyLimits("Slot", 1, 10);
-	// setting this property to different keywords leads to a command
-	  pAct = new CPropertyAction (this, &WPTRobot::OnCommand);
-      CreateProperty("Command", "Undefined", MM::String, false, pAct);
-      
+    // Stage and Slot passed as properties
+    CPropertyAction* pAct = new CPropertyAction(this, &WPTRobot::OnStage);
+    CreateProperty("Stage", "1", MM::Integer, false, pAct);
+    // SetPropertyLimits("Stage", 1, 3); // setting limits must be edited again, if set up changed
 
- 
+    pAct = new CPropertyAction(this, &WPTRobot::OnSlot);
+    CreateProperty("Slot", "1", MM::Integer, false, pAct);
+    // SetPropertyLimits("Slot", 1, 10);
 
-   int ret = UpdateStatus();
-   if (ret != DEVICE_OK)
-      return ret;
+    // setting this property to different keywords leads to a command
+    pAct = new CPropertyAction(this, &WPTRobot::OnCommand);
+    CreateProperty("Command", "Undefined", MM::String, false, pAct);
 
-   initialized_ = true;
-   return DEVICE_OK;
+    int ret = UpdateStatus();
+    if (ret != DEVICE_OK) {
+        return ret;
+    }
+
+    initialized_ = true;
+    return DEVICE_OK;
 }
 
-int WPTRobot::Shutdown()
-{
-   if (initialized_)
-   {
-      initialized_ = false;
-   }
-   return DEVICE_OK;
+int WPTRobot::Shutdown() {
+    if (initialized_) {
+        initialized_ = false;
+    }
+    return DEVICE_OK;
 }
 
-bool WPTRobot::Busy()
-{
-   // reply is only given after move is completed, so busy() not necessary
-   return false;
- 
+bool WPTRobot::Busy() {
+    return false; // reply is only given after move is completed, so Busy() not necessary
 }
 
-int WPTRobot::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct)
-{
-   if (eAct == MM::BeforeGet)
-   {
-      pProp->Set(port_.c_str());
-   }
-   else if (eAct == MM::AfterSet)
-   {
-      if (initialized_)
-      {
-         // revert
-         pProp->Set(port_.c_str());
-         return ERR_PORT_CHANGE_FORBIDDEN;
-      }
-
-      pProp->Get(port_);
-   }
-
-   return DEVICE_OK;
+int WPTRobot::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct) {
+    if (eAct == MM::BeforeGet) {
+        pProp->Set(port_.c_str());
+    } else if (eAct == MM::AfterSet) {
+        if (initialized_) {
+            // revert
+            pProp->Set(port_.c_str());
+            return ERR_PORT_CHANGE_FORBIDDEN;
+        }
+        pProp->Get(port_);
+    }
+    return DEVICE_OK;
 }
 
-int WPTRobot::OnStage(MM::PropertyBase* pProp, MM::ActionType eAct)
-{//Just reading and writing to the stage variable
-   if (eAct == MM::BeforeGet)
-   {
-      pProp->Set(stage_);
-   }
-   else if (eAct == MM::AfterSet)
-   {
-	      pProp->Get(stage_);
-   }
- 
-	return DEVICE_OK;
-
+// Just reading and writing to the stage variable
+int WPTRobot::OnStage(MM::PropertyBase* pProp, MM::ActionType eAct) {
+    if (eAct == MM::BeforeGet) {
+        pProp->Set(stage_);
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(stage_);
+    }
+    return DEVICE_OK;
 }
 
-int WPTRobot::OnSlot(MM::PropertyBase* pProp, MM::ActionType eAct)
-{//Just reading and writing to the slot variable
-   if (eAct == MM::BeforeGet)
-   {
-      pProp->Set(slot_);
-   }
-   else if (eAct == MM::AfterSet)
-   {
-	      pProp->Get(slot_);
-   }
- 
-
-  return DEVICE_OK;
+// Just reading and writing to the slot variable
+int WPTRobot::OnSlot(MM::PropertyBase* pProp, MM::ActionType eAct) {
+    if (eAct == MM::BeforeGet) {
+        pProp->Set(slot_);
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(slot_);
+    }
+    return DEVICE_OK;
 }
 
+int WPTRobot::OnCommand(MM::PropertyBase* pProp, MM::ActionType eAct) {
+    if (eAct == MM::BeforeGet) {
+        pProp->Set(command_.c_str());
+    } else if (eAct == MM::AfterSet) {
+        // Read what keyword the user issued, and send the corresponding cmd
+        pProp->Get(command_);
 
-int WPTRobot::OnCommand(MM::PropertyBase* pProp, MM::ActionType eAct)
-{
+        ostringstream os;
+        string answer;
+        int ret;
 
-	if (eAct == MM::BeforeGet)
-   {
-      pProp->Set(command_.c_str());
-   }
-   else if (eAct == MM::AfterSet)
-   {// Read what keyword the user issued, and send the corresponding cmd
-      pProp->Get(command_);
+        if (command_.substr(0, 3) == "ORG") {
+            // user issued ORG command
+            os << "ORG";
 
-	  ostringstream os;
-	  int ret;
-	  string answer;	
+            ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
 
-	 //if its ORG cmd
-	  if(command_.substr(0,3)=="ORG") // user issued ORG command
-	  {
-	  os<<"ORG";	
-	  ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
-	   if (ret != DEVICE_OK) //checking if sendserialcmd was exected without errors
-         return ret;
-      
+            ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
 
-     
-      ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);//waiting for reply
-	   if (ret != DEVICE_OK)//checking if GetSerialAnswer was exected without errors
-         return ret;
-      
+            // checking if the answer is what is expected,
+            // if not just give an error and quit
+            if (answer.length() != 3) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+            if (answer.substr(0, 3).compare("ORG") != 0) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+        } else if (command_.substr(0, 3) == "GET") {
+            // user issued GET command
+            os << "GET " << stage_ << "," << slot_;
 
-		if(answer.length()!=3 )//checking if the answer is what we are expecting
-			return ERR_UNRECOGNIZED_ANSWER;// if not just give an error and quit
-		if(answer.substr(0, 3).compare("ORG") != 0)
-			return ERR_UNRECOGNIZED_ANSWER;
-	  }
-	  else if(command_.substr(0,3)=="GET")//user issued GET
-	  {
-	  os<<"GET "<<stage_<<","<<slot_; // Crafting the cmd to be sent to serial port
+            ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
 
-	  ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
-	   if (ret != DEVICE_OK)
-         return ret;
-      
-     
-      ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);
-	   if (ret != DEVICE_OK)
-         return ret;
-     
-		if(answer.length()!=3 )	
-			return ERR_UNRECOGNIZED_ANSWER;
-		if(answer.substr(0, 3).compare("GET") != 0)
-			return ERR_UNRECOGNIZED_ANSWER;
+            ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
 
-	  }
-	  else if(command_.substr(0,3)=="PUT")//user issued PUT
-	  {
-	  os<<"PUT "<<stage_<<","<<slot_;
+            if (answer.length() != 3) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+            if (answer.substr(0, 3).compare("GET") != 0) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+        } else if (command_.substr(0, 3) == "PUT") {
+            // user issued PUT command
+            os << "PUT " << stage_ << "," << slot_;
 
-	  ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
-       if (ret != DEVICE_OK)
-         return ret;
+            ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
 
-     
-      ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);
-	   if (ret != DEVICE_OK)
-         return ret;
-      
-		if(answer.length()!=3)	
-			return ERR_UNRECOGNIZED_ANSWER;
-		if(answer.substr(0, 3).compare("PUT") != 0)
-			return ERR_UNRECOGNIZED_ANSWER;
+            ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
 
-	 }
-	  else if(command_.substr(0,3)=="AES")// used issued STOP,
-	  {
-	  os<<"AES";// AES is cmd for Emergency stop, stops the robot cold, issue DRT cmd to enable again.	
-	  ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
-	   if (ret != DEVICE_OK)
-         return ret;
-      
+            if (answer.length() != 3) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+            if (answer.substr(0, 3).compare("PUT") != 0) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+        } else if (command_.substr(0, 3) == "AES") {
+            // used issued STOP command
 
-     
-      ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);
-	   if (ret != DEVICE_OK)
-         return ret;
-      
+            // AES is cmd for emergency stop, stops the robot cold, issue DRT cmd to enable again
+            os << "AES";
 
-		if(answer.length()!=3 )
-			return ERR_UNRECOGNIZED_ANSWER;
-		if(answer.substr(0, 3).compare("AES") != 0)
-			return ERR_UNRECOGNIZED_ANSWER;
-	  }
-	  else if(command_.substr(0,3)=="DRT")// used issued STOP,
-	  {
-	  os<<"DRT";//used to over ride errors
-	  ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
-	   if (ret != DEVICE_OK)
-         return ret;
-      
+            ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
 
-     
-      ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);
-	   if (ret != DEVICE_OK)
-         return ret;
-      
+            ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
 
-		if(answer.length()!=3 )
-			return ERR_UNRECOGNIZED_ANSWER;
-		if(answer.substr(0, 3).compare("DRT") != 0)
-			return ERR_UNRECOGNIZED_ANSWER;
-	  }
+            if (answer.length() != 3) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+            if (answer.substr(0, 3).compare("AES") != 0) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+        } else if (command_.substr(0, 3) == "DRT") {
+            // user issued DRT command
 
+            // user to over ride errors
+            os << "DRT";
 
-   }
-   return DEVICE_OK;
+            ret = SendSerialCommand(port_.c_str(), os.str().c_str(), "\r\n");
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
+
+            ret = GetSerialAnswer(port_.c_str(), "\r\n", answer);
+            if (ret != DEVICE_OK) {
+                return ret;
+            }
+
+            if (answer.length() != 3) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+            if (answer.substr(0, 3).compare("DRT") != 0) {
+                return ERR_UNRECOGNIZED_ANSWER;
+            }
+        }
+    }
+    return DEVICE_OK;
 }
-

--- a/DeviceAdapters/ASIWPTR/wptr.h
+++ b/DeviceAdapters/ASIWPTR/wptr.h
@@ -32,16 +32,16 @@
 #include "MMDevice.h"
 
 // Error codes
-//#define ERR_UNKNOWN_POSITION         10002
-#define ERR_PORT_CHANGE_FORBIDDEN    10004
-#define ERR_INVALID_STEP_SIZE        10006
-#define ERR_INVALID_MODE             10008
-#define ERR_UNRECOGNIZED_ANSWER      10009
-#define ERR_UNSPECIFIED_ERROR        10010
+// constexpr int ERR_UNKNOWN_POSITION = 10002;
+constexpr int ERR_PORT_CHANGE_FORBIDDEN = 10004;
+constexpr int ERR_INVALID_STEP_SIZE = 10006;
+constexpr int ERR_INVALID_MODE = 10008;
+constexpr int ERR_UNRECOGNIZED_ANSWER = 10009;
+constexpr int ERR_UNSPECIFIED_ERROR = 10010;
 
-#define ERR_OFFSET 10100
+constexpr int ERR_OFFSET = 10100;
 
-int ClearPort(MM::Device& device, MM::Core& core, std::string port);
+int ClearPort(MM::Device& device, MM::Core& core, const std::string& port);
 
 class WPTRobot : public CGenericBase<WPTRobot> {
 public:

--- a/DeviceAdapters/ASIWPTR/wptr.h
+++ b/DeviceAdapters/ASIWPTR/wptr.h
@@ -6,7 +6,7 @@
 // DESCRIPTION:   RND's WTR controller adapter
 //
 // COPYRIGHT:     Applied Scientific Instrumentation, Eugene OR
-//				  Robots and Design Co, Ltd.	
+//                Robots and Design Co, Ltd.
 //                University of California, San Francisco
 //
 // LICENSE:       This file is distributed under the BSD license.
@@ -23,18 +23,15 @@
 // AUTHOR:         Vikram Kopuri, based on Code by Nenad Amodaj Nico Stuurman and Jizhen Zhao
 //
 
-#ifndef _wptr_H_
-#define _wptr_H_
+#ifndef ASIWPTR_H
+#define ASIWPTR_H
 
-#include "MMDevice.h"
-#include "DeviceBase.h"
 #include <string>
-#include <map>
 
-//////////////////////////////////////////////////////////////////////////////
+#include "DeviceBase.h"
+#include "MMDevice.h"
+
 // Error codes
-//
-
 //#define ERR_UNKNOWN_POSITION         10002
 #define ERR_PORT_CHANGE_FORBIDDEN    10004
 #define ERR_INVALID_STEP_SIZE        10006
@@ -46,33 +43,31 @@
 
 int ClearPort(MM::Device& device, MM::Core& core, std::string port);
 
-
-class WPTRobot : public CGenericBase<WPTRobot>
-{
+class WPTRobot : public CGenericBase<WPTRobot> {
 public:
-   WPTRobot();
-   ~WPTRobot();
+    WPTRobot();
+    ~WPTRobot();
 
-   //MMDevice API
-   bool Busy();
-   void GetName(char* pszName) const;
-   unsigned long GetNumberOfPositions()const {return numPos_;}
+    // MMDevice API
+    bool Busy();
+    void GetName(char* name) const;
+    unsigned long GetNumberOfPositions() const { return numPos_; }
 
-   int Initialize();
-   int Shutdown();
+    int Initialize();
+    int Shutdown();
 
-   int OnPort(MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnStage(MM::PropertyBase* pProp, MM::ActionType eAct); 
-   int OnSlot(MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnCommand(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnPort(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnStage(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnSlot(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnCommand(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
-   unsigned numPos_;
-   bool initialized_;                                                        
-  // MMCore name of serial port
-   std::string port_;
-   // Command exchange with MMCore
-   std::string command_;
-   long stage_ , slot_; 
+    bool initialized_;
+    unsigned int numPos_;
+    std::string port_;    // MMCore name of serial port
+    std::string command_; // Command exchange with MMCore
+    long stage_;
+    long slot_;
 };
-#endif //_wptr_H_
+
+#endif // ASIWPTR_H


### PR DESCRIPTION
Format code.

Initialize all variables in constructor of WPFRobot (fixes compiler warning).
Remove use of strcmp. 
Remove use of "using namespace std".
Use compare overload instead of substr.
Use constexpr instead of #define.