### PR TITLE
Fixed commands in CoherentOBIS DeviceAdapter.

### DIFF
--- a/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
+++ b/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
@@ -25,7 +25,6 @@
 #ifdef WIN32
    #include <windows.h>
 #endif
-#include "FixSnprintf.h"
 
 #include "CoherentOBIS.h"
 

--- a/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
+++ b/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
@@ -25,6 +25,7 @@
 #ifdef WIN32
    #include <windows.h>
 #endif
+#include "FixSnprintf.h"
 
 #include "CoherentOBIS.h"
 
@@ -116,8 +117,6 @@ CoherentObis::CoherentObis(const char* name) :
 
    CPropertyAction* pActDeviceIndex = new CPropertyAction(this, &CoherentObis::OnDeviceIndex);
    CreateProperty("DeviceIndex", "1", MM::Integer, false, pActDeviceIndex, true);
-   AddAllowedValue("DeviceIndex", "0");
-   AddAllowedValue("DeviceIndex", "1");
    UpdateStatus();
 }
 
@@ -233,12 +232,16 @@ int CoherentObis::Shutdown()
 
 std::string CoherentObis::getPrefix() const
 {
-   return deviceIndex_ == 0 ? "SYST" : "SYST1";
+    std::ostringstream oss;
+    oss << "SYST" << deviceIndex_;
+    return oss.str();
 }
 
 std::string CoherentObis::getPowerPrefix() const 
 {
-    return deviceIndex_ == 0 ? "SOUR" : "SOUR1";
+    std::ostringstream oss;
+    oss << "SOUR" << deviceIndex_;
+    return oss.str();
 }
 
 std::string CoherentObis::getPowerSetpointToken() const

--- a/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
+++ b/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
@@ -112,7 +112,7 @@ CoherentObis::CoherentObis(const char* name) :
 
    EnableDelay(); // signals that the delay setting will be used
 
-   // Default device index is 1 (uses SYST/SOUR)
+   // Default device index is 1 (uses SYST1/SOUR1)
    deviceIndex_ = 1;
 
    CPropertyAction* pActDeviceIndex = new CPropertyAction(this, &CoherentObis::OnDeviceIndex);

--- a/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
+++ b/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
@@ -112,7 +112,7 @@ CoherentObis::CoherentObis(const char* name) :
 
    EnableDelay(); // signals that the delay setting will be used
 
-   // Default device index is 0 (uses SYST/SOUR)
+   // Default device index is 1 (uses SYST/SOUR)
    deviceIndex_ = 1;
 
    CPropertyAction* pActDeviceIndex = new CPropertyAction(this, &CoherentObis::OnDeviceIndex);

--- a/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
+++ b/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
@@ -88,18 +88,18 @@ CoherentObis::CoherentObis(const char* name) :
    error_(0),
    changedTime_(0.0),
    queryToken_("?"),
-   powerSetpointToken_("SOUR1:POW:LEV:IMM:AMPL"),
-   powerReadbackToken_("SOUR1:POW:LEV:IMM:AMPL"),
+   powerSetpointToken_("SOUR:POW:LEV:IMM:AMPL"),
+   powerReadbackToken_("SOUR:POW:LEV:IMM:AMPL"),
    CDRHToken_("CDRH"),  // if this is on, laser delays 5 SEC before turning on
    CWToken_("CW"),
-   laserOnToken_("SOUR1:AM:STATE"),
+   laserOnToken_("SOUR:AM:STATE"),
    TECServoToken_("T"),
    headSerialNoToken_("SYST:INF:SNUM"),
-   headUsageHoursToken_("SYST1:DIOD:HOUR"),
-   wavelengthToken_("SYST1:INF:WAV"),
-   externalPowerControlToken_("SOUR1:POW:LEV:IMM:AMPL"),
-   maxPowerToken_("SOUR1:POW:LIM:HIGH"),
-   minPowerToken_("SOUR1:POW:LIM:LOW")
+   headUsageHoursToken_("SYST:DIOD:HOUR"),
+   wavelengthToken_("SYST:INF:WAV"),
+   externalPowerControlToken_("SOUR:POW:LEV:IMM:AMPL"),
+   maxPowerToken_("SOUR:POW:LIM:HIGH"),
+   minPowerToken_("SOUR:POW:LIM:LOW")
 {
    assert(strlen(name) < (unsigned int) MM::MaxStrLength);
 
@@ -155,9 +155,9 @@ int CoherentObis::Initialize()
 
 
    //Initialize laser??
-   setLaser("SYST1:COMM:HAND","On");
-   setLaser("SYST1:COMM:PROM","Off");
-   msg << "SYST1:ERR:CLE" ;
+   setLaser("SYST:COMM:HAND","On");
+   setLaser("SYST:COMM:PROM","Off");
+   msg << "SYST:ERR:CLE" ;
    Send(msg.str());
 
    // query laser for power limits

--- a/DeviceAdapters/CoherentOBIS/CoherentOBIS.h
+++ b/DeviceAdapters/CoherentOBIS/CoherentOBIS.h
@@ -83,9 +83,9 @@ public:
 
    void initLimits()
    {
-      std::string val = queryLaser(maxPowerToken_);
+      std::string val = queryLaser(getMaxPowerToken());
       minlp(atof(val.c_str())*1000);
-      val = queryLaser(maxPowerToken_);
+      val = queryLaser(getMaxPowerToken());
       maxlp(atof(val.c_str())*1000);
    }
 
@@ -109,6 +109,7 @@ public:
    // action interface
    // ----------------
    int OnPort(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnDeviceIndex(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnPowerSetpoint(MM::PropertyBase* pProp, MM::ActionType eAct, long index);
    int OnPowerReadback(MM::PropertyBase* pProp, MM::ActionType eAct, long index);
    int OnState(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -128,6 +129,7 @@ public:
 
 private:
    bool initialized_;
+   int deviceIndex_;
    long state_;
    std::string name_;
    int error_;
@@ -135,23 +137,26 @@ private:
 
    // todo move these to DevImpl for better data hiding
    const std::string queryToken_;
-   const std::string powerSetpointToken_;
-   const std::string powerReadbackToken_;
    const std::string CDRHToken_;  // if this is on, laser delays 5 SEC before turning on
    const std::string CWToken_;
-   const std::string laserOnToken_;
    const std::string TECServoToken_;
-   const std::string headSerialNoToken_;
-   const std::string headUsageHoursToken_;
-   const std::string wavelengthToken_;
-   const std::string externalPowerControlToken_;
-   const std::string maxPowerToken_;
-   const std::string minPowerToken_;
 
    std::string port_;
 
    string buf_string_;
 
+   std::string getPrefix() const;
+   std::string getPowerPrefix() const;
+   
+   std::string getPowerSetpointToken() const;
+   std::string getPowerReadbackToken() const;
+   std::string getLaserOnToken() const;
+   std::string getHeadSerialNoToken() const;
+   std::string getHeadUsageHoursToken() const;
+   std::string getWavelengthToken() const;
+   std::string getExternalPowerControlToken() const;
+   std::string getMaxPowerToken() const;
+   std::string getMinPowerToken() const;
 
    void SetPowerSetpoint(double powerSetpoint__, double& achievedSetpoint__);
    void GetPowerSetpoint(double& powerSetpoint__);


### PR DESCRIPTION
Addressing issues described in the following image.sc post: https://forum.image.sc/t/i-cannot-control-coherent-obis-laser-properly-with-micromanager/70937/8.

Using the CoherentOBIS LS/LX laser with micro-manager, the device reports a state of "2" (invalid) and repeatedly reverts to this state. With some testing and packet sniffing, it appears some commands that succeed in PuTTY-- with SYST: or SOUR:-- are sent to the device as SYST1: and SOUR1, causing the device errors and constant switching of states as the device can't be queried.

In the DeviceAdapter, these are hard-coded (SYST1 and SOUR1, with a strange comment "Initialize laser??"), not some enumeration. Fixing the DeviceAdapter and rebuilding with Device Interface 71 (the version our build is using) resolved our errors.

