### PR TITLE
Mock device adapters for MMCore unit testing

### DIFF
--- a/MMCore/LoadableModules/LoadedDeviceAdapterImpl.h
+++ b/MMCore/LoadableModules/LoadedDeviceAdapterImpl.h
@@ -1,0 +1,43 @@
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     MMCore
+//
+// COPYRIGHT:     University of California, San Francisco, 2013-2014
+//                2025, Board of Regents of the University of Wisconsin System
+//
+// LICENSE:       This file is distributed under the "Lesser GPL" (LGPL) license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// AUTHOR:        Mark Tsuchida
+
+#pragma once
+
+#include "../../MMDevice/MMDevice.h"
+
+
+class LoadedDeviceAdapterImpl
+{
+public:
+   virtual ~LoadedDeviceAdapterImpl() = default;
+
+   virtual void Unload() = 0;
+
+   // Wrappers around raw module interface functions
+   virtual void InitializeModuleData() = 0;
+   virtual long GetModuleVersion() const = 0;
+   virtual long GetDeviceInterfaceVersion() const = 0;
+   virtual unsigned GetNumberOfDevices() const = 0;
+   virtual bool GetDeviceName(unsigned index, char* buf, unsigned bufLen) const = 0;
+   virtual bool GetDeviceDescription(const char* deviceName,
+      char* buf, unsigned bufLen) const = 0;
+   virtual bool GetDeviceType(const char* deviceName, int* type) const = 0;
+   virtual MM::Device* CreateDevice(const char* deviceName) = 0;
+   virtual void DeleteDevice(MM::Device* device) = 0;
+};

--- a/MMCore/LoadableModules/LoadedDeviceAdapterImplMock.cpp
+++ b/MMCore/LoadableModules/LoadedDeviceAdapterImplMock.cpp
@@ -1,0 +1,81 @@
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     MMCore
+//
+// COPYRIGHT:     University of California, San Francisco, 2013-2014
+//                2025, Board of Regents of the University of Wisconsin System
+//
+// LICENSE:       This file is distributed under the "Lesser GPL" (LGPL) license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// AUTHOR:        Mark Tsuchida
+
+#include "LoadedDeviceAdapterImplMock.h"
+
+#include "../../MMDevice/MMDevice.h"
+#include "../../MMDevice/ModuleInterface.h"
+
+
+void LoadedDeviceAdapterImplMock::InitializeModuleData()
+{
+   impl_->InitializeModuleData(
+      [&](const char* name, MM::DeviceType type, const char* desc) {
+         registeredDevices_.RegisterDevice(name, type, desc);
+      });
+}
+
+
+long LoadedDeviceAdapterImplMock::GetModuleVersion() const
+{
+   return MODULE_INTERFACE_VERSION;
+}
+
+
+long LoadedDeviceAdapterImplMock::GetDeviceInterfaceVersion() const
+{
+   return DEVICE_INTERFACE_VERSION;
+}
+
+
+unsigned LoadedDeviceAdapterImplMock::GetNumberOfDevices() const
+{
+   return registeredDevices_.GetNumberOfDevices();
+}
+
+
+bool LoadedDeviceAdapterImplMock::GetDeviceName(unsigned index, char* buf, unsigned bufLen) const
+{
+   return registeredDevices_.GetDeviceName(index, buf, bufLen);
+}
+
+
+bool LoadedDeviceAdapterImplMock::GetDeviceDescription(const char* deviceName,
+   char* buf, unsigned bufLen) const
+{
+   return registeredDevices_.GetDeviceDescription(deviceName, buf, bufLen);
+}
+
+
+bool LoadedDeviceAdapterImplMock::GetDeviceType(const char* deviceName, int* type) const
+{
+   return registeredDevices_.GetDeviceType(deviceName, type);
+}
+
+
+MM::Device* LoadedDeviceAdapterImplMock::CreateDevice(const char* deviceName)
+{
+   return impl_->CreateDevice(deviceName);
+}
+
+
+void LoadedDeviceAdapterImplMock::DeleteDevice(MM::Device* device)
+{
+   return impl_->DeleteDevice(device);
+}

--- a/MMCore/LoadableModules/LoadedDeviceAdapterImplMock.h
+++ b/MMCore/LoadableModules/LoadedDeviceAdapterImplMock.h
@@ -1,0 +1,50 @@
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     MMCore
+//
+// COPYRIGHT:     University of California, San Francisco, 2013-2014
+//                2025, Board of Regents of the University of Wisconsin System
+//
+// LICENSE:       This file is distributed under the "Lesser GPL" (LGPL) license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// AUTHOR:        Mark Tsuchida
+
+#pragma once
+
+#include "LoadedDeviceAdapterImpl.h"
+
+#include "../MockDeviceAdapter.h"
+#include "../../MMDevice/RegisteredDeviceCollection.h"
+
+
+class LoadedDeviceAdapterImplMock : public LoadedDeviceAdapterImpl
+{
+public:
+   explicit LoadedDeviceAdapterImplMock(MockDeviceAdapter* impl)
+      : impl_(impl) {}
+
+   void Unload() override {};
+
+   void InitializeModuleData() override;
+   long GetModuleVersion() const override;
+   long GetDeviceInterfaceVersion() const override;
+   unsigned GetNumberOfDevices() const override;
+   bool GetDeviceName(unsigned index, char* buf, unsigned bufLen) const override;
+   bool GetDeviceDescription(const char* deviceName,
+      char* buf, unsigned bufLen) const override;
+   bool GetDeviceType(const char* deviceName, int* type) const override;
+   MM::Device* CreateDevice(const char* deviceName) override;
+   void DeleteDevice(MM::Device* device) override;
+
+private:
+   MockDeviceAdapter* impl_;
+   MM::internal::RegisteredDeviceCollection registeredDevices_;
+};

--- a/MMCore/LoadableModules/LoadedDeviceAdapterImplRegular.cpp
+++ b/MMCore/LoadableModules/LoadedDeviceAdapterImplRegular.cpp
@@ -1,0 +1,96 @@
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     MMCore
+//
+// COPYRIGHT:     University of California, San Francisco, 2013-2014
+//                2025, Board of Regents of the University of Wisconsin System
+//
+// LICENSE:       This file is distributed under the "Lesser GPL" (LGPL) license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// AUTHOR:        Mark Tsuchida
+
+#include "LoadedDeviceAdapterImplRegular.h"
+
+
+LoadedDeviceAdapterImplRegular::LoadedDeviceAdapterImplRegular(const std::string& filename)
+   : module_(std::make_unique<LoadedModule>(filename)),
+     InitializeModuleData_(reinterpret_cast<fnInitializeModuleData>(module_->GetFunction("InitializeModuleData"))),
+     CreateDevice_(reinterpret_cast<fnCreateDevice>(module_->GetFunction("CreateDevice"))),
+     DeleteDevice_(reinterpret_cast<fnDeleteDevice>(module_->GetFunction("DeleteDevice"))),
+     GetModuleVersion_(reinterpret_cast<fnGetModuleVersion>(module_->GetFunction("GetModuleVersion"))),
+     GetDeviceInterfaceVersion_(reinterpret_cast<fnGetDeviceInterfaceVersion>(module_->GetFunction("GetDeviceInterfaceVersion"))),
+     GetNumberOfDevices_(reinterpret_cast<fnGetNumberOfDevices>(module_->GetFunction("GetNumberOfDevices"))),
+     GetDeviceName_(reinterpret_cast<fnGetDeviceName>(module_->GetFunction("GetDeviceName"))),
+     GetDeviceType_(reinterpret_cast<fnGetDeviceType>(module_->GetFunction("GetDeviceType"))),
+     GetDeviceDescription_(reinterpret_cast<fnGetDeviceDescription>(module_->GetFunction("GetDeviceDescription")))
+{
+}
+
+
+void LoadedDeviceAdapterImplRegular::Unload()
+{
+   module_->Unload();
+}
+
+
+void LoadedDeviceAdapterImplRegular::InitializeModuleData()
+{
+   InitializeModuleData_();
+}
+
+
+long LoadedDeviceAdapterImplRegular::GetModuleVersion() const
+{
+   return GetModuleVersion_();
+}
+
+
+long LoadedDeviceAdapterImplRegular::GetDeviceInterfaceVersion() const
+{
+   return GetDeviceInterfaceVersion_();
+}
+
+
+unsigned LoadedDeviceAdapterImplRegular::GetNumberOfDevices() const
+{
+   return GetNumberOfDevices_();
+}
+
+
+bool LoadedDeviceAdapterImplRegular::GetDeviceName(unsigned index, char* buf, unsigned bufLen) const
+{
+   return GetDeviceName_(index, buf, bufLen);
+}
+
+
+bool LoadedDeviceAdapterImplRegular::GetDeviceDescription(const char* deviceName,
+   char* buf, unsigned bufLen) const
+{
+   return GetDeviceDescription_(deviceName, buf, bufLen);
+}
+
+
+bool LoadedDeviceAdapterImplRegular::GetDeviceType(const char* deviceName, int* type) const
+{
+   return GetDeviceType_(deviceName, type);
+}
+
+
+MM::Device* LoadedDeviceAdapterImplRegular::CreateDevice(const char* deviceName)
+{
+   return CreateDevice_(deviceName);
+}
+
+
+void LoadedDeviceAdapterImplRegular::DeleteDevice(MM::Device* device)
+{
+   DeleteDevice_(device);
+}

--- a/MMCore/LoadableModules/LoadedDeviceAdapterImplRegular.h
+++ b/MMCore/LoadableModules/LoadedDeviceAdapterImplRegular.h
@@ -1,0 +1,61 @@
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     MMCore
+//
+// COPYRIGHT:     University of California, San Francisco, 2013-2014
+//                2025, Board of Regents of the University of Wisconsin System
+//
+// LICENSE:       This file is distributed under the "Lesser GPL" (LGPL) license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// AUTHOR:        Mark Tsuchida
+
+#pragma once
+
+#include "LoadedDeviceAdapterImpl.h"
+
+#include "../../MMDevice/ModuleInterface.h"
+#include "LoadedModule.h"
+
+#include <memory>
+#include <string>
+
+
+class LoadedDeviceAdapterImplRegular : public LoadedDeviceAdapterImpl
+{
+public:
+   explicit LoadedDeviceAdapterImplRegular(const std::string& filename);
+
+   void Unload() override;
+
+   void InitializeModuleData() override;
+   long GetModuleVersion() const override;
+   long GetDeviceInterfaceVersion() const override;
+   unsigned GetNumberOfDevices() const override;
+   bool GetDeviceName(unsigned index, char* buf, unsigned bufLen) const override;
+   bool GetDeviceDescription(const char* deviceName,
+      char* buf, unsigned bufLen) const override;
+   bool GetDeviceType(const char* deviceName, int* type) const override;
+   MM::Device* CreateDevice(const char* deviceName) override;
+   void DeleteDevice(MM::Device* device) override;
+
+private:
+   std::unique_ptr<LoadedModule> module_;
+
+   fnInitializeModuleData InitializeModuleData_;
+   fnCreateDevice CreateDevice_;
+   fnDeleteDevice DeleteDevice_;
+   fnGetModuleVersion GetModuleVersion_;
+   fnGetDeviceInterfaceVersion GetDeviceInterfaceVersion_;
+   fnGetNumberOfDevices GetNumberOfDevices_;
+   fnGetDeviceName GetDeviceName_;
+   fnGetDeviceType GetDeviceType_;
+   fnGetDeviceDescription GetDeviceDescription_;
+};

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -8433,3 +8433,24 @@ std::string CMMCore::getInstalledDeviceDescription(const char* hubLabel, const c
    }
    return description.empty() ? "N/A" : description;
 }
+
+/**
+ * \brief Testing only: load a mock device adapter.
+ * 
+ * This function is designed for unit testing of MMCore itself, and its
+ * interface is subject to change. It is also not designed for language
+ * bindings (Java, Python) in mind (at least for now).
+ * 
+ * Do not use this in production code.
+ * 
+ * The caller is responsible for keeping \p implementation valid until this
+ * Core is destroyed (or until unloadLibrary(name) is called, but that is
+ * not recommended.)
+ */
+void CMMCore::loadMockDeviceAdapter(const char* name,
+      MockDeviceAdapter* implementation) throw (CMMError)
+{
+   if (!name)
+      throw CMMError("Null device adapter name");
+   pluginManager_->LoadMockAdapter(name, implementation);
+}

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -65,6 +65,7 @@
 #include "Error.h"
 #include "ErrorCodes.h"
 #include "Logging/Logger.h"
+#include "MockDeviceAdapter.h"
 
 #include <cstring>
 #include <deque>
@@ -671,6 +672,14 @@ public:
          const char* peripheralLabel) throw (CMMError);
    std::vector<std::string> getLoadedPeripheralDevices(const char* hubLabel) throw (CMMError);
    ///@}
+
+#if !defined(SWIGJAVA) && !defined(SWIGPYTHON)
+   /** \name Testing */
+   ///@{
+   void loadMockDeviceAdapter(const char* name,
+         MockDeviceAdapter* implementation) throw (CMMError);
+   ///@}
+#endif
 
 private:
    // make object non-copyable

--- a/MMCore/MMCore.vcxproj
+++ b/MMCore/MMCore.vcxproj
@@ -101,6 +101,7 @@
     <ClCompile Include="FrameBuffer.cpp" />
     <ClCompile Include="LibraryInfo\LibraryPathsWindows.cpp" />
     <ClCompile Include="LoadableModules\LoadedDeviceAdapter.cpp" />
+    <ClCompile Include="LoadableModules\LoadedDeviceAdapterImplMock.cpp" />
     <ClCompile Include="LoadableModules\LoadedDeviceAdapterImplRegular.cpp" />
     <ClCompile Include="LoadableModules\LoadedModule.cpp" />
     <ClCompile Include="LoadableModules\LoadedModuleImpl.cpp" />
@@ -148,6 +149,7 @@
     <ClInclude Include="LibraryInfo\LibraryPaths.h" />
     <ClInclude Include="LoadableModules\LoadedDeviceAdapter.h" />
     <ClInclude Include="LoadableModules\LoadedDeviceAdapterImpl.h" />
+    <ClInclude Include="LoadableModules\LoadedDeviceAdapterImplMock.h" />
     <ClInclude Include="LoadableModules\LoadedDeviceAdapterImplRegular.h" />
     <ClInclude Include="LoadableModules\LoadedModule.h" />
     <ClInclude Include="LoadableModules\LoadedModuleImpl.h" />
@@ -168,6 +170,7 @@
     <ClInclude Include="LogManager.h" />
     <ClInclude Include="MMCore.h" />
     <ClInclude Include="MMEventCallback.h" />
+    <ClInclude Include="MockDeviceAdapter.h" />
     <ClInclude Include="PluginManager.h" />
     <ClInclude Include="Semaphore.h" />
     <ClInclude Include="Task.h" />

--- a/MMCore/MMCore.vcxproj
+++ b/MMCore/MMCore.vcxproj
@@ -101,6 +101,7 @@
     <ClCompile Include="FrameBuffer.cpp" />
     <ClCompile Include="LibraryInfo\LibraryPathsWindows.cpp" />
     <ClCompile Include="LoadableModules\LoadedDeviceAdapter.cpp" />
+    <ClCompile Include="LoadableModules\LoadedDeviceAdapterImplRegular.cpp" />
     <ClCompile Include="LoadableModules\LoadedModule.cpp" />
     <ClCompile Include="LoadableModules\LoadedModuleImpl.cpp" />
     <ClCompile Include="LoadableModules\LoadedModuleImplWindows.cpp" />
@@ -146,6 +147,8 @@
     <ClInclude Include="FrameBuffer.h" />
     <ClInclude Include="LibraryInfo\LibraryPaths.h" />
     <ClInclude Include="LoadableModules\LoadedDeviceAdapter.h" />
+    <ClInclude Include="LoadableModules\LoadedDeviceAdapterImpl.h" />
+    <ClInclude Include="LoadableModules\LoadedDeviceAdapterImplRegular.h" />
     <ClInclude Include="LoadableModules\LoadedModule.h" />
     <ClInclude Include="LoadableModules\LoadedModuleImpl.h" />
     <ClInclude Include="LoadableModules\LoadedModuleImplWindows.h" />

--- a/MMCore/MMCore.vcxproj.filters
+++ b/MMCore/MMCore.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClCompile Include="Devices\VolumetricPumpInstance.cpp">
       <Filter>Source Files\Devices</Filter>
     </ClCompile>
+    <ClCompile Include="LoadableModules\LoadedDeviceAdapterImplRegular.cpp">
+      <Filter>Source Files\LoadableModules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CircularBuffer.h">
@@ -316,6 +319,12 @@
     </ClInclude>
     <ClInclude Include="Devices\PressurePumpInstance.h">
       <Filter>Header Files\Devices</Filter>
+    </ClInclude>
+    <ClInclude Include="LoadableModules\LoadedDeviceAdapterImpl.h">
+      <Filter>Header Files\LoadableModules</Filter>
+    </ClInclude>
+    <ClInclude Include="LoadableModules\LoadedDeviceAdapterImplRegular.h">
+      <Filter>Header Files\LoadableModules</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MMCore/MMCore.vcxproj.filters
+++ b/MMCore/MMCore.vcxproj.filters
@@ -150,6 +150,9 @@
     <ClCompile Include="LoadableModules\LoadedDeviceAdapterImplRegular.cpp">
       <Filter>Source Files\LoadableModules</Filter>
     </ClCompile>
+    <ClCompile Include="LoadableModules\LoadedDeviceAdapterImplMock.cpp">
+      <Filter>Source Files\LoadableModules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CircularBuffer.h">
@@ -324,6 +327,12 @@
       <Filter>Header Files\LoadableModules</Filter>
     </ClInclude>
     <ClInclude Include="LoadableModules\LoadedDeviceAdapterImplRegular.h">
+      <Filter>Header Files\LoadableModules</Filter>
+    </ClInclude>
+    <ClInclude Include="MockDeviceAdapter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="LoadableModules\LoadedDeviceAdapterImplMock.h">
       <Filter>Header Files\LoadableModules</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MMCore/Makefile.am
+++ b/MMCore/Makefile.am
@@ -69,6 +69,8 @@ libMMCore_la_SOURCES = \
 	LoadableModules/LoadedDeviceAdapter.cpp \
 	LoadableModules/LoadedDeviceAdapter.h \
 	LoadableModules/LoadedDeviceAdapterImpl.h \
+	LoadableModules/LoadedDeviceAdapterImplMock.cpp \
+	LoadableModules/LoadedDeviceAdapterImplMock.h \
 	LoadableModules/LoadedDeviceAdapterImplRegular.cpp \
 	LoadableModules/LoadedDeviceAdapterImplRegular.h \
 	LoadableModules/LoadedModule.cpp \
@@ -95,6 +97,7 @@ libMMCore_la_SOURCES = \
 	Logging/MetadataFormatter.h \
 	MMCore.cpp \
 	MMCore.h \
+	MockDeviceAdapter.h \
 	PluginManager.cpp \
 	PluginManager.h \
 	Semaphore.cpp \

--- a/MMCore/Makefile.am
+++ b/MMCore/Makefile.am
@@ -68,6 +68,9 @@ libMMCore_la_SOURCES = \
 	LibraryInfo/LibraryPathsUnix.cpp \
 	LoadableModules/LoadedDeviceAdapter.cpp \
 	LoadableModules/LoadedDeviceAdapter.h \
+	LoadableModules/LoadedDeviceAdapterImpl.h \
+	LoadableModules/LoadedDeviceAdapterImplRegular.cpp \
+	LoadableModules/LoadedDeviceAdapterImplRegular.h \
 	LoadableModules/LoadedModule.cpp \
 	LoadableModules/LoadedModule.h \
 	LoadableModules/LoadedModuleImpl.cpp \

--- a/MMCore/MockDeviceAdapter.h
+++ b/MMCore/MockDeviceAdapter.h
@@ -1,0 +1,33 @@
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     MMCore
+//
+// COPYRIGHT:     2025 Board of Regents of the University of Wisconsin System
+//
+// LICENSE:       This file is distributed under the "Lesser GPL" (LGPL) license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// AUTHOR:        Mark Tsuchida
+
+#pragma once
+
+#include "../MMDevice/MMDevice.h"
+
+#include <functional>
+
+// Derive from this class to create a mock device adapter implementation.
+// (For use by MMCore unit tests.)
+struct MockDeviceAdapter {
+   using RegisterDeviceFunc = std::function<void(const char*, MM::DeviceType, const char*)>;
+
+   virtual void InitializeModuleData(RegisterDeviceFunc registerDevice) = 0;
+   virtual MM::Device* CreateDevice(const char* name) = 0;
+   virtual void DeleteDevice(MM::Device* device) = 0;
+};

--- a/MMCore/PluginManager.cpp
+++ b/MMCore/PluginManager.cpp
@@ -36,6 +36,7 @@
 #include "Error.h"
 #include "LibraryInfo/LibraryPaths.h"
 #include "LoadableModules/LoadedDeviceAdapter.h"
+#include "LoadableModules/LoadedDeviceAdapterImplMock.h"
 #include "LoadableModules/LoadedDeviceAdapterImplRegular.h"
 #include "PluginManager.h"
 
@@ -163,6 +164,25 @@ CPluginManager::GetDeviceAdapter(const char* moduleName)
    }
    return GetDeviceAdapter(std::string(moduleName));
 }
+
+void
+CPluginManager::LoadMockAdapter(const std::string& name, MockDeviceAdapter* impl)
+{
+   if (name.empty())
+   {
+      throw CMMError("Empty device adapter module name");
+   }
+
+   auto it = moduleMap_.find(name);
+   if (it != moduleMap_.end())
+   {
+      throw CMMError("Device adapter with name " + ToQuotedString(name) + " is already loaded");
+   }
+
+   moduleMap_[name] = std::make_shared<LoadedDeviceAdapter>(
+      name, std::make_unique<LoadedDeviceAdapterImplMock>(impl));
+}
+
 
 /** 
  * Unload a module.

--- a/MMCore/PluginManager.h
+++ b/MMCore/PluginManager.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "MockDeviceAdapter.h"
 #include "../MMDevice/DeviceThreads.h"
 
 #include <map>
@@ -54,6 +55,8 @@ public:
    GetDeviceAdapter(const std::string& moduleName);
    std::shared_ptr<LoadedDeviceAdapter>
    GetDeviceAdapter(const char* moduleName);
+
+   void LoadMockAdapter(const std::string& name, MockDeviceAdapter* impl);
 
 private:
    static std::vector<std::string> GetDefaultSearchPaths();

--- a/MMCore/meson.build
+++ b/MMCore/meson.build
@@ -65,6 +65,7 @@ mmcore_sources = files(
     'LibraryInfo/LibraryPathsUnix.cpp',
     'LibraryInfo/LibraryPathsWindows.cpp',
     'LoadableModules/LoadedDeviceAdapter.cpp',
+    'LoadableModules/LoadedDeviceAdapterImplRegular.cpp',
     'LoadableModules/LoadedModule.cpp',
     'LoadableModules/LoadedModuleImpl.cpp',
     'LoadableModules/LoadedModuleImplUnix.cpp',

--- a/MMCore/meson.build
+++ b/MMCore/meson.build
@@ -65,6 +65,7 @@ mmcore_sources = files(
     'LibraryInfo/LibraryPathsUnix.cpp',
     'LibraryInfo/LibraryPathsWindows.cpp',
     'LoadableModules/LoadedDeviceAdapter.cpp',
+    'LoadableModules/LoadedDeviceAdapterImplMock.cpp',
     'LoadableModules/LoadedDeviceAdapterImplRegular.cpp',
     'LoadableModules/LoadedModule.cpp',
     'LoadableModules/LoadedModuleImpl.cpp',
@@ -93,6 +94,7 @@ mmcore_public_headers = files(
     'Logging/GenericMetadata.h',
     'MMCore.h',
     'MMEventCallback.h',
+    'MockDeviceAdapter.h',
 )
 # Note that the MMDevice headers are also needed; which of those are part of
 # MMCore's public interface is poorly defined at the moment.

--- a/MMCore/unittest/MockDeviceAdapter-Tests.cpp
+++ b/MMCore/unittest/MockDeviceAdapter-Tests.cpp
@@ -1,0 +1,43 @@
+#include <catch2/catch_all.hpp>
+
+#include "MMCore.h"
+#include "../../MMDevice/DeviceBase.h"
+
+class MyMockDevice : public CGenericBase<MyMockDevice> {
+public:
+   int Initialize() override { return DEVICE_OK; }
+   int Shutdown() override { return DEVICE_OK; }
+   bool Busy() override { return false; }
+   void GetName(char* name) const override {
+      snprintf(name, MM::MaxStrLength, "name-returned-by-device");
+   }
+};
+
+class MyMockAdapter : public MockDeviceAdapter {
+public:
+   void InitializeModuleData(RegisterDeviceFunc registerDevice) override {
+      registerDevice("mydevice", MM::GenericDevice, "my device description");
+   }
+
+   MM::Device* CreateDevice(const char* name) override {
+      CHECK(std::string(name) == "mydevice");
+      return new MyMockDevice();
+   }
+
+   void DeleteDevice(MM::Device* device) override {
+      delete device;
+   }
+};
+
+TEST_CASE("Register and load a mock device")
+{
+   MyMockAdapter adapter;
+
+   CMMCore c;
+   c.loadMockDeviceAdapter("myadapter", &adapter);
+   c.loadDevice("mylabel", "myadapter", "mydevice");
+   c.initializeDevice("mylabel");
+   c.waitForDevice("mylabel");
+   CHECK(c.getDeviceName("mylabel") == "name-returned-by-device");
+   c.unloadDevice("mylabel");
+}

--- a/MMCore/unittest/meson.build
+++ b/MMCore/unittest/meson.build
@@ -14,6 +14,7 @@ mmcore_test_sources = files(
     'CoreCreateDestroy-Tests.cpp',
     'Logger-Tests.cpp',
     'LoggingSplitEntryIntoLines-Tests.cpp',
+    'MockDeviceAdapter-Tests.cpp',
 )
 
 mmcore_test_exe = executable(

--- a/MMDevice/MMDevice-SharedRuntime.vcxproj
+++ b/MMDevice/MMDevice-SharedRuntime.vcxproj
@@ -29,6 +29,7 @@
     <ClInclude Include="MMDeviceConstants.h" />
     <ClInclude Include="ModuleInterface.h" />
     <ClInclude Include="Property.h" />
+    <ClInclude Include="RegisteredDeviceCollection.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B8C95F39-54BF-40A9-807B-598DF2821D55}</ProjectGuid>

--- a/MMDevice/MMDevice-SharedRuntime.vcxproj.filters
+++ b/MMDevice/MMDevice-SharedRuntime.vcxproj.filters
@@ -61,5 +61,8 @@
     <ClInclude Include="Property.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="RegisteredDeviceCollection.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/MMDevice/MMDevice-StaticRuntime.vcxproj
+++ b/MMDevice/MMDevice-StaticRuntime.vcxproj
@@ -29,6 +29,7 @@
     <ClInclude Include="MMDeviceConstants.h" />
     <ClInclude Include="ModuleInterface.h" />
     <ClInclude Include="Property.h" />
+    <ClInclude Include="RegisteredDeviceCollection.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{AF3143A4-5529-4C78-A01A-9F2A8977ED64}</ProjectGuid>

--- a/MMDevice/MMDevice-StaticRuntime.vcxproj.filters
+++ b/MMDevice/MMDevice-StaticRuntime.vcxproj.filters
@@ -61,5 +61,8 @@
     <ClInclude Include="Property.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="RegisteredDeviceCollection.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/MMDevice/Makefile.am
+++ b/MMDevice/Makefile.am
@@ -10,7 +10,8 @@ noinst_HEADERS = \
 	MMDevice.h \
 	MMDeviceConstants.h \
 	ModuleInterface.h \
-	Property.h
+	Property.h \
+	RegisteredDeviceCollection.h
 
 libMMDevice_la_SOURCES = \
 	$(noinst_HEADERS) \

--- a/MMDevice/RegisteredDeviceCollection.h
+++ b/MMDevice/RegisteredDeviceCollection.h
@@ -69,17 +69,17 @@ public:
       return static_cast<unsigned>(devices_.size());
    }
 
-   bool GetDeviceName(unsigned deviceIndex, char* name, unsigned bufLen) const
+   bool GetDeviceName(unsigned deviceIndex, char* name, unsigned bufSize) const
    {
       if (deviceIndex >= devices_.size())
          return false;
 
       const std::string& deviceName = devices_[deviceIndex].name;
 
-      if (deviceName.size() >= bufLen)
+      if (deviceName.size() >= bufSize)
          return false; // buffer too small, can't truncate the name
 
-      std::snprintf(name, bufLen, "%s", deviceName.c_str());
+      std::snprintf(name, bufSize, "%s", deviceName.c_str());
       return true;
    }
 
@@ -100,14 +100,14 @@ public:
       return true;
    }
 
-   bool GetDeviceDescription(const char* deviceName, char* description, unsigned bufLen) const
+   bool GetDeviceDescription(const char* deviceName, char* description, unsigned bufSize) const
    {
       auto it = std::find_if(devices_.begin(), devices_.end(),
          [&](const DeviceInfo& dev) { return dev.name == deviceName; });
       if (it == devices_.end())
          return false;
 
-      std::snprintf(description, bufLen, "%s", it->description.c_str());
+      std::snprintf(description, bufSize, "%s", it->description.c_str());
       return true;
    }
 };

--- a/MMDevice/RegisteredDeviceCollection.h
+++ b/MMDevice/RegisteredDeviceCollection.h
@@ -1,0 +1,116 @@
+///////////////////////////////////////////////////////////////////////////////
+// FILE:          RegisteredDeviceCollection.h
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     MMDevice - Device adapter kit
+//-----------------------------------------------------------------------------
+// COPYRIGHT:     University of California, San Francisco, 2006
+//                Board of Regents of the University of Wisconsin System, 2025
+// LICENSE:       This file is distributed under the BSD license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+// This header contains internal implementation of device registration.
+// Device adapter code must not use these definitions directly.
+
+#pragma once
+
+#include "MMDeviceConstants.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace MM {
+namespace internal {
+
+class RegisteredDeviceCollection
+{
+   struct DeviceInfo
+   {
+      std::string name;
+      MM::DeviceType type = MM::DeviceType::UnknownType;
+      std::string description;
+   };
+
+   std::vector<DeviceInfo> devices_;
+
+public:
+   void RegisterDevice(const char* deviceName, MM::DeviceType deviceType, const char* deviceDescription)
+   {
+      if (!deviceName)
+         return;
+
+      if (!deviceDescription)
+         // This is a bug; let the programmer know by displaying an ugly string
+         deviceDescription = "(Null description)";
+
+      auto it = std::find_if(devices_.begin(), devices_.end(),
+         [&](const DeviceInfo& dev) { return dev.name == deviceName; });
+      if (it != devices_.end())
+      {
+         // Device with this name already registered
+         // TODO This should be an error
+         return;
+      }
+
+      devices_.push_back(DeviceInfo{ deviceName, deviceType, deviceDescription });
+
+   }
+
+   unsigned GetNumberOfDevices() const
+   {
+      return static_cast<unsigned>(devices_.size());
+   }
+
+   bool GetDeviceName(unsigned deviceIndex, char* name, unsigned bufLen) const
+   {
+      if (deviceIndex >= devices_.size())
+         return false;
+
+      const std::string& deviceName = devices_[deviceIndex].name;
+
+      if (deviceName.size() >= bufLen)
+         return false; // buffer too small, can't truncate the name
+
+      std::snprintf(name, bufLen, "%s", deviceName.c_str());
+      return true;
+   }
+
+   bool GetDeviceType(const char* deviceName, int* type) const
+   {
+      auto it = std::find_if(devices_.begin(), devices_.end(),
+         [&](const DeviceInfo& dev) { return dev.name == deviceName; });
+      if (it == devices_.end())
+      {
+         *type = MM::UnknownType;
+         return false;
+      }
+
+      // Prefer int over enum across DLL boundary so that the module ABI does not
+      // change (somewhat pedantic, but let's be safe).
+      *type = static_cast<int>(it->type);
+
+      return true;
+   }
+
+   bool GetDeviceDescription(const char* deviceName, char* description, unsigned bufLen) const
+   {
+      auto it = std::find_if(devices_.begin(), devices_.end(),
+         [&](const DeviceInfo& dev) { return dev.name == deviceName; });
+      if (it == devices_.end())
+         return false;
+
+      std::snprintf(description, bufLen, "%s", it->description.c_str());
+      return true;
+   }
+};
+
+} // namespace internal
+} // namespace MM

--- a/MMDevice/meson.build
+++ b/MMDevice/meson.build
@@ -41,6 +41,7 @@ mmdevice_public_headers = files(
     'MMDeviceConstants.h',
     'ModuleInterface.h',
     'Property.h',
+    'RegisteredDeviceCollection.h',
 )
 # TODO Support installing public headers
 

--- a/MMDevice/unittest/RegisteredDeviceCollection-Tests.cpp
+++ b/MMDevice/unittest/RegisteredDeviceCollection-Tests.cpp
@@ -1,0 +1,83 @@
+#include <catch2/catch_all.hpp>
+
+#include "RegisteredDeviceCollection.h"
+
+namespace MM {
+namespace internal {
+
+TEST_CASE("RegisteredDeviceCollection empty") {
+   RegisteredDeviceCollection c;
+   CHECK(c.GetNumberOfDevices() == 0);
+   // Size-zero buffer is not touched
+   CHECK_FALSE(c.GetDeviceName(0, nullptr, 0));
+   CHECK_FALSE(c.GetDeviceDescription("nonexistent", nullptr, 0));
+   char buf[256];
+   CHECK_FALSE(c.GetDeviceName(0, buf, sizeof(buf)));
+   CHECK_FALSE(c.GetDeviceDescription("nonexistent", buf, sizeof(buf)));
+   int typ = 42;
+   CHECK_FALSE(c.GetDeviceType("nonexistent", &typ));
+   CHECK(typ == MM::UnknownType);
+}
+
+TEST_CASE("RegisteredDeviceCollection single device returns correct info") {
+   RegisteredDeviceCollection c;
+   c.RegisterDevice("name", MM::ShutterDevice, "description");
+   CHECK(c.GetNumberOfDevices() == 1);
+
+   // Size-zero buffer is not touched
+   CHECK_FALSE(c.GetDeviceName(0, nullptr, 0));
+   // Description truncation is not an error
+   CHECK(c.GetDeviceDescription("name", nullptr, 0));
+
+   char buf[12];
+   CHECK_FALSE(c.GetDeviceName(0, buf, 4));
+   CHECK(c.GetDeviceName(0, buf, 5));
+   CHECK(std::string(buf) == "name");
+   CHECK_FALSE(c.GetDeviceName(1, buf, 11));
+
+   CHECK(c.GetDeviceDescription("name", buf, 5));
+   CHECK(std::string(buf) == "desc");
+   CHECK(c.GetDeviceDescription("name", buf, 12));
+   CHECK(std::string(buf) == "description");
+   CHECK_FALSE(c.GetDeviceDescription("nonexistent", buf, 12));
+
+   int typ = 42;
+   CHECK(c.GetDeviceType("name", &typ));
+   CHECK(typ == MM::ShutterDevice);
+   CHECK_FALSE(c.GetDeviceType("nonexistent", &typ));
+   CHECK(typ == MM::UnknownType);
+}
+
+TEST_CASE("RegisteredDeviceCollection multiple devices return correct info") {
+   RegisteredDeviceCollection c;
+   c.RegisterDevice("lucky-ferret", MM::ShutterDevice, "A shutter");
+   c.RegisterDevice("bright-gnu", MM::CameraDevice, "The Camera");
+   c.RegisterDevice("tender-dodo", MM::StageDevice, "Let me focus");
+   CHECK(c.GetNumberOfDevices() == 3);
+
+   char buf[256];
+   CHECK(c.GetDeviceName(0, buf, sizeof(buf)));
+   CHECK(std::string(buf) == "lucky-ferret");
+   CHECK(c.GetDeviceName(1, buf, sizeof(buf)));
+   CHECK(std::string(buf) == "bright-gnu");
+   CHECK(c.GetDeviceName(2, buf, sizeof(buf)));
+   CHECK(std::string(buf) == "tender-dodo");
+
+   CHECK(c.GetDeviceDescription("lucky-ferret", buf, sizeof(buf)));
+   CHECK(std::string(buf) == "A shutter");
+   CHECK(c.GetDeviceDescription("bright-gnu", buf, sizeof(buf)));
+   CHECK(std::string(buf) == "The Camera");
+   CHECK(c.GetDeviceDescription("tender-dodo", buf, sizeof(buf)));
+   CHECK(std::string(buf) == "Let me focus");
+
+   int typ;
+   CHECK(c.GetDeviceType("lucky-ferret", &typ));
+   CHECK(typ == MM::ShutterDevice);
+   CHECK(c.GetDeviceType("bright-gnu", &typ));
+   CHECK(typ == MM::CameraDevice);
+   CHECK(c.GetDeviceType("tender-dodo", &typ));
+   CHECK(typ == MM::StageDevice);
+}
+
+} // namespace internal
+} // namespace MM

--- a/MMDevice/unittest/meson.build
+++ b/MMDevice/unittest/meson.build
@@ -13,6 +13,7 @@ mmdevice_test_sources = files(
     'DeviceUtils-Tests.cpp',
     'FloatPropertyTruncation-Tests.cpp',
     'MMTime-Tests.cpp',
+    'RegisteredDeviceCollection-Tests.cpp',
 )
 
 mmdevice_test_exe = executable(


### PR DESCRIPTION
One of the main reasons we haven't added more unit tests for MMCore has been that most things cannot be tested without loading devices, but using any given device adapter (whether DemoCamera or SequenceTester) is too indirect, inflexible, and fragile.

This PR adds the ability to create ad-hoc, purpose-crafted mock device adapters in C++ unit tests. Tests can directly interact with such self-created mocks to ensure that MMCore is interacting with devices as expected.

There might be future extensions of this that allow testing via (Python/Java) language bindings, etc., but for now, it is a minimum implementation intended only for unit tests written in C++.

TODO:

- [x] It currently segfaults; debug
- [x] Make sure I haven't broken regular device adapter loading
- [x] Make sure adding this doesn't break or contaminate the SWIG bindings (MMCoreJ, pymmcore)
