### PR TITLE
feat: Only save non-default (user-defined) labels in config

### DIFF
--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -725,6 +725,9 @@ private:
    mutable MMThreadLock stateCacheLock_;
    mutable Configuration stateCache_; // Synchronized by stateCacheLock_
 
+   // Storage for initial state labels after device initialization
+   std::map<std::string, std::map<long, std::string>> initialStateLabels_;
+
    MMThreadLock* pPostedErrorsLock_;
    mutable std::deque<std::pair< int, std::string> > postedErrors_;
 


### PR DESCRIPTION
One possible solution to #679 

just a thought, curious what @nicost and @marktsuchida think (not married to it of course... just an idea)