### PR TITLE
Prevent `boost::bind` warning on `_1`, ` _2`, ...

### DIFF
--- a/DeviceAdapters/DirectElectron/src/DEClientLib/DENetwork.cpp
+++ b/DeviceAdapters/DirectElectron/src/DEClientLib/DENetwork.cpp
@@ -1,9 +1,9 @@
 #include "DENetwork.h"
 #include "DEExceptions.h"
 
-#include <boost/bind.hpp>
 #include <boost/asio.hpp>
 #include <boost/array.hpp>
+#include <boost/bind/bind.hpp>
 
 template <typename T>
 boost::asio::io_service& GetIoService(T* s) {
@@ -93,6 +93,7 @@ void DENetwork::setResult(optional<boost::system::error_code>* a, const boost::s
 bool DENetwork::send(void* data, std::size_t size, unsigned long timeout)
 {
 	using namespace boost; 
+	using namespace boost::placeholders;
 
 	optional<boost::system::error_code> timeout_result;
 	optional<boost::system::error_code> write_result;
@@ -143,6 +144,7 @@ bool DENetwork::send(void* data, std::size_t size, unsigned long timeout)
 bool DENetwork::receive(void* data, std::size_t size, unsigned long timeout)
 {
 	using namespace boost; 
+	using namespace boost::placeholders;
 
 	optional<boost::system::error_code> timeout_result;
 	optional<boost::system::error_code> read_result;

--- a/DeviceAdapters/IIDC/IIDCCamera.cpp
+++ b/DeviceAdapters/IIDC/IIDCCamera.cpp
@@ -25,7 +25,7 @@
 #include "IIDCVendorAVT.h"
 #include "IIDCVideoMode.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include <boost/version.hpp>
@@ -714,6 +714,7 @@ Camera::StartContinuousCapture(uint32_t nrDMABuffers, size_t nrFrames,
       FrameCallbackFunction frameCallback,
       FinishCallbackFunction finishCallback)
 {
+   using namespace boost::placeholders;
    EnsureReadyForCapture();
 
    captureFrameCallback_ = frameCallback;
@@ -732,6 +733,7 @@ Camera::StartMultiShotCapture(uint32_t nrDMABuffers, uint16_t nrFrames,
       FrameCallbackFunction frameCallback,
       FinishCallbackFunction finishCallback)
 {
+   using namespace boost::placeholders;
    EnsureReadyForCapture();
 
    if (!IsMultiShotCapable())
@@ -752,6 +754,7 @@ Camera::StartOneShotCapture(uint32_t nrDMABuffers, unsigned timeoutMs,
       FrameCallbackFunction frameCallback,
       FinishCallbackFunction finishCallback)
 {
+   using namespace boost::placeholders;
    EnsureReadyForCapture();
 
    if (!IsOneShotCapable())

--- a/DeviceAdapters/IIDC/MMIIDCCamera.cpp
+++ b/DeviceAdapters/IIDC/MMIIDCCamera.cpp
@@ -44,7 +44,7 @@
 #include <unistd.h> // swab()
 #endif
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
@@ -491,6 +491,7 @@ MMIIDCCamera::Initialize()
 
    try
    {
+      using namespace boost::placeholders;
       // We use this device for MMCore logging, if this is the first device.
       hub_ = MMIIDCHub::GetInstance(
             boost::bind(&MMIIDCCamera::LogIIDCMessage, this, _1, _2));
@@ -619,6 +620,7 @@ MMIIDCCamera::SnapImage()
 
    try
    {
+      using namespace boost::placeholders;
       if (iidcCamera_->IsOneShotCapable())
          iidcCamera_->StartOneShotCapture(3, timeoutMs,
                boost::bind(&MMIIDCCamera::SnapCallback, this, _1, _2, _3, _4, _5),
@@ -908,6 +910,7 @@ MMIIDCCamera::StartSequenceAcquisition(long count, double /*intervalMs*/, bool s
 
    try
    {
+      using namespace boost::placeholders;
       if (iidcCamera_->IsMultiShotCapable() && count < 65536)
       {
          iidcCamera_->StartMultiShotCapture(16, static_cast<uint16_t>(count), timeoutMs,
@@ -2024,6 +2027,7 @@ void
 MMIIDCCamera::SnapCallback(const void* pixels, size_t width, size_t height,
    IIDC::PixelFormat format, uint32_t timestampUs)
 {
+   using namespace boost::placeholders;
    // Request that the callback be passed an owned pixel buffer
    ProcessImage(pixels, true, format, width, height,
          softROILeft_, softROITop_, roiWidth_, roiHeight_,
@@ -2037,6 +2041,7 @@ void
 MMIIDCCamera::SequenceCallback(const void* pixels, size_t width, size_t height,
    IIDC::PixelFormat format, uint32_t timestampUs)
 {
+   using namespace boost::placeholders;
    // Request that the callback be passed an unowned pixel buffer, since the
    // pixels will be copied to the Core
    ProcessImage(pixels, false, format, width, height,

--- a/DeviceAdapters/SequenceTester/SequenceTester.cpp
+++ b/DeviceAdapters/SequenceTester/SequenceTester.cpp
@@ -26,7 +26,6 @@
 
 #include "ModuleInterface.h"
 
-#include <boost/bind/bind.hpp>
 #include <boost/move/move.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>
@@ -439,8 +438,9 @@ TesterCamera::StartSequenceAcquisitionImpl(bool finite, long count,
 
    // Note: boost::packaged_task<void ()> in more recent versions of Boost.
    boost::packaged_task<void> captureTask(
-         boost::bind(&TesterCamera::SendSequence, this,
-            finite, count, stopOnOverflow));
+         [this, finite, count, stopOnOverflow] {
+            SendSequence(finite, count, stopOnOverflow);
+         });
    sequenceFuture_ = captureTask.get_future();
 
    boost::thread captureThread(boost::move(captureTask));
@@ -895,8 +895,7 @@ TesterAutofocus::Initialize()
    incrementalFocus_->SetBusySetting(GetBusySetting());
 
    linkedZStage_ = StringSetting::New(GetLogger(), this, "LinkedZStage");
-   linkedZStage_->GetPostSetSignal().connect(
-         boost::bind(&Self::UpdateZStageLink, this));
+   linkedZStage_->GetPostSetSignal().connect([this]{ UpdateZStageLink(); });
    CreateStringProperty("LinkedZStage", linkedZStage_);
 
    setZDisablesContinuousFocus_ = BoolSetting::New(GetLogger(), this,
@@ -1022,7 +1021,7 @@ TesterAutofocus::UpdateZStageLink()
       return;
 
    zStageConnection_ = zPosUm->GetPostSetSignal().connect(
-         boost::bind(&Self::HandleLinkedZStageSetPosition, this));
+         [this] { HandleLinkedZStageSetPosition(); });
 }
 
 

--- a/DeviceAdapters/SequenceTester/TriggerInput.cpp
+++ b/DeviceAdapters/SequenceTester/TriggerInput.cpp
@@ -24,7 +24,6 @@
 #include "TriggerInput.h"
 #include "SequenceTester.h"
 
-#include <boost/bind/bind.hpp>
 #include <string>
 
 
@@ -38,12 +37,12 @@ TriggerInput::Initialize(InterDevice::Ptr device,
    triggerSourceDevice_ = StringSetting::New(device_->GetLogger(),
          device_.get(), settingNamePrefix_ + "TriggerSourceDevice");
    triggerSourceDevice_->GetPostSetSignal().connect(
-         boost::bind(&TriggerInput::UpdateTriggerConnection, this));
+         [this] { UpdateTriggerConnection(); });
 
    triggerSourcePort_ = StringSetting::New(device_->GetLogger(),
          device_.get(), settingNamePrefix_ + "TriggerSourcePort");
    triggerSourcePort_->GetPostSetSignal().connect(
-         boost::bind(&TriggerInput::UpdateTriggerConnection, this));
+         [this] { UpdateTriggerConnection(); });
 
    sequenceMaxLength_ = IntegerSetting::New(device_->GetLogger(),
          device_.get(), settingNamePrefix_ + "TriggerSequenceMaxLength",

--- a/DeviceAdapters/SerialManager/AsioClient.h
+++ b/DeviceAdapters/SerialManager/AsioClient.h
@@ -27,7 +27,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/serial_port.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include <deque>

--- a/DeviceAdapters/SerialManager/SerialManager.cpp
+++ b/DeviceAdapters/SerialManager/SerialManager.cpp
@@ -38,7 +38,7 @@
 #include <dirent.h>
 #endif
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>


### PR DESCRIPTION
Prevent the following warning:

```
.../boost/bind.hpp:36:1: warning: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.
```

New code should use lambdas rather than boost::bind or std::bind, but that transformation is not quite trivial, so keep boost::bind so as not to risk breaking the code. Instead follow the warning message's advice and use `using namespace boost::placeholders` locally.

In the case of SequenceTester, however, lambdas are simpler so use them.