### PR TITLE
MMCore: Add static methods for version numbers

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -112,7 +112,7 @@
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 11, MMCore_versionMinor = 8, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 11, MMCore_versionMinor = 9, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -385,6 +385,15 @@ std::string CMMCore::getVersionInfo() const
    return txt.str();
 }
 
+/** Returns the MMCore major version number. */
+int CMMCore::getMMCoreVersionMajor() { return MMCore_versionMajor; }
+
+/** Returns the MMCore minor version number. */
+int CMMCore::getMMCoreVersionMinor() { return MMCore_versionMinor; }
+
+/** Returns the MMCore patch version number. */
+int CMMCore::getMMCoreVersionPatch() { return MMCore_versionPatch; }
+
 /**
  * Get available devices from the specified device library.
  */
@@ -448,6 +457,12 @@ std::string CMMCore::getAPIVersionInfo() const
    txt << "Device API version " << DEVICE_INTERFACE_VERSION << ", " << "Module API version " << MODULE_INTERFACE_VERSION;
    return txt.str();
 }
+
+/** Returns the MMDevice module interface version number. */
+int CMMCore::getMMDeviceModuleInterfaceVersion() { return MODULE_INTERFACE_VERSION; }
+
+/** Returns the MMDevice device interface version number. */
+int CMMCore::getMMDeviceDeviceInterfaceVersion() { return DEVICE_INTERFACE_VERSION; }
 
 /**
  * Returns the entire system state, i.e. the collection of all property values from all devices.

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -174,8 +174,21 @@ public:
 
    std::string getCoreErrorText(int code) const;
 
+   // Note that version functions need to be implemented in the .cpp file so
+   // that they reflect the actual code being run (e.g., in a DLL), not the
+   // header or language bindings layer (where applicable).
+
+   // These two are not 'static' for backward compatibility (would break binary
+   // compatibility of Java bindings).
    std::string getVersionInfo() const;
    std::string getAPIVersionInfo() const;
+
+   static int getMMCoreVersionMajor();
+   static int getMMCoreVersionMinor();
+   static int getMMCoreVersionPatch();
+   static int getMMDeviceModuleInterfaceVersion();
+   static int getMMDeviceDeviceInterfaceVersion();
+
    Configuration getSystemState();
    void setSystemState(const Configuration& conf);
    Configuration getConfigState(const char* group, const char* config) throw (CMMError);

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -3,7 +3,7 @@
    <groupId>org.micro-manager.mmcorej</groupId>
    <artifactId>MMCoreJ</artifactId>
    <packaging>jar</packaging>
-   <version>11.8.0</version>
+   <version>11.9.0</version>
    <name>Micro-Manager Java Interface to MMCore</name>
    <description>Micro-Manager is open source software for control of automated/motorized microscopes.  This specific packages provides the Java interface to the device abstractino layer (MMCore) that is written in C++ with a C-interface</description>
    <url>http://micro-manager.org</url>


### PR DESCRIPTION
These are more direct than parsing the strings returned by
getVersionInfo() and getAPIVersionInfo(), and do not require
instantiating CMMCore in order to call.

I also considered changing getVersionInfo() and getAPIVersionInfo() to
`static`, which does not break C++ source compatibility. However,
changing a method to static breaks Java binary compatibility (ability to
swap in a newer JAR), so would require bumping the MMCore major version
(since we currently don't have a separate MMCoreJ version number). While
that may not be particularly disruptive, I'm leaving these alone for
now.

(It could get annoying if the very functions to query the version don't work uniformly across versions.)

Closes #681.