### PR TITLE
MMCore: Add tests for pixel size/affine scaling

### DIFF
--- a/MMCore/unittest/MockDeviceAdapter-Tests.cpp
+++ b/MMCore/unittest/MockDeviceAdapter-Tests.cpp
@@ -1,7 +1,9 @@
 #include <catch2/catch_all.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "MMCore.h"
 #include "../../MMDevice/DeviceBase.h"
+#include "MockDeviceUtils.h"
 
 class MyMockDevice : public CGenericBase<MyMockDevice> {
 public:
@@ -40,4 +42,20 @@ TEST_CASE("Register and load a mock device")
    c.waitForDevice("mylabel");
    CHECK(c.getDeviceName("mylabel") == "name-returned-by-device");
    c.unloadDevice("mylabel");
+}
+
+TEST_CASE("Create mock devices using MockAdapterWithDevices convenience class") {
+   MyMockDevice dev1;
+   MyMockDevice dev2;
+   MockAdapterWithDevices adapter{
+      {"dev1", &dev1},
+      {"dev2", &dev2},
+   };
+
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+
+   using Catch::Matchers::ContainsSubstring;
+   CHECK_THAT(c.getDeviceDescription("dev1"), ContainsSubstring("dev1"));
+   CHECK_THAT(c.getDeviceDescription("dev2"), ContainsSubstring("dev2"));
 }

--- a/MMCore/unittest/MockDeviceUtils.h
+++ b/MMCore/unittest/MockDeviceUtils.h
@@ -1,0 +1,53 @@
+#include "MMCore.h"
+
+#include <initializer_list>
+#include <utility>
+#include <string>
+
+// A mock device adapter that provides the device(s) passed in at construction.
+// This is intended for tests where we're not testing device creation and
+// destruction, and each device is only loaded once. This class does not own
+// the devices; the caller is responsible for that (usually, the devices should
+// just be created on the stack).
+class MockAdapterWithDevices : public MockDeviceAdapter {
+   std::string adapter_name = "mock_adapter";
+   std::vector<std::pair<std::string, MM::Device*>> devices;
+
+public:
+   explicit MockAdapterWithDevices(
+      std::initializer_list<std::pair<std::string, MM::Device*>> il)
+      : devices(il) {}
+
+   void InitializeModuleData(RegisterDeviceFunc registerDevice) override {
+      for (auto name_device : devices) {
+         const auto name = name_device.first;
+         const auto device = name_device.second;
+         const auto desc = "description for " + name;
+         registerDevice(name.c_str(), device->GetType(), desc.c_str());
+      }
+   }
+
+   MM::Device *CreateDevice(const char *name) override {
+      for (auto name_device : devices) {
+         if (name_device.first == name) {
+            return name_device.second;
+         }
+      }
+      return nullptr;
+   }
+
+   void DeleteDevice(MM::Device *device) override {}
+
+   // Convenience for loading all the devices
+   void LoadIntoCore(CMMCore &core) {
+      core.loadMockDeviceAdapter(adapter_name.c_str(), this);
+      for (auto name_device : devices) {
+         const auto name = name_device.first;
+         core.loadDevice(name.c_str(), adapter_name.c_str(), name.c_str());
+      }
+      for (auto name_device : devices) {
+         const auto name = name_device.first;
+         core.initializeDevice(name.c_str());
+      }
+   }
+};

--- a/MMCore/unittest/PixelSize-Tests.cpp
+++ b/MMCore/unittest/PixelSize-Tests.cpp
@@ -1,0 +1,143 @@
+#include <catch2/catch_all.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
+
+#include "MMCore.h"
+#include "../../MMDevice/DeviceBase.h"
+#include "MockDeviceUtils.h"
+
+namespace {
+
+class MockMagnifier : public CMagnifierBase<MockMagnifier> {
+   double mag;
+
+public:
+   explicit MockMagnifier(double mag) : mag(mag) {}
+
+   int Initialize() override { return DEVICE_OK; }
+   int Shutdown() override { return DEVICE_OK; }
+   bool Busy() override { return false; }
+   void GetName(char* name) const override {
+      snprintf(name, MM::MaxStrLength, "MockMagnifier");
+   }
+   double GetMagnification() override {
+      return mag;
+   }
+};
+
+class MockCamera : public CCameraBase<MockCamera> {
+   int binning;
+
+public:
+   explicit MockCamera(int binning) : binning(binning) {}
+
+   int Initialize() override { return DEVICE_OK; }
+   int Shutdown() override { return DEVICE_OK; }
+   bool Busy() override { return false; }
+   void GetName(char* name) const override {
+      snprintf(name, MM::MaxStrLength, "MockCamera");
+   }
+
+   int SnapImage() override { return DEVICE_ERR; }
+   const unsigned char* GetImageBuffer() override { return nullptr; }
+   long GetImageBufferSize() const override { return 0; }
+   unsigned GetImageWidth() const override { return 0; }
+   unsigned GetImageHeight() const override { return 0; }
+   unsigned GetImageBytesPerPixel() const override { return 0; }
+   unsigned GetBitDepth() const override { return 0; }
+   int GetBinning() const override { return binning; }
+   int SetBinning(int) override { return DEVICE_ERR; }
+   void SetExposure(double) override { FAIL(); }
+   double GetExposure() const override { return 0.0; }
+   int SetROI(unsigned, unsigned, unsigned, unsigned) override { return DEVICE_ERR; }
+   int GetROI(unsigned&, unsigned&, unsigned&, unsigned&) override { return DEVICE_ERR; }
+   int ClearROI() override { return DEVICE_ERR; }
+   int IsExposureSequenceable(bool&) const override { return DEVICE_ERR; }
+};
+
+}
+
+TEST_CASE("Pixel size and affine matrix are unscaled with no magnifier or camera") {
+   const char* resID = "res0";
+   std::vector<double> matrix = {
+      0.9, 0.1, 0.5,
+      0.2, 1.1, -0.5,
+      // 0.0, 0.0, 1.0,
+   };
+
+   CMMCore c;
+   c.definePixelSizeConfig(resID);
+   c.setPixelSizeUm(resID, 0.95);
+   c.setPixelSizeAffine(resID, matrix);
+   c.setPixelSizeConfig(resID);
+
+   CHECK(c.getPixelSizeUm(false) == 0.95);
+   CHECK(c.getPixelSizeAffine(false) == matrix);
+}
+
+TEST_CASE("Pixel size and affine matrix are scaled by magnification") {
+   MockMagnifier mag0(2.0);
+   MockMagnifier mag1(3.0);
+   MockAdapterWithDevices adapter{
+      {"mag0", &mag0},
+      {"mag1", &mag1},
+   };
+
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+
+   const char* resID = "res0";
+   std::vector<double> matrix = {
+      0.9, 0.1, 0.5,
+      0.2, 1.1, -0.5,
+   };
+
+   c.definePixelSizeConfig(resID);
+   c.setPixelSizeUm(resID, 0.95);
+   c.setPixelSizeAffine(resID, matrix);
+   c.setPixelSizeConfig(resID);
+
+   // Scaling the affine matrix just applies the scaling to the linear part and
+   // the translation part -- so all elements are scaled equally.
+   auto scaledMatrix = matrix;
+   for (auto& v : scaledMatrix) {
+      v /= 6.0;
+   }
+
+   CHECK_THAT(c.getPixelSizeUm(false),
+      Catch::Matchers::WithinAbs(0.95 / 6.0, 1e-9));
+   CHECK_THAT(c.getPixelSizeAffine(false),
+      Catch::Matchers::Approx(scaledMatrix).margin(1e-9));
+}
+
+TEST_CASE("Pixel size and affine matrix are scaled by camera binning") {
+   MockCamera cam(4);
+   MockAdapterWithDevices adapter{
+      {"cam", &cam},
+   };
+
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("cam");
+
+   const char* resID = "res0";
+   std::vector<double> matrix = {
+      0.9, 0.1, 0.5,
+      0.2, 1.1, -0.5,
+   };
+
+   c.definePixelSizeConfig(resID);
+   c.setPixelSizeUm(resID, 0.95);
+   c.setPixelSizeAffine(resID, matrix);
+   c.setPixelSizeConfig(resID);
+
+   auto scaledMatrix = matrix;
+   for (auto& v : scaledMatrix) {
+      v *= 4.0;
+   }
+
+   CHECK_THAT(c.getPixelSizeUm(false),
+      Catch::Matchers::WithinAbs(0.95 * 4.0, 1e-9));
+   CHECK_THAT(c.getPixelSizeAffine(false),
+      Catch::Matchers::Approx(scaledMatrix).margin(1e-9));
+}

--- a/MMCore/unittest/meson.build
+++ b/MMCore/unittest/meson.build
@@ -15,6 +15,7 @@ mmcore_test_sources = files(
     'Logger-Tests.cpp',
     'LoggingSplitEntryIntoLines-Tests.cpp',
     'MockDeviceAdapter-Tests.cpp',
+    'PixelSize-Tests.cpp',
 )
 
 mmcore_test_exe = executable(


### PR DESCRIPTION
For the benefit of #658.

Adds a convenience class for mock device adapters. We need to further reduce boilerplate for mock devices, but perhaps after we have a few more tests of the same sort.