### PR TITLE
Update core properties after unloading a device

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -781,6 +781,8 @@ void CMMCore::unloadDevice(const char* label///< the name of the device to unloa
       LOG_DEBUG(coreLogger_) << "Will unload device " << label;
       deviceManager_->UnloadDevice(pDevice);
       LOG_DEBUG(coreLogger_) << "Did unload device " << label;
+      
+      updateCoreProperties();
    }
    catch (CMMError& err) {
       logError("MMCore::unloadDevice", err.getMsg().c_str());


### PR DESCRIPTION
found another inconsistency between core properties and core state:

```python
>>> core = CMMCorePlus()
>>> core.loadSystemConfiguration()
>>> core.getProperty('Core', 'Shutter')
'White Light Shutter'

>>> core.unloadDevice('White Light Shutter')
>>> core.getProperty('Core', 'Shutter')
'White Light Shutter'

>>> core = CMMCorePlus()
>>> core.loadSystemConfiguration()
>>> core.getAllowedPropertyValues('Core', 'Shutter')
('', 'LED Shutter', 'White Light Shutter')
>>> core.unloadDevice('LED Shutter')
>>> core.getAllowedPropertyValues('Core', 'Shutter')
('', 'LED Shutter', 'White Light Shutter')
>>> core.setProperty('Core', 'Shutter', 'LED Shutter')
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[13], line 1
----> 1 core.setProperty('Core', 'Shutter', 'LED Shutter')

File ~/dev/self/pymmcore-widgets/.venv/lib/python3.12/site-packages/pymmcore_plus/core/_mmcore_plus.py:359, in CMMCorePlus.setProperty(self, label, propName, propValue)
    350 """Set property named `propName` on device `label` to `propValue`.
    351 
    352 **Why Override?**  In `MMCore`, the calling of the `onPropertyChanged`
   (...)    356 and the property Value has actually changed.
    357 """
    358 with self._property_change_emission_ensured(label, (propName,)):
--> 359     super().setProperty(label, propName, propValue)

RuntimeError: No device with label "LED Shutter"
```