### PR TITLE
ZeissCAN29: Clang needs forward declaration

### DIFF
--- a/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
+++ b/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
@@ -360,6 +360,9 @@ class ColibriModel
 };
 
 
+class ZeissPositionReporter;
+
+
 class ZeissHub
 {
    friend class ZeissScope;


### PR DESCRIPTION
Apparently the friend declaration is enough for MSVC but not (Apple) Clang.

Fix for #663.