### PR TITLE
Fix OpenUC2 build for case sensitive file systems

### DIFF
--- a/DeviceAdapters/OpenUC2/Shutter.h
+++ b/DeviceAdapters/OpenUC2/Shutter.h
@@ -3,7 +3,7 @@
 
 
 #include "DeviceBase.h"
-#include "openUC2.h"
+#include "openuc2.h"
 #include <string>
 
 class UC2Hub;

--- a/DeviceAdapters/OpenUC2/UC2hub.cpp
+++ b/DeviceAdapters/OpenUC2/UC2hub.cpp
@@ -1,5 +1,5 @@
 
-#include "openUC2.h"
+#include "openuc2.h"
 #include "UC2Hub.h"
 #include "ModuleInterface.h"
 

--- a/DeviceAdapters/OpenUC2/XYStage.h
+++ b/DeviceAdapters/OpenUC2/XYStage.h
@@ -2,7 +2,7 @@
 #define _OPENUC2_XYSTAGE_H_
 
 #include "DeviceBase.h"
-#include "openUC2.h"
+#include "openuc2.h"
 #include <string>
 
 class UC2Hub;

--- a/DeviceAdapters/OpenUC2/ZStage.h
+++ b/DeviceAdapters/OpenUC2/ZStage.h
@@ -2,7 +2,7 @@
 #define _OPENUC2_ZSTAGE_H_
 
 #include "DeviceBase.h"
-#include "openUC2.h"
+#include "openuc2.h"
 #include <string>
 
 class UC2Hub;

--- a/DeviceAdapters/OpenUC2/openUC2.vcxproj
+++ b/DeviceAdapters/OpenUC2/openUC2.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Headers -->
-    <ClInclude Include="openUC2.h" />
+    <ClInclude Include="openuc2.h" />
     <ClInclude Include="UC2Hub.h" />
     <ClInclude Include="XYStage.h" />
     <ClInclude Include="ZStage.h" />

--- a/DeviceAdapters/OpenUC2/openUC2.vcxproj.filters
+++ b/DeviceAdapters/OpenUC2/openUC2.vcxproj.filters
@@ -15,7 +15,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="openUC2.h">
+    <ClInclude Include="openuc2.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="UC2Hub.h">

--- a/DeviceAdapters/OpenUC2/openuc2.cpp
+++ b/DeviceAdapters/OpenUC2/openuc2.cpp
@@ -1,4 +1,4 @@
-#include "openUC2.h"
+#include "openuc2.h"
 #include "UC2Hub.h"
 #include "XYStage.h"
 #include "ZStage.h"


### PR DESCRIPTION
@beniroquai @marktsuchida 
I was getting build errors that the compiler couldn't find `openUC2.h`.  I noticed that it didn't exist, but `openuc2.h` did (same for .cpp).  I renamed the files and corrected the Makefile accordingly. 