### PR TITLE
PCO: avoid truncation in division in OnExposure.

### DIFF
--- a/DeviceAdapters/PCO_Generic/MicroManager.cpp
+++ b/DeviceAdapters/PCO_Generic/MicroManager.cpp
@@ -334,7 +334,7 @@ int CPCOCam::OnCCDType(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CPCOCam::OnExposure(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-  int tb[3] = {1000000, 1000, 1};
+  double tb[3] = {1000000.0, 1000.0, 1.0};
   if(eAct == MM::BeforeGet)
   {
     if(m_pCamera->m_iCamClass == 3)
@@ -2181,7 +2181,7 @@ int CPCOCam::ClearROI()
 
 void CPCOCam::SetExposure(double dExp)
 {
-  SetProperty(MM::g_Keyword_Exposure, CDeviceUtils::ConvertToString(dExp));
+  SetProperty(MM::g_Keyword_Exposure, std::to_string(dExp).c_str());
 }
 
 int CPCOCam::ResizeImageBuffer()
@@ -2499,7 +2499,6 @@ int CPCOCam::SequenceThread::svc()
       err = 1;
       break;
     }
-    //CDeviceUtils::SleepMs(20);
     count = camera_->m_iNumImagesInserted;
     ReleaseMutex(camera_->mxMutex);
   }


### PR DESCRIPTION
Also replace buggy CDeviceUtils::ConvertToString with std__toString.