### PR TITLE
MMCore: Allow to compile with C++17

### DIFF
--- a/.github/workflows/ci-mmdevice-mmcore.yml
+++ b/.github/workflows/ci-mmdevice-mmcore.yml
@@ -27,6 +27,9 @@ jobs:
           - windows
           - macos
           - ubuntu
+        cppstd:  # Test the oldest and newest standards we support
+          - c++14
+          - c++17
         include:
           - os: windows
             runner: windows-2025
@@ -37,7 +40,7 @@ jobs:
           - os: ubuntu
             runner: ubuntu-22.04
             cxx: g++
-    name: ${{ matrix.runner }}-${{ matrix.cxx }}
+    name: ${{ matrix.runner }}-${{ matrix.cxx }}-${{ matrix.cppstd }}
     runs-on: ${{ matrix.runner }}
     env:
       CXX: ${{ matrix.cxx }}
@@ -55,7 +58,7 @@ jobs:
       - name: Build and test MMDevice
         run: |
           cd MMDevice
-          meson setup builddir --buildtype debug
+          meson setup builddir --buildtype debug -Dcpp_std=${{ matrix.cppstd }}
           meson test -C builddir --print-errorlogs
       - name: Prepare MMCore source
         shell: bash
@@ -65,5 +68,5 @@ jobs:
       - name: Build and test MMCore
         run: |
           cd MMCore
-          meson setup builddir --buildtype debug
+          meson setup builddir --buildtype debug -Dcpp_std=${{ matrix.cppstd }}
           meson test -C builddir --print-errorlogs

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -185,7 +185,7 @@ static std::string FormatLocalTime(std::chrono::time_point<std::chrono::system_c
 /**
 * Inserts a single image in the buffer.
 */
-bool CircularBuffer::InsertImage(const unsigned char* pixArray, unsigned int width, unsigned int height, unsigned int byteDepth, const Metadata* pMd) throw (CMMError)
+bool CircularBuffer::InsertImage(const unsigned char* pixArray, unsigned int width, unsigned int height, unsigned int byteDepth, const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError)
 {
    return InsertMultiChannel(pixArray, 1, width, height, byteDepth, pMd);
 }
@@ -193,7 +193,7 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray, unsigned int wid
 /**
 * Inserts a single image, possibly with multiple channels, but with 1 component, in the buffer.
 */
-bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned int numChannels, unsigned int width, unsigned int height, unsigned int byteDepth, const Metadata* pMd) throw (CMMError)
+bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned int numChannels, unsigned int width, unsigned int height, unsigned int byteDepth, const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError)
 {
    return InsertMultiChannel(pixArray, numChannels, width, height, byteDepth, 1, pMd);
 }
@@ -201,7 +201,7 @@ bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned 
 /**
 * Inserts a single image, possibly with multiple components, in the buffer.
 */
-bool CircularBuffer::InsertImage(const unsigned char* pixArray, unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents, const Metadata* pMd) throw (CMMError)
+bool CircularBuffer::InsertImage(const unsigned char* pixArray, unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents, const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError)
 {
     return InsertMultiChannel(pixArray, 1, width, height, byteDepth, nComponents, pMd);
 }
@@ -209,7 +209,7 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray, unsigned int wid
 /**
 * Inserts a multi-channel frame in the buffer.
 */
-bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned int numChannels, unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents, const Metadata* pMd) throw (CMMError)
+bool CircularBuffer::InsertMultiChannel(const unsigned char* pixArray, unsigned int numChannels, unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents, const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError)
 {
     MMThreadGuard insertGuard(g_insertLock);
  

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -36,15 +36,6 @@
 #include <memory>
 #include <string>
 
-#ifdef _MSC_VER
-#pragma warning(disable: 4290) // 'C++ exception specification ignored'
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#endif
-
 const long long bytesInMB = 1 << 20;
 const long adjustThreshold = LONG_MAX / 2;
 

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -55,10 +55,10 @@ public:
    unsigned int Height() const {MMThreadGuard guard(g_bufferLock); return height_;}
    unsigned int Depth() const {MMThreadGuard guard(g_bufferLock); return pixDepth_;}
 
-   bool InsertImage(const unsigned char* pixArray, unsigned int width, unsigned int height, unsigned int byteDepth, const Metadata* pMd) throw (CMMError);
-   bool InsertMultiChannel(const unsigned char* pixArray, unsigned int numChannels, unsigned int width, unsigned int height, unsigned int byteDepth, const Metadata* pMd) throw (CMMError);
-   bool InsertImage(const unsigned char* pixArray, unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents, const Metadata* pMd) throw (CMMError);
-   bool InsertMultiChannel(const unsigned char* pixArray, unsigned int numChannels, unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents, const Metadata* pMd) throw (CMMError);
+   bool InsertImage(const unsigned char* pixArray, unsigned int width, unsigned int height, unsigned int byteDepth, const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError);
+   bool InsertMultiChannel(const unsigned char* pixArray, unsigned int numChannels, unsigned int width, unsigned int height, unsigned int byteDepth, const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError);
+   bool InsertImage(const unsigned char* pixArray, unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents, const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError);
+   bool InsertMultiChannel(const unsigned char* pixArray, unsigned int numChannels, unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents, const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError);
    const unsigned char* GetTopImage() const;
    const unsigned char* GetNextImage();
    const mm::ImgBuffer* GetTopImageBuffer(unsigned channel) const;

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -35,17 +35,6 @@
 #include <memory>
 #include <vector>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4290) // 'C++ exception specification ignored'
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#endif
-
 class ThreadPool;
 class TaskSet_CopyMemory;
 
@@ -105,11 +94,3 @@ private:
    std::shared_ptr<ThreadPool> threadPool_;
    std::shared_ptr<TaskSet_CopyMemory> tasksMemCopy_;
 };
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif

--- a/MMCore/ConfigGroup.h
+++ b/MMCore/ConfigGroup.h
@@ -22,17 +22,6 @@
 
 #pragma once
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4290) // 'C++ exception specification ignored'
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#endif
-
 #include "Configuration.h"
 #include "Error.h"
 #include <string>
@@ -432,11 +421,3 @@ public:
       }
    }
 };
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif

--- a/MMCore/ConfigGroup.h
+++ b/MMCore/ConfigGroup.h
@@ -366,7 +366,7 @@ public:
 
    void setPixelSizeUm(double pixSize) {pixelSizeUm_ = pixSize;}
    double getPixelSizeUm() const {return pixelSizeUm_;}
-   void setPixelConfigAffineMatrix(std::vector<double> &affineMatrix) throw (CMMError)
+   void setPixelConfigAffineMatrix(std::vector<double> &affineMatrix) MMCORE_LEGACY_THROW(CMMError)
    { 
       if (affineMatrix.size() != 6) 
       {

--- a/MMCore/Configuration.cpp
+++ b/MMCore/Configuration.cpp
@@ -27,15 +27,6 @@
 #include <sstream>
 #include <string>
 
-#ifdef _MSC_VER
-#pragma warning(disable: 4290) // 'C++ exception specification ignored'
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#endif
-
 std::string PropertySetting::generateKey(const char* device, const char* prop)
 {
    std::string key(device);

--- a/MMCore/Configuration.cpp
+++ b/MMCore/Configuration.cpp
@@ -74,7 +74,7 @@ std::string Configuration::getVerbose() const
 /**
  * Returns the setting with specified index.
  */
-PropertySetting Configuration::getSetting(size_t index) const throw (CMMError)
+PropertySetting Configuration::getSetting(size_t index) const MMCORE_LEGACY_THROW(CMMError)
 {
    if (index >= settings_.size())
    {

--- a/MMCore/Configuration.h
+++ b/MMCore/Configuration.h
@@ -100,7 +100,7 @@ public:
    bool isSettingIncluded(const PropertySetting& ps);
    bool isConfigurationIncluded(const Configuration& cfg);
 
-   PropertySetting getSetting(size_t index) const throw (CMMError);
+   PropertySetting getSetting(size_t index) const MMCORE_LEGACY_THROW(CMMError);
    PropertySetting getSetting(const char* device, const char* prop);
    
    /**

--- a/MMCore/Configuration.h
+++ b/MMCore/Configuration.h
@@ -20,17 +20,6 @@
 
 #pragma once
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4290) // 'C++ exception specification ignored'
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#endif
-
 #include <string>
 #include <vector>
 #include <map>
@@ -124,11 +113,3 @@ private:
    std::vector<PropertySetting> settings_;
    std::map<std::string, int> index_;
 };
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif

--- a/MMCore/Error.h
+++ b/MMCore/Error.h
@@ -31,6 +31,20 @@
 #include <string>
 
 
+// At the moment we rely on C++ dynamic exception specifiers (deprecated in
+// C++11, removed in C++17) to tell SWIG-Java which exceptions may be thrown by
+// API functions. But to avoid warnings and errors from the C++ compiler, we
+// hide them behind a macro.
+// Also hide 'noexcept' from SWIG 3.x, which doesn't support that keyword.
+#ifdef SWIG
+#define MMCORE_LEGACY_THROW(ex) throw (ex)
+#define MMCORE_NOEXCEPT throw ()
+#else
+#define MMCORE_LEGACY_THROW(ex)
+#define MMCORE_NOEXCEPT noexcept
+#endif
+
+
 /// Core error class. Exceptions thrown by the Core public API are of this type.
 /**
  * Exceptions can be "chained" to express underlying causes of errors.
@@ -116,10 +130,10 @@ public:
    /// Copy constructor (perform a deep copy).
    CMMError(const CMMError& other);
 
-   virtual ~CMMError() throw() {}
+   virtual ~CMMError() {}
 
    /// Implements std::exception interface.
-   virtual const char* what() const throw() { return message_.c_str(); }
+   virtual const char* what() const MMCORE_NOEXCEPT { return message_.c_str(); }
 
    /// Get the error message for this error.
    virtual std::string getMsg() const;

--- a/MMCore/Logging/GenericStreamSink.h
+++ b/MMCore/Logging/GenericStreamSink.h
@@ -33,7 +33,7 @@ namespace logging
 class CannotOpenFileException : public std::exception
 {
 public:
-   virtual const char* what() const throw() { return "Cannot open log file"; }
+   virtual const char* what() const noexcept { return "Cannot open log file"; }
 };
 
 

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -68,15 +68,6 @@
 #include <thread>
 #include <vector>
 
-#ifdef _MSC_VER
-#pragma warning(disable: 4290) // 'C++ exception specification ignored'
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#endif
-
 /*
  * Important! Read this before changing this file:
  *

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -221,7 +221,7 @@ CMMCore::~CMMCore()
  * disable a permanently enabled feature, or attempting to enable a permanently
  * disabled feature.
  */
-void CMMCore::enableFeature(const char* name, bool enable) throw (CMMError)
+void CMMCore::enableFeature(const char* name, bool enable) MMCORE_LEGACY_THROW(CMMError)
 {
     if (name == nullptr)
         throw CMMError("Null feature name", MMERR_NullPointerException);
@@ -238,7 +238,7 @@ void CMMCore::enableFeature(const char* name, bool enable) throw (CMMError)
  *
  * @throws CMMError if the feature name is null or unknown.
  */
-bool CMMCore::isFeatureEnabled(const char* name) throw (CMMError)
+bool CMMCore::isFeatureEnabled(const char* name) MMCORE_LEGACY_THROW(CMMError)
 {
     if (name == nullptr)
         throw CMMError("Null feature name", MMERR_NullPointerException);
@@ -251,7 +251,7 @@ bool CMMCore::isFeatureEnabled(const char* name) throw (CMMError)
  * @param filename The log filename. If empty or null, the primary log file is
  * disabled.
  */
-void CMMCore::setPrimaryLogFile(const char* filename, bool truncate) throw (CMMError)
+void CMMCore::setPrimaryLogFile(const char* filename, bool truncate) MMCORE_LEGACY_THROW(CMMError)
 {
    std::string filenameStr;
    if (filename)
@@ -337,7 +337,7 @@ bool CMMCore::stderrLogEnabled()
  * @returns A handle required when calling stopSecondaryLogFile().
  */
 int CMMCore::startSecondaryLogFile(const char* filename, bool enableDebug,
-      bool truncate, bool synchronous) throw (CMMError)
+      bool truncate, bool synchronous) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!filename)
       throw CMMError("Filename is null");
@@ -358,7 +358,7 @@ int CMMCore::startSecondaryLogFile(const char* filename, bool enableDebug,
  *
  * @param handle The secondary log handle returned by startSecondaryLogFile().
  */
-void CMMCore::stopSecondaryLogFile(int handle) throw (CMMError)
+void CMMCore::stopSecondaryLogFile(int handle) MMCORE_LEGACY_THROW(CMMError)
 {
    typedef mm::LogManager::LogFileHandle LogFileHandle;
    LogFileHandle h = static_cast<LogFileHandle>(handle);
@@ -389,7 +389,7 @@ int CMMCore::getMMCoreVersionPatch() { return MMCore_versionPatch; }
  * Get available devices from the specified device library.
  */
 std::vector<std::string>
-CMMCore::getAvailableDevices(const char* moduleName) throw (CMMError)
+CMMCore::getAvailableDevices(const char* moduleName) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<LoadedDeviceAdapter> module =
       pluginManager_->GetDeviceAdapter(moduleName);
@@ -400,7 +400,7 @@ CMMCore::getAvailableDevices(const char* moduleName) throw (CMMError)
  * Get descriptions for available devices from the specified library.
  */
 std::vector<std::string>
-CMMCore::getAvailableDeviceDescriptions(const char* moduleName) throw (CMMError)
+CMMCore::getAvailableDeviceDescriptions(const char* moduleName) MMCORE_LEGACY_THROW(CMMError)
 {
    // XXX It is a little silly that we return the list of descriptions, rather
    // than provide access to the description of each device.
@@ -421,7 +421,7 @@ CMMCore::getAvailableDeviceDescriptions(const char* moduleName) throw (CMMError)
  * Get type information for available devices from the specified library.
  */
 std::vector<long>
-CMMCore::getAvailableDeviceTypes(const char* moduleName) throw (CMMError)
+CMMCore::getAvailableDeviceTypes(const char* moduleName) MMCORE_LEGACY_THROW(CMMError)
 {
    // XXX It is a little silly that we return the list of types, rather than
    // provide access to the type of each device.
@@ -528,7 +528,7 @@ Configuration CMMCore::getSystemStateCache() const
  * Returns a partial state of the system, only for devices included in the
  * specified configuration.
  */
-Configuration CMMCore::getConfigState(const char* group, const char* config) throw (CMMError)
+Configuration CMMCore::getConfigState(const char* group, const char* config) MMCORE_LEGACY_THROW(CMMError)
 {
    Configuration cfgData = getConfigData(group, config);
 
@@ -548,7 +548,7 @@ Configuration CMMCore::getConfigState(const char* group, const char* config) thr
  * Returns the partial state of the system, only for the devices included in the
  * specified group. It will create a union of all devices referenced in a group.
  */
-Configuration CMMCore::getConfigGroupState(const char* group) throw (CMMError)
+Configuration CMMCore::getConfigGroupState(const char* group) MMCORE_LEGACY_THROW(CMMError)
 {
    return getConfigGroupState(group, false);
 }
@@ -557,7 +557,7 @@ Configuration CMMCore::getConfigGroupState(const char* group) throw (CMMError)
  * Returns the partial state of the system cache, only for the devices included in the
  * specified group. It will create a union of all devices referenced in a group.
  */
-Configuration CMMCore::getConfigGroupStateFromCache(const char* group) throw (CMMError)
+Configuration CMMCore::getConfigGroupStateFromCache(const char* group) MMCORE_LEGACY_THROW(CMMError)
 {
    return getConfigGroupState(group, true);
 }
@@ -566,7 +566,7 @@ Configuration CMMCore::getConfigGroupStateFromCache(const char* group) throw (CM
  * Returns the partial state of the system, only for the devices included in the
  * specified group. It will create a union of all devices referenced in a group.
  */
-Configuration CMMCore::getConfigGroupState(const char* group, bool fromCache) throw (CMMError)
+Configuration CMMCore::getConfigGroupState(const char* group, bool fromCache) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(group);
 
@@ -675,7 +675,7 @@ void CMMCore::setDeviceAdapterSearchPaths(const std::vector<std::string>& paths)
  * search paths. This method does not check whether the files are valid and
  * compatible device adapters.
  */
-std::vector<std::string> CMMCore::getDeviceAdapterNames() throw (CMMError)
+std::vector<std::string> CMMCore::getDeviceAdapterNames() MMCORE_LEGACY_THROW(CMMError)
 {
    return pluginManager_->GetAvailableDeviceAdapters();
 }
@@ -687,7 +687,7 @@ std::vector<std::string> CMMCore::getDeviceAdapterNames() throw (CMMError)
  * @param deviceName   the name of the device. The name must correspond to one of the names recognized
  *                 by the specific plugin library.
  */
-void CMMCore::loadDevice(const char* label, const char* moduleName, const char* deviceName) throw (CMMError)
+void CMMCore::loadDevice(const char* label, const char* moduleName, const char* deviceName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckDeviceLabel(label);
    if (!moduleName)
@@ -772,7 +772,7 @@ void CMMCore::assignDefaultRole(std::shared_ptr<DeviceInstance> pDevice)
  * Unloads the device from the core and adjusts all configuration data.
  */
 void CMMCore::unloadDevice(const char* label///< the name of the device to unload
-                           ) throw (CMMError)
+                           ) MMCORE_LEGACY_THROW(CMMError)
 {
    // "Core" cannot be unloaded.
    if (label != nullptr && std::string(label) == MM::g_Keyword_CoreDevice)
@@ -802,7 +802,7 @@ void CMMCore::unloadDevice(const char* label///< the name of the device to unloa
  *
  * This function is not thread safe.
  */
-void CMMCore::unloadAllDevices() throw (CMMError)
+void CMMCore::unloadAllDevices() MMCORE_LEGACY_THROW(CMMError)
 {
    try {
       configGroups_->Clear();
@@ -848,7 +848,7 @@ void CMMCore::unloadAllDevices() throw (CMMError)
 /**
  * Unloads all devices from the core, clears all configuration data.
  */
-void CMMCore::reset() throw (CMMError)
+void CMMCore::reset() MMCORE_LEGACY_THROW(CMMError)
 {
    try
    {
@@ -883,7 +883,7 @@ void CMMCore::reset() throw (CMMError)
  * Calls Initialize() method for each loaded device.
  * Parallel implemnetation should be faster
  */
-void CMMCore::initializeAllDevices() throw (CMMError)
+void CMMCore::initializeAllDevices() MMCORE_LEGACY_THROW(CMMError)
 {
    if (this->isFeatureEnabled("ParallelDeviceInitialization"))
    {
@@ -901,7 +901,7 @@ void CMMCore::initializeAllDevices() throw (CMMError)
  * This method also initialized allowed values for core properties, based
  * on the collection of loaded devices.
  */
-void CMMCore::initializeAllDevicesSerial() throw (CMMError)
+void CMMCore::initializeAllDevicesSerial() MMCORE_LEGACY_THROW(CMMError)
 {
    std::vector<std::string> devices = deviceManager_->GetDeviceList();
    LOG_INFO(coreLogger_) << "Will initialize " << devices.size() << " devices (serially)";
@@ -936,7 +936,7 @@ void CMMCore::initializeAllDevicesSerial() throw (CMMError)
  * This method also initializes allowed values for core properties, based
  * on the collection of loaded devices.
  */
-void CMMCore::initializeAllDevicesParallel() throw (CMMError)
+void CMMCore::initializeAllDevicesParallel() MMCORE_LEGACY_THROW(CMMError)
 {
    std::vector<std::string> devices = deviceManager_->GetDeviceList();
    LOG_INFO(coreLogger_) << "Will initialize " << devices.size() << " devices (in parallel)";
@@ -1047,7 +1047,7 @@ int CMMCore::initializeVectorOfDevices(std::vector<std::pair<std::shared_ptr<Dev
  * will be populated with the currently loaded devices 
  * of that type
  */
-void CMMCore::updateCoreProperties() throw (CMMError)
+void CMMCore::updateCoreProperties() MMCORE_LEGACY_THROW(CMMError)
 {
    updateCoreProperty(MM::g_Keyword_CoreCamera, MM::CameraDevice);
    updateCoreProperty(MM::g_Keyword_CoreShutter, MM::ShutterDevice);
@@ -1061,7 +1061,7 @@ void CMMCore::updateCoreProperties() throw (CMMError)
    properties_->Refresh();
 }
 
-void CMMCore::updateCoreProperty(const char* propName, MM::DeviceType devType) throw (CMMError)
+void CMMCore::updateCoreProperty(const char* propName, MM::DeviceType devType) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckPropertyName(propName);
 
@@ -1078,7 +1078,7 @@ void CMMCore::updateCoreProperty(const char* propName, MM::DeviceType devType) t
  * @param label   the device label
  */
 void CMMCore::initializeDevice(const char* label ///< the device to initialize
-                               ) throw (CMMError)
+                               ) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
@@ -1098,7 +1098,7 @@ void CMMCore::initializeDevice(const char* label ///< the device to initialize
  * @param label the device label
  */
 DeviceInitializationState
-CMMCore::getDeviceInitializationState(const char* label) const throw (CMMError)
+CMMCore::getDeviceInitializationState(const char* label) const MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<DeviceInstance> pDevice = deviceManager_->GetDevice(label);
 
@@ -1133,7 +1133,7 @@ void CMMCore::updateSystemStateCache()
 /**
  * Returns device type.
  */
-MM::DeviceType CMMCore::getDeviceType(const char* label) throw (CMMError)
+MM::DeviceType CMMCore::getDeviceType(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return MM::CoreDevice;
@@ -1146,7 +1146,7 @@ MM::DeviceType CMMCore::getDeviceType(const char* label) throw (CMMError)
 /**
  * Returns device library (aka module, device adapter) name.
  */
-std::string CMMCore::getDeviceLibrary(const char* label) throw (CMMError)
+std::string CMMCore::getDeviceLibrary(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return "";
@@ -1160,7 +1160,7 @@ std::string CMMCore::getDeviceLibrary(const char* label) throw (CMMError)
 /**
  * Forcefully unload a library. Experimental. Don't use.
  */
-void CMMCore::unloadLibrary(const char* moduleName) throw (CMMError)
+void CMMCore::unloadLibrary(const char* moduleName) MMCORE_LEGACY_THROW(CMMError)
 {
   	if (moduleName == 0)
       throw CMMError(errorText_[MMERR_NullPointerException],  MMERR_NullPointerException);
@@ -1194,7 +1194,7 @@ void CMMCore::unloadLibrary(const char* moduleName) throw (CMMError)
  * "Name" is determined by the library and is immutable, while "label" is
  * user assigned and represents a high-level handle to a device.
  */
-std::string CMMCore::getDeviceName(const char* label) throw (CMMError)
+std::string CMMCore::getDeviceName(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return "Core";
@@ -1207,7 +1207,7 @@ std::string CMMCore::getDeviceName(const char* label) throw (CMMError)
 /**
  * Returns parent device.
  */
-std::string CMMCore::getParentLabel(const char* label) throw (CMMError)
+std::string CMMCore::getParentLabel(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
@@ -1220,7 +1220,7 @@ std::string CMMCore::getParentLabel(const char* label) throw (CMMError)
 /**
  * Sets parent device label
  */
-void CMMCore::setParentLabel(const char* label, const char* parentLabel) throw (CMMError)
+void CMMCore::setParentLabel(const char* label, const char* parentLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
@@ -1244,7 +1244,7 @@ void CMMCore::setParentLabel(const char* label, const char* parentLabel) throw (
  * Returns description text for a given device label.
  * "Description" is determined by the library and is immutable.
  */
-std::string CMMCore::getDeviceDescription(const char* label) throw (CMMError)
+std::string CMMCore::getDeviceDescription(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return "Core device";
@@ -1266,7 +1266,7 @@ std::string CMMCore::getDeviceDescription(const char* label) throw (CMMError)
  * @return the delay time in milliseconds
  * @param label    the device label
  */
-double CMMCore::getDeviceDelayMs(const char* label) throw (CMMError)
+double CMMCore::getDeviceDelayMs(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return 0.0;
@@ -1284,7 +1284,7 @@ double CMMCore::getDeviceDelayMs(const char* label) throw (CMMError)
  * @param label      the device label
  * @param delayMs    the desired delay in milliseconds
  */
-void CMMCore::setDeviceDelayMs(const char* label, double delayMs) throw (CMMError)
+void CMMCore::setDeviceDelayMs(const char* label, double delayMs) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return; // ignore
@@ -1300,7 +1300,7 @@ void CMMCore::setDeviceDelayMs(const char* label, double delayMs) throw (CMMErro
  * @param label    the device label
  * @return true if the device uses a delay
  */
-bool CMMCore::usesDeviceDelay(const char* label) throw (CMMError)
+bool CMMCore::usesDeviceDelay(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return false;
@@ -1315,7 +1315,7 @@ bool CMMCore::usesDeviceDelay(const char* label) throw (CMMError)
  * @param label the device label
  * @return true if the device is busy
  */
-bool CMMCore::deviceBusy(const char* label) throw (CMMError)
+bool CMMCore::deviceBusy(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return false;
@@ -1341,7 +1341,7 @@ void CMMCore::sleep(double intervalMs) const
  * non-busy.
  * @param label   the device label
  */
-void CMMCore::waitForDevice(const char* label) throw (CMMError)
+void CMMCore::waitForDevice(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return; // core property commands always block - no need to poll
@@ -1355,7 +1355,7 @@ void CMMCore::waitForDevice(const char* label) throw (CMMError)
  * Waits (blocks the calling thread) until the specified device becomes
  * @param device   the device label
  */
-void CMMCore::waitForDevice(std::shared_ptr<DeviceInstance> pDev) throw (CMMError)
+void CMMCore::waitForDevice(std::shared_ptr<DeviceInstance> pDev) MMCORE_LEGACY_THROW(CMMError)
 {
    LOG_DEBUG(coreLogger_) << "Waiting for device " << pDev->GetLabel() << "...";
 
@@ -1394,7 +1394,7 @@ void CMMCore::waitForDevice(std::shared_ptr<DeviceInstance> pDev) throw (CMMErro
  * of the devices is busy.
  * @return status (true on busy)
  */
-bool CMMCore::systemBusy() throw (CMMError)
+bool CMMCore::systemBusy() MMCORE_LEGACY_THROW(CMMError)
 {
    return deviceTypeBusy(MM::AnyType);
 }
@@ -1403,7 +1403,7 @@ bool CMMCore::systemBusy() throw (CMMError)
 /**
  * Blocks until all devices in the system become ready (not-busy).
  */
-void CMMCore::waitForSystem() throw (CMMError)
+void CMMCore::waitForSystem() MMCORE_LEGACY_THROW(CMMError)
 {
    waitForDeviceType(MM::AnyType);
 }
@@ -1416,7 +1416,7 @@ void CMMCore::waitForSystem() throw (CMMError)
  * @return true on busy
  * @param devType   a constant specifying the device type
  */
-bool CMMCore::deviceTypeBusy(MM::DeviceType devType) throw (CMMError)
+bool CMMCore::deviceTypeBusy(MM::DeviceType devType) MMCORE_LEGACY_THROW(CMMError)
 {
    std::vector<std::string> devices = deviceManager_->GetDeviceList(devType);
    for (size_t i=0; i<devices.size(); i++)
@@ -1441,7 +1441,7 @@ bool CMMCore::deviceTypeBusy(MM::DeviceType devType) throw (CMMError)
  * Blocks until all devices of the specific type become ready (not-busy).
  * @param devType    a constant specifying the device type
  */
-void CMMCore::waitForDeviceType(MM::DeviceType devType) throw (CMMError)
+void CMMCore::waitForDeviceType(MM::DeviceType devType) MMCORE_LEGACY_THROW(CMMError)
 {
    std::vector<std::string> devices = deviceManager_->GetDeviceList(devType);
    for (size_t i=0; i<devices.size(); i++)
@@ -1453,7 +1453,7 @@ void CMMCore::waitForDeviceType(MM::DeviceType devType) throw (CMMError)
  * @param group      the configuration group
  * @param config     the configuration preset
  */
-void CMMCore::waitForConfig(const char* group, const char* configName) throw (CMMError)
+void CMMCore::waitForConfig(const char* group, const char* configName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(group);
    CheckConfigPresetName(configName);
@@ -1473,7 +1473,7 @@ void CMMCore::waitForConfig(const char* group, const char* configName) throw (CM
  * @param label     the stage device label
  * @param position  the desired stage position, in microns
  */
-void CMMCore::setPosition(const char* label, double position) throw (CMMError)
+void CMMCore::setPosition(const char* label, double position) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -1495,7 +1495,7 @@ void CMMCore::setPosition(const char* label, double position) throw (CMMError)
  * (focus) device.
  * @param position  the desired stage position, in microns
  */
-void CMMCore::setPosition(double position) throw (CMMError)
+void CMMCore::setPosition(double position) MMCORE_LEGACY_THROW(CMMError)
 {
     setPosition(getFocusDevice().c_str(), position);
 }
@@ -1505,7 +1505,7 @@ void CMMCore::setPosition(double position) throw (CMMError)
  * @param label    the single-axis drive device label
  * @param d        the amount to move the stage, in microns (positive or negative)
  */
-void CMMCore::setRelativePosition(const char* label, double d) throw (CMMError)
+void CMMCore::setRelativePosition(const char* label, double d) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -1528,7 +1528,7 @@ void CMMCore::setRelativePosition(const char* label, double d) throw (CMMError)
  * positioner (focus) device.
  * @param d        the amount to move the stage, in microns (positive or negative)
  */
-void CMMCore::setRelativePosition(double d) throw (CMMError)
+void CMMCore::setRelativePosition(double d) MMCORE_LEGACY_THROW(CMMError)
 {
     setRelativePosition(getFocusDevice().c_str(), d);
 }
@@ -1538,7 +1538,7 @@ void CMMCore::setRelativePosition(double d) throw (CMMError)
  * @return the position in microns
  * @param label     the single-axis drive device label
  */
-double CMMCore::getPosition(const char* label) throw (CMMError)
+double CMMCore::getPosition(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -1559,7 +1559,7 @@ double CMMCore::getPosition(const char* label) throw (CMMError)
  * Z positioner (focus) device.
  * @return the position in microns
  */
-double CMMCore::getPosition() throw (CMMError)
+double CMMCore::getPosition() MMCORE_LEGACY_THROW(CMMError)
 {
     return getPosition(getFocusDevice().c_str());
 }
@@ -1570,7 +1570,7 @@ double CMMCore::getPosition() throw (CMMError)
  * @param x      the X axis position in microns
  * @param y      the Y axis position in microns
  */
-void CMMCore::setXYPosition(const char* label, double x, double y) throw (CMMError)
+void CMMCore::setXYPosition(const char* label, double x, double y) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -1594,7 +1594,7 @@ void CMMCore::setXYPosition(const char* label, double x, double y) throw (CMMErr
  * @param x      the X axis position in microns
  * @param y      the Y axis position in microns
  */
-void CMMCore::setXYPosition(double x, double y) throw (CMMError)
+void CMMCore::setXYPosition(double x, double y) MMCORE_LEGACY_THROW(CMMError)
 {
     setXYPosition(getXYStageDevice().c_str(), x, y);
 }
@@ -1605,7 +1605,7 @@ void CMMCore::setXYPosition(double x, double y) throw (CMMError)
  * @param dx     the distance to move in X (positive or negative)
  * @param dy     the distance to move in Y (positive or negative)
  */
-void CMMCore::setRelativeXYPosition(const char* label, double dx, double dy) throw (CMMError)
+void CMMCore::setRelativeXYPosition(const char* label, double dx, double dy) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -1629,7 +1629,7 @@ void CMMCore::setRelativeXYPosition(const char* label, double dx, double dy) thr
  * @param dx     the distance to move in X (positive or negative)
  * @param dy     the distance to move in Y (positive or negative)
  */
-void CMMCore::setRelativeXYPosition(double dx, double dy) throw (CMMError) {
+void CMMCore::setRelativeXYPosition(double dx, double dy) MMCORE_LEGACY_THROW(CMMError) {
     setRelativeXYPosition(getXYStageDevice().c_str(), dx, dy);
 }
 
@@ -1639,7 +1639,7 @@ void CMMCore::setRelativeXYPosition(double dx, double dy) throw (CMMError) {
  * @param x            a return parameter yielding the X position in microns
  * @param y            a return parameter yielding the Y position in microns
  */
-void CMMCore::getXYPosition(const char* label, double& x, double& y) throw (CMMError)
+void CMMCore::getXYPosition(const char* label, double& x, double& y) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -1659,7 +1659,7 @@ void CMMCore::getXYPosition(const char* label, double& x, double& y) throw (CMME
  * @param x            a return parameter yielding the X position in microns
  * @param y            a return parameter yielding the Y position in microns
  */
-void CMMCore::getXYPosition(double& x, double& y) throw (CMMError)
+void CMMCore::getXYPosition(double& x, double& y) MMCORE_LEGACY_THROW(CMMError)
 {
     getXYPosition(getXYStageDevice().c_str(), x, y);
 }
@@ -1669,7 +1669,7 @@ void CMMCore::getXYPosition(double& x, double& y) throw (CMMError)
  * @return    the x position
  * @param  label   the stage device label
  */
-double CMMCore::getXPosition(const char* label) throw (CMMError)
+double CMMCore::getXPosition(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -1692,7 +1692,7 @@ double CMMCore::getXPosition(const char* label) throw (CMMError)
  * @return    the x position
  * @param  label   the stage device label
  */
-double CMMCore::getXPosition() throw (CMMError)
+double CMMCore::getXPosition() MMCORE_LEGACY_THROW(CMMError)
 {
     return getXPosition(getXYStageDevice().c_str());
 }
@@ -1702,7 +1702,7 @@ double CMMCore::getXPosition() throw (CMMError)
  * @return   the y position
  * @param   label   the stage device label
  */
-double CMMCore::getYPosition(const char* label) throw (CMMError)
+double CMMCore::getYPosition(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -1725,7 +1725,7 @@ double CMMCore::getYPosition(const char* label) throw (CMMError)
  * @return    the y position
  * @param  label   the stage device label
  */
-double CMMCore::getYPosition() throw (CMMError)
+double CMMCore::getYPosition() MMCORE_LEGACY_THROW(CMMError)
 {
     return getYPosition(getXYStageDevice().c_str());
 }
@@ -1737,7 +1737,7 @@ double CMMCore::getYPosition() throw (CMMError)
  *
  * @param label    the stage device label (either XY or focus/Z stage)
  */
-void CMMCore::stop(const char* label) throw (CMMError)
+void CMMCore::stop(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<DeviceInstance> stage =
       deviceManager_->GetDevice(label);
@@ -1791,7 +1791,7 @@ void CMMCore::stop(const char* label) throw (CMMError)
  *
  * @param label    the stage device label (either XY or focus/Z stage)
  */
-void CMMCore::home(const char* label) throw (CMMError)
+void CMMCore::home(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<DeviceInstance> stage =
       deviceManager_->GetDevice(label);
@@ -1844,7 +1844,7 @@ void CMMCore::home(const char* label) throw (CMMError)
  *
  * @param label    the stage device label
  */
-void CMMCore::setOriginXY(const char* label) throw (CMMError)
+void CMMCore::setOriginXY(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -1866,7 +1866,7 @@ void CMMCore::setOriginXY(const char* label) throw (CMMError)
  * The current position becomes the new origin. Not to be confused with
  * setAdapterOriginXY().
  */
-void CMMCore::setOriginXY() throw (CMMError)
+void CMMCore::setOriginXY() MMCORE_LEGACY_THROW(CMMError)
 {
     setOriginXY(getXYStageDevice().c_str());
 }
@@ -1878,7 +1878,7 @@ void CMMCore::setOriginXY() throw (CMMError)
  *
  * @param label    the xy stage device label
  */
-void CMMCore::setOriginX(const char* label) throw (CMMError)
+void CMMCore::setOriginX(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -1900,7 +1900,7 @@ void CMMCore::setOriginX(const char* label) throw (CMMError)
  *
  * The current position becomes the new X = 0.
  */
-void CMMCore::setOriginX() throw (CMMError)
+void CMMCore::setOriginX() MMCORE_LEGACY_THROW(CMMError)
 {
    setOriginX(getXYStageDevice().c_str());
 }
@@ -1912,7 +1912,7 @@ void CMMCore::setOriginX() throw (CMMError)
  *
  * @param label    the xy stage device label
  */
-void CMMCore::setOriginY(const char* label) throw (CMMError)
+void CMMCore::setOriginY(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -1934,7 +1934,7 @@ void CMMCore::setOriginY(const char* label) throw (CMMError)
  *
  * The current position becomes the new Y = 0.
  */
-void CMMCore::setOriginY() throw (CMMError)
+void CMMCore::setOriginY() MMCORE_LEGACY_THROW(CMMError)
 {
    setOriginY(getXYStageDevice().c_str());
 }
@@ -1947,7 +1947,7 @@ void CMMCore::setOriginY() throw (CMMError)
  *
  * @param label    the stage device label
  */
-void CMMCore::setOrigin(const char* label) throw (CMMError)
+void CMMCore::setOrigin(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -1969,7 +1969,7 @@ void CMMCore::setOrigin(const char* label) throw (CMMError)
  * The current position becomes the new origin (Z = 0). Not to be confused with
  * setAdapterOrigin().
  */
-void CMMCore::setOrigin() throw (CMMError)
+void CMMCore::setOrigin() MMCORE_LEGACY_THROW(CMMError)
 {
     setOrigin(getFocusDevice().c_str());
 }
@@ -1984,7 +1984,7 @@ void CMMCore::setOrigin() throw (CMMError)
  * @param label    the stage device label
  * @param newZUm   the new coordinate to assign to the current Z position
  */
-void CMMCore::setAdapterOrigin(const char* label, double newZUm) throw (CMMError)
+void CMMCore::setAdapterOrigin(const char* label, double newZUm) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -2011,7 +2011,7 @@ void CMMCore::setAdapterOrigin(const char* label, double newZUm) throw (CMMError
  *
  * @param newZUm   the new coordinate to assign to the current Z position
  */
-void CMMCore::setAdapterOrigin(double newZUm) throw (CMMError)
+void CMMCore::setAdapterOrigin(double newZUm) MMCORE_LEGACY_THROW(CMMError)
 {
     setAdapterOrigin(getFocusDevice().c_str(), newZUm);
 }
@@ -2027,7 +2027,7 @@ void CMMCore::setAdapterOrigin(double newZUm) throw (CMMError)
  * @param newYUm   the new coordinate to assign to the current Y position
  */
 void CMMCore::setAdapterOriginXY(const char* label,
-      double newXUm, double newYUm) throw (CMMError)
+      double newXUm, double newYUm) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pXYStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -2054,7 +2054,7 @@ void CMMCore::setAdapterOriginXY(const char* label,
  * @param newXUm   the new coordinate to assign to the current X position
  * @param newYUm   the new coordinate to assign to the current Y position
  */
-void CMMCore::setAdapterOriginXY(double newXUm, double newYUm) throw (CMMError)
+void CMMCore::setAdapterOriginXY(double newXUm, double newYUm) MMCORE_LEGACY_THROW(CMMError)
 {
     setAdapterOriginXY(getXYStageDevice().c_str(), newXUm, newYUm);
 }
@@ -2074,7 +2074,7 @@ void CMMCore::setAdapterOriginXY(double newXUm, double newYUm) throw (CMMError)
  * An exception is thrown if the direction has not been set and the device
  * encounters an error when determining the default direction.
  */
-int CMMCore::getFocusDirection(const char* stageLabel) throw (CMMError)
+int CMMCore::getFocusDirection(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> stage =
       deviceManager_->GetDeviceOfType<StageInstance>(stageLabel);
@@ -2128,7 +2128,7 @@ void CMMCore::setFocusDirection(const char* stageLabel, int sign)
  * @param cameraLabel    the camera device label
  * @return   true if exposure can be sequenced
  */
-bool CMMCore::isExposureSequenceable(const char* cameraLabel) throw (CMMError)
+bool CMMCore::isExposureSequenceable(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
@@ -2149,7 +2149,7 @@ bool CMMCore::isExposureSequenceable(const char* cameraLabel) throw (CMMError)
  * This should only be called for cameras where exposure time is sequenceable
  * @param cameraLabel    the camera device label
  */
-void CMMCore::startExposureSequence(const char* cameraLabel) throw (CMMError)
+void CMMCore::startExposureSequence(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
@@ -2166,7 +2166,7 @@ void CMMCore::startExposureSequence(const char* cameraLabel) throw (CMMError)
  * This should only be called for cameras where exposure time is sequenceable
  * @param cameraLabel   the camera device label
  */
-void CMMCore::stopExposureSequence(const char* cameraLabel) throw (CMMError)
+void CMMCore::stopExposureSequence(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
@@ -2183,7 +2183,7 @@ void CMMCore::stopExposureSequence(const char* cameraLabel) throw (CMMError)
  * This should only be called for cameras where exposure time is sequenceable
  * @param cameraLabel    the camera device label
  */
-long CMMCore::getExposureSequenceMaxLength(const char* cameraLabel) throw (CMMError)
+long CMMCore::getExposureSequenceMaxLength(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
@@ -2203,7 +2203,7 @@ long CMMCore::getExposureSequenceMaxLength(const char* cameraLabel) throw (CMMEr
  * @param cameraLabel      the camera device label
  * @param exposureTime_ms  sequence of exposure times the camera will use during a sequence acquisition
  */
-void CMMCore::loadExposureSequence(const char* cameraLabel, std::vector<double> exposureTime_ms) throw (CMMError)
+void CMMCore::loadExposureSequence(const char* cameraLabel, std::vector<double> exposureTime_ms) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(cameraLabel);
@@ -2241,7 +2241,7 @@ void CMMCore::loadExposureSequence(const char* cameraLabel, std::vector<double> 
  * @param label   the stage device label
  * @return   true if the stage can be sequenced
  */
-bool CMMCore::isStageSequenceable(const char* label) throw (CMMError)
+bool CMMCore::isStageSequenceable(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -2262,7 +2262,7 @@ bool CMMCore::isStageSequenceable(const char* label) throw (CMMError)
  * @param label   the stage device label
  * @return   true if the stage supports linear sequences
  */
-bool CMMCore::isStageLinearSequenceable(const char* label) throw (CMMError)
+bool CMMCore::isStageLinearSequenceable(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -2282,7 +2282,7 @@ bool CMMCore::isStageLinearSequenceable(const char* label) throw (CMMError)
  * This should only be called for stages
  * @param label    the stage device label
  */
-void CMMCore::startStageSequence(const char* label) throw (CMMError)
+void CMMCore::startStageSequence(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -2299,7 +2299,7 @@ void CMMCore::startStageSequence(const char* label) throw (CMMError)
  * This should only be called for stages that are sequenceable
  * @param label    the stage device label
  */
-void CMMCore::stopStageSequence(const char* label) throw (CMMError)
+void CMMCore::stopStageSequence(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -2317,7 +2317,7 @@ void CMMCore::stopStageSequence(const char* label) throw (CMMError)
  * @param label    the stage device label
  * @return         the maximum length (integer)
  */
-long CMMCore::getStageSequenceMaxLength(const char* label) throw (CMMError)
+long CMMCore::getStageSequenceMaxLength(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -2337,7 +2337,7 @@ long CMMCore::getStageSequenceMaxLength(const char* label) throw (CMMError)
  * @param label              the device label
  * @param positionSequence   a sequence of positions that the stage will execute in response to external triggers
  */
-void CMMCore::loadStageSequence(const char* label, std::vector<double> positionSequence) throw (CMMError)
+void CMMCore::loadStageSequence(const char* label, std::vector<double> positionSequence) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(label);
@@ -2371,7 +2371,7 @@ void CMMCore::loadStageSequence(const char* label, std::vector<double> positionS
  *                   Presumably the sequence will repeat after this
  *                   number of TTLs was received
  */
-void CMMCore::setStageLinearSequence(const char* label, double dZ_um, int nSlices) throw (CMMError)
+void CMMCore::setStageLinearSequence(const char* label, double dZ_um, int nSlices) MMCORE_LEGACY_THROW(CMMError)
 {
    if (nSlices < 0)
       throw CMMError("Linear sequence cannot have negative length");
@@ -2391,7 +2391,7 @@ void CMMCore::setStageLinearSequence(const char* label, double dZ_um, int nSlice
  * Queries XY stage if it can be used in a sequence
  * @param label    the XY stage device label
  */
-bool CMMCore::isXYStageSequenceable(const char* label) throw (CMMError)
+bool CMMCore::isXYStageSequenceable(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -2413,7 +2413,7 @@ bool CMMCore::isXYStageSequenceable(const char* label) throw (CMMError)
  * This should only be called for stages
  * @param label       the XY stage device label
  */
-void CMMCore::startXYStageSequence(const char* label) throw (CMMError)
+void CMMCore::startXYStageSequence(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -2430,7 +2430,7 @@ void CMMCore::startXYStageSequence(const char* label) throw (CMMError)
  * This should only be called for stages that are sequenceable
  * @param label     the XY stage device label
  */
-void CMMCore::stopXYStageSequence(const char* label) throw (CMMError)
+void CMMCore::stopXYStageSequence(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -2448,7 +2448,7 @@ void CMMCore::stopXYStageSequence(const char* label) throw (CMMError)
  * @param label   the XY stage device label
  * @return        the maximum allowed sequence length
  */
-long CMMCore::getXYStageSequenceMaxLength(const char* label) throw (CMMError)
+long CMMCore::getXYStageSequenceMaxLength(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -2472,7 +2472,7 @@ long CMMCore::getXYStageSequenceMaxLength(const char* label) throw (CMMError)
  */
 void CMMCore::loadXYStageSequence(const char* label,
                                   std::vector<double> xSequence,
-                                  std::vector<double> ySequence) throw (CMMError)
+                                  std::vector<double> ySequence) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<XYStageInstance> pStage =
       deviceManager_->GetDeviceOfType<XYStageInstance>(label);
@@ -2503,7 +2503,7 @@ void CMMCore::loadXYStageSequence(const char* label,
  * Acquires a single image with current settings.
  * Snap is not allowed while the acquisition thread is run
  */
-void CMMCore::snapImage() throw (CMMError)
+void CMMCore::snapImage() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -2609,7 +2609,7 @@ bool CMMCore::getAutoShutter()
 * Opens or closes the specified shutter.
 * @param  state     the desired state of the shutter (true for open)
 */
-void CMMCore::setShutterOpen(const char* shutterLabel, bool state) throw (CMMError)
+void CMMCore::setShutterOpen(const char* shutterLabel, bool state) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<ShutterInstance> pShutter =
       deviceManager_->GetDeviceOfType<ShutterInstance>(shutterLabel);
@@ -2637,7 +2637,7 @@ void CMMCore::setShutterOpen(const char* shutterLabel, bool state) throw (CMMErr
  * Opens or closes the currently selected (default) shutter.
  * @param  state     the desired state of the shutter (true for open)
  */
-void CMMCore::setShutterOpen(bool state) throw (CMMError)
+void CMMCore::setShutterOpen(bool state) MMCORE_LEGACY_THROW(CMMError)
 {
    std::string shutterLabel = getShutterDevice();
    if (shutterLabel.empty()) return;
@@ -2648,7 +2648,7 @@ void CMMCore::setShutterOpen(bool state) throw (CMMError)
  * Returns the state of the specified shutter.
  * @param  shutterLabel   the name of the shutter
  */
-bool CMMCore::getShutterOpen(const char* shutterLabel) throw (CMMError)
+bool CMMCore::getShutterOpen(const char* shutterLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<ShutterInstance> pShutter =
       deviceManager_->GetDeviceOfType<ShutterInstance>(shutterLabel);
@@ -2669,7 +2669,7 @@ bool CMMCore::getShutterOpen(const char* shutterLabel) throw (CMMError)
 /**
  * Returns the state of the currently selected (default) shutter.
  */
-bool CMMCore::getShutterOpen() throw (CMMError)
+bool CMMCore::getShutterOpen() MMCORE_LEGACY_THROW(CMMError)
 {
    std::string shutterLabel = getShutterDevice();
    if (shutterLabel.empty()) return true;
@@ -2697,7 +2697,7 @@ bool CMMCore::getShutterOpen() throw (CMMError)
  * @return a pointer to the internal image buffer.
  * @throws CMMError   when the camera returns no data
  */
-void* CMMCore::getImage() throw (CMMError)
+void* CMMCore::getImage() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
@@ -2763,7 +2763,7 @@ void* CMMCore::getImage() throw (CMMError)
  * @param channelNr   Channel number for which the image buffer is requested
  * @return a pointer to the internal image buffer.
  */
-void* CMMCore::getImage(unsigned channelNr) throw (CMMError)
+void* CMMCore::getImage(unsigned channelNr) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
@@ -2828,7 +2828,7 @@ long CMMCore::getImageBufferSize()
  * @param intervalMs       The interval between images, currently only supported by Andor cameras
  * @param stopOnOverflow   whether or not the camera stops acquiring when the circular buffer is full
  */
-void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool stopOnOverflow) throw (CMMError)
+void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError)
 {
    // scope for the thread guard
    {
@@ -2883,7 +2883,7 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
  * The difference between this method and the one with the same name but operating on the "default"
  * camera is that it does not automatically initialize the circular buffer.
  */
-void CMMCore::startSequenceAcquisition(const char* label, long numImages, double intervalMs, bool stopOnOverflow) throw (CMMError)
+void CMMCore::startSequenceAcquisition(const char* label, long numImages, double intervalMs, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
@@ -2915,7 +2915,7 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
  * Prepare the camera for the sequence acquisition to save the time in the
  * StartSequenceAcqusition() call which is supposed to come next.
  */
-void CMMCore::prepareSequenceAcquisition(const char* label) throw (CMMError)
+void CMMCore::prepareSequenceAcquisition(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
@@ -2939,7 +2939,7 @@ void CMMCore::prepareSequenceAcquisition(const char* label) throw (CMMError)
 /**
  * Initialize circular buffer based on the current camera settings.
  */
-void CMMCore::initializeCircularBuffer() throw (CMMError)
+void CMMCore::initializeCircularBuffer() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -2963,7 +2963,7 @@ void CMMCore::initializeCircularBuffer() throw (CMMError)
  * Stops streaming camera sequence acquisition for a specified camera.
  * @param label   The camera name
  */
-void CMMCore::stopSequenceAcquisition(const char* label) throw (CMMError)
+void CMMCore::stopSequenceAcquisition(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
@@ -2985,7 +2985,7 @@ void CMMCore::stopSequenceAcquisition(const char* label) throw (CMMError)
  * Starts the continuous camera sequence acquisition.
  * This command does not block the calling thread for the duration of the acquisition.
  */
-void CMMCore::startContinuousSequenceAcquisition(double intervalMs) throw (CMMError)
+void CMMCore::startContinuousSequenceAcquisition(double intervalMs) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -3021,7 +3021,7 @@ void CMMCore::startContinuousSequenceAcquisition(double intervalMs) throw (CMMEr
 /**
  * Stops streaming camera sequence acquisition.
  */
-void CMMCore::stopSequenceAcquisition() throw (CMMError)
+void CMMCore::stopSequenceAcquisition() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -3049,7 +3049,7 @@ void CMMCore::stopSequenceAcquisition() throw (CMMError)
  * Check if the current camera is acquiring the sequence
  * Returns false when the sequence is done
  */
-bool CMMCore::isSequenceRunning() throw ()
+bool CMMCore::isSequenceRunning() MMCORE_NOEXCEPT
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -3071,7 +3071,7 @@ bool CMMCore::isSequenceRunning() throw ()
  * Check if the specified camera is acquiring the sequence
  * Returns false when the sequence is done
  */
-bool CMMCore::isSequenceRunning(const char* label) throw (CMMError)
+bool CMMCore::isSequenceRunning(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
@@ -3084,7 +3084,7 @@ bool CMMCore::isSequenceRunning(const char* label) throw (CMMError)
  * Gets the last image from the circular buffer.
  * Returns 0 if the buffer is empty.
  */
-void* CMMCore::getLastImage() throw (CMMError)
+void* CMMCore::getLastImage() MMCORE_LEGACY_THROW(CMMError)
 {
 
    // scope for the thread guard
@@ -3111,7 +3111,7 @@ void* CMMCore::getLastImage() throw (CMMError)
    }
 }
 
-void* CMMCore::getLastImageMD(unsigned channel, unsigned slice, Metadata& md) const throw (CMMError)
+void* CMMCore::getLastImageMD(unsigned channel, unsigned slice, Metadata& md) const MMCORE_LEGACY_THROW(CMMError)
 {
    // Slices have never been implemented on the device interface side
    if (slice != 0)
@@ -3139,7 +3139,7 @@ void* CMMCore::getLastImageMD(unsigned channel, unsigned slice, Metadata& md) co
  * on little endian the format is BGRA888 
  * (see: https://en.wikipedia.org/wiki/RGBA_color_model).
  */
-void* CMMCore::getLastImageMD(Metadata& md) const throw (CMMError)
+void* CMMCore::getLastImageMD(Metadata& md) const MMCORE_LEGACY_THROW(CMMError)
 {
    return getLastImageMD(0, 0, md);
 }
@@ -3156,7 +3156,7 @@ void* CMMCore::getLastImageMD(Metadata& md) const throw (CMMError)
  * on little endian the format is BGRA888 
  * (see: https://en.wikipedia.org/wiki/RGBA_color_model).
  */
-void* CMMCore::getNBeforeLastImageMD(unsigned long n, Metadata& md) const throw (CMMError)
+void* CMMCore::getNBeforeLastImageMD(unsigned long n, Metadata& md) const MMCORE_LEGACY_THROW(CMMError)
 {
    const mm::ImgBuffer* pBuf = cbuf_->GetNthFromTopImageBuffer(n);
    if (pBuf != 0)
@@ -3180,7 +3180,7 @@ void* CMMCore::getNBeforeLastImageMD(unsigned long n, Metadata& md) const throw 
  * on little endian the format is BGRA888 
  * (see: https://en.wikipedia.org/wiki/RGBA_color_model).
  */
-void* CMMCore::popNextImage() throw (CMMError)
+void* CMMCore::popNextImage() MMCORE_LEGACY_THROW(CMMError)
 {
    unsigned char* pBuf = const_cast<unsigned char*>(cbuf_->GetNextImage());
    if (pBuf != 0)
@@ -3194,7 +3194,7 @@ void* CMMCore::popNextImage() throw (CMMError)
  * channel indicates which cameraChannel image should be retrieved.
  * slice has not been implement and should always be 0
  */
-void* CMMCore::popNextImageMD(unsigned channel, unsigned slice, Metadata& md) throw (CMMError)
+void* CMMCore::popNextImageMD(unsigned channel, unsigned slice, Metadata& md) MMCORE_LEGACY_THROW(CMMError)
 {
    // Slices have never been implemented on the device interface side
    if (slice != 0)
@@ -3213,7 +3213,7 @@ void* CMMCore::popNextImageMD(unsigned channel, unsigned slice, Metadata& md) th
 /**
  * Gets and removes the next image (and metadata) from the circular buffer
  */
-void* CMMCore::popNextImageMD(Metadata& md) throw (CMMError)
+void* CMMCore::popNextImageMD(Metadata& md) MMCORE_LEGACY_THROW(CMMError)
 {
    return popNextImageMD(0, 0, md);
 }
@@ -3224,7 +3224,7 @@ void* CMMCore::popNextImageMD(Metadata& md) throw (CMMError)
  * It is rarely necessary to call this directly since starting a sequence
  * acquisition or changing the ROI will always clear the buffer.
  */
-void CMMCore::clearCircularBuffer() throw (CMMError)
+void CMMCore::clearCircularBuffer() MMCORE_LEGACY_THROW(CMMError)
 {
    cbuf_->Clear();
 }
@@ -3233,7 +3233,7 @@ void CMMCore::clearCircularBuffer() throw (CMMError)
  * Reserve memory for the circular buffer.
  */
 void CMMCore::setCircularBufferMemoryFootprint(unsigned sizeMB ///< n megabytes
-                                               ) throw (CMMError)
+                                               ) MMCORE_LEGACY_THROW(CMMError)
 {
    delete cbuf_; // discard old buffer
    LOG_DEBUG(coreLogger_) << "Will set circular buffer size to " <<
@@ -3407,7 +3407,7 @@ std::string CMMCore::getAutoFocusDevice()
 /**
  * Sets the current auto-focus device.
  */
-void CMMCore::setAutoFocusDevice(const char* autofocusLabel) throw (CMMError)
+void CMMCore::setAutoFocusDevice(const char* autofocusLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    if (autofocusLabel && strlen(autofocusLabel)>0)
    {
@@ -3474,7 +3474,7 @@ std::string CMMCore::getGalvoDevice()
 /**
  * Sets the current image processor device.
  */
-void CMMCore::setImageProcessorDevice(const char* procLabel) throw (CMMError)
+void CMMCore::setImageProcessorDevice(const char* procLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    if (procLabel && strlen(procLabel)>0)
    {
@@ -3498,7 +3498,7 @@ void CMMCore::setImageProcessorDevice(const char* procLabel) throw (CMMError)
 /**
  * Sets the current slm device.
  */
-void CMMCore::setSLMDevice(const char* slmLabel) throw (CMMError)
+void CMMCore::setSLMDevice(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    if (slmLabel && strlen(slmLabel)>0)
    {
@@ -3523,7 +3523,7 @@ void CMMCore::setSLMDevice(const char* slmLabel) throw (CMMError)
 /**
  * Sets the current galvo device.
  */
-void CMMCore::setGalvoDevice(const char* galvoLabel) throw (CMMError)
+void CMMCore::setGalvoDevice(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    if (galvoLabel && strlen(galvoLabel)>0)
    {
@@ -3547,7 +3547,7 @@ void CMMCore::setGalvoDevice(const char* galvoLabel) throw (CMMError)
 /**
  * Specifies the group determining the channel selection.
  */
-void CMMCore::setChannelGroup(const char* chGroup) throw (CMMError)
+void CMMCore::setChannelGroup(const char* chGroup) MMCORE_LEGACY_THROW(CMMError)
 {
    // Don't do anything if the new channelgroup is the same as the old one
    if (channelGroup_.compare(chGroup) == 0)
@@ -3588,7 +3588,7 @@ std::string CMMCore::getChannelGroup()
  * Sets the current shutter device.
  * @param shutter    the shutter device label
  */
-void CMMCore::setShutterDevice(const char* shutterLabel) throw (CMMError)
+void CMMCore::setShutterDevice(const char* shutterLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!shutterLabel || strlen(shutterLabel) > 0) // Allow empty label
       CheckDeviceLabel(shutterLabel);
@@ -3637,7 +3637,7 @@ void CMMCore::setShutterDevice(const char* shutterLabel) throw (CMMError)
  * Sets the current focus device.
  * @param focus    the focus stage device label
  */
-void CMMCore::setFocusDevice(const char* focusLabel) throw (CMMError)
+void CMMCore::setFocusDevice(const char* focusLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    if (focusLabel && strlen(focusLabel)>0)
    {
@@ -3661,7 +3661,7 @@ void CMMCore::setFocusDevice(const char* focusLabel) throw (CMMError)
 /**
  * Sets the current XY device.
  */
-void CMMCore::setXYStageDevice(const char* xyDeviceLabel) throw (CMMError)
+void CMMCore::setXYStageDevice(const char* xyDeviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    if (xyDeviceLabel && strlen(xyDeviceLabel)>0)
    {
@@ -3686,7 +3686,7 @@ void CMMCore::setXYStageDevice(const char* xyDeviceLabel) throw (CMMError)
  * Sets the current camera device.
  * @param camera   the camera device label
  */
-void CMMCore::setCameraDevice(const char* cameraLabel) throw (CMMError)
+void CMMCore::setCameraDevice(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    // If a sequence acquisition is running, the camera cannot be switched. (In
    // order to start sequences for multiple cameras, one must instead use the
@@ -3727,7 +3727,7 @@ void CMMCore::setCameraDevice(const char* cameraLabel) throw (CMMError)
  * @return property name array
  * @param label    the device label
  */
-std::vector<std::string> CMMCore::getDevicePropertyNames(const char* label) throw (CMMError)
+std::vector<std::string> CMMCore::getDevicePropertyNames(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return properties_->GetNames();
@@ -3776,7 +3776,7 @@ std::vector<std::string> CMMCore::getLoadedDevicesOfType(MM::DeviceType devType)
  * @param label     the device label
  * @param propName  the property name
  */
-std::vector<std::string> CMMCore::getAllowedPropertyValues(const char* label, const char* propName) throw (CMMError)
+std::vector<std::string> CMMCore::getAllowedPropertyValues(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return properties_->GetAllowedValues(propName);
@@ -3806,7 +3806,7 @@ std::vector<std::string> CMMCore::getAllowedPropertyValues(const char* label, co
  * @param label      the device label
  * @param propName   the property name
  */
-std::string CMMCore::getProperty(const char* label, const char* propName) throw (CMMError)
+std::string CMMCore::getProperty(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return properties_->Get(propName);
@@ -3834,7 +3834,7 @@ std::string CMMCore::getProperty(const char* label, const char* propName) throw 
  * @param label       the device label
  * @param propName    the property name
  */
-std::string CMMCore::getPropertyFromCache(const char* label, const char* propName) const throw (CMMError)
+std::string CMMCore::getPropertyFromCache(const char* label, const char* propName) const MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return properties_->Get(propName);
@@ -3860,7 +3860,7 @@ std::string CMMCore::getPropertyFromCache(const char* label, const char* propNam
  * @param propValue   the new property value
  */
 void CMMCore::setProperty(const char* label, const char* propName,
-                          const char* propValue) throw (CMMError)
+                          const char* propValue) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckDeviceLabel(label);
    CheckPropertyName(propName);
@@ -3903,7 +3903,7 @@ void CMMCore::setProperty(const char* label, const char* propName,
  * @param propValue    the new property value
  */
 void CMMCore::setProperty(const char* label, const char* propName,
-                          const bool propValue) throw (CMMError)
+                          const bool propValue) MMCORE_LEGACY_THROW(CMMError)
 {
    setProperty(label, propName, (propValue ? "1" : "0"));
 }
@@ -3916,7 +3916,7 @@ void CMMCore::setProperty(const char* label, const char* propName,
  * @param propValue  the new property value
  */
 void CMMCore::setProperty(const char* label, const char* propName,
-                          const long propValue) throw (CMMError)
+                          const long propValue) MMCORE_LEGACY_THROW(CMMError)
 {
    setProperty(label, propName, ToString(propValue).c_str());
 }
@@ -3929,7 +3929,7 @@ void CMMCore::setProperty(const char* label, const char* propName,
  * @param propValue  the new property value
  */
 void CMMCore::setProperty(const char* label, const char* propName,
-                          const float propValue) throw (CMMError)
+                          const float propValue) MMCORE_LEGACY_THROW(CMMError)
 {
    setProperty(label, propName, ToString(propValue).c_str());
 }
@@ -3942,7 +3942,7 @@ void CMMCore::setProperty(const char* label, const char* propName,
  * @param propValue      the new property value
  */
 void CMMCore::setProperty(const char* label, const char* propName,
-                          const double propValue) throw (CMMError)
+                          const double propValue) MMCORE_LEGACY_THROW(CMMError)
 {
    setProperty(label, propName, ToString(propValue).c_str());
 }
@@ -3952,7 +3952,7 @@ void CMMCore::setProperty(const char* label, const char* propName,
  * Checks if device has a property with a specified name.
  * The exception will be thrown in case device label is not defined.
  */
-bool CMMCore::hasProperty(const char* label, const char* propName) throw (CMMError)
+bool CMMCore::hasProperty(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return properties_->Has(propName);
@@ -3970,7 +3970,7 @@ bool CMMCore::hasProperty(const char* label, const char* propName) throw (CMMErr
  * @param label    the device label
  * @param propName the property name
  */
-bool CMMCore::isPropertyReadOnly(const char* label, const char* propName) throw (CMMError)
+bool CMMCore::isPropertyReadOnly(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return properties_->IsReadOnly(propName);
@@ -3988,7 +3988,7 @@ bool CMMCore::isPropertyReadOnly(const char* label, const char* propName) throw 
  * @param label      the device label
  * @param propName   the property name
  */
-bool CMMCore::isPropertyPreInit(const char* label, const char* propName) throw (CMMError)
+bool CMMCore::isPropertyPreInit(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return false;
@@ -4002,7 +4002,7 @@ bool CMMCore::isPropertyPreInit(const char* label, const char* propName) throw (
 /**
  * Returns the property lower limit value, if the property has limits - 0 otherwise.
  */
-double CMMCore::getPropertyLowerLimit(const char* label, const char* propName) throw (CMMError)
+double CMMCore::getPropertyLowerLimit(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return 0.0;
@@ -4016,7 +4016,7 @@ double CMMCore::getPropertyLowerLimit(const char* label, const char* propName) t
 /**
  * Returns the property upper limit value, if the property has limits - 0 otherwise.
  */
-double CMMCore::getPropertyUpperLimit(const char* label, const char* propName) throw (CMMError)
+double CMMCore::getPropertyUpperLimit(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return 0.0;
@@ -4032,7 +4032,7 @@ double CMMCore::getPropertyUpperLimit(const char* label, const char* propName) t
  * @param label      the device name
  * @param propName   the property label
  */
-bool CMMCore::hasPropertyLimits(const char* label, const char* propName) throw (CMMError)
+bool CMMCore::hasPropertyLimits(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return false;
@@ -4048,7 +4048,7 @@ bool CMMCore::hasPropertyLimits(const char* label, const char* propName) throw (
  * @param label      the device name
  * @param propName   the property label
  */
-bool CMMCore::isPropertySequenceable(const char* label, const char* propName) throw (CMMError)
+bool CMMCore::isPropertySequenceable(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return false;
@@ -4065,7 +4065,7 @@ bool CMMCore::isPropertySequenceable(const char* label, const char* propName) th
  * @param label      the device name
  * @param propName   the property label
  */
-long CMMCore::getPropertySequenceMaxLength(const char* label, const char* propName) throw (CMMError)
+long CMMCore::getPropertySequenceMaxLength(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       return 0;
@@ -4083,7 +4083,7 @@ long CMMCore::getPropertySequenceMaxLength(const char* label, const char* propNa
  * @param label      the device name
  * @param propName   the property label
  */
-void CMMCore::startPropertySequence(const char* label, const char* propName) throw (CMMError)
+void CMMCore::startPropertySequence(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
@@ -4101,7 +4101,7 @@ void CMMCore::startPropertySequence(const char* label, const char* propName) thr
  * @param label     the device label
  * @param propName  the property name
  */
-void CMMCore::stopPropertySequence(const char* label, const char* propName) throw (CMMError)
+void CMMCore::stopPropertySequence(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
@@ -4120,7 +4120,7 @@ void CMMCore::stopPropertySequence(const char* label, const char* propName) thro
  * @param propName        the property label
  * @param eventSequence   the sequence of events/states that the device will execute in response to external triggers
  */
-void CMMCore::loadPropertySequence(const char* label, const char* propName, std::vector<std::string> eventSequence) throw (CMMError)
+void CMMCore::loadPropertySequence(const char* label, const char* propName, std::vector<std::string> eventSequence) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
       // XXX Should be a throw
@@ -4145,7 +4145,7 @@ void CMMCore::loadPropertySequence(const char* label, const char* propName, std:
 /**
  * Returns the intrinsic property type.
  */
-MM::PropertyType CMMCore::getPropertyType(const char* label, const char* propName) throw (CMMError)
+MM::PropertyType CMMCore::getPropertyType(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (IsCoreDeviceLabel(label))
    {
@@ -4319,7 +4319,7 @@ std::string CMMCore::getCameraChannelName(unsigned int channelNr)
  * Sets the exposure setting of the current camera in milliseconds.
  * @param dExp   the exposure in milliseconds
  */
-void CMMCore::setExposure(double dExp) throw (CMMError)
+void CMMCore::setExposure(double dExp) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
@@ -4342,7 +4342,7 @@ void CMMCore::setExposure(double dExp) throw (CMMError)
  * @param label  the camera device label
  * @param dExp   the exposure in milliseconds
  */
-void CMMCore::setExposure(const char* label, double dExp) throw (CMMError)
+void CMMCore::setExposure(const char* label, double dExp) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCamera =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
@@ -4372,7 +4372,7 @@ void CMMCore::setExposure(const char* label, double dExp) throw (CMMError)
  * Returns the current exposure setting of the camera in milliseconds.
  * @return the exposure time in milliseconds
  */
-double CMMCore::getExposure() throw (CMMError)
+double CMMCore::getExposure() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -4390,7 +4390,7 @@ double CMMCore::getExposure() throw (CMMError)
 * @param label  the camera device label
 * @return the exposure time in milliseconds
 */
-double CMMCore::getExposure(const char* label) throw (CMMError)
+double CMMCore::getExposure(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
   std::shared_ptr<CameraInstance> pCamera =
         deviceManager_->GetDeviceOfType<CameraInstance>(label);
@@ -4420,7 +4420,7 @@ double CMMCore::getExposure(const char* label) throw (CMMError)
  * @param xSize  number of horizontal pixels
  * @param ySize  number of horizontal pixels
  */
-void CMMCore::setROI(int x, int y, int xSize, int ySize) throw (CMMError)
+void CMMCore::setROI(int x, int y, int xSize, int ySize) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -4460,7 +4460,7 @@ void CMMCore::setROI(int x, int y, int xSize, int ySize) throw (CMMError)
  * @param xSize  number of horizontal pixels
  * @param ySize  number of horizontal pixels
  */
-void CMMCore::getROI(int& x, int& y, int& xSize, int& ySize) throw (CMMError)
+void CMMCore::getROI(int& x, int& y, int& xSize, int& ySize) MMCORE_LEGACY_THROW(CMMError)
 {
    unsigned uX(0), uY(0), uXSize(0), uYSize(0);
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
@@ -4499,7 +4499,7 @@ void CMMCore::getROI(int& x, int& y, int& xSize, int& ySize) throw (CMMError)
 * @param xSize  number of horizontal pixels
 * @param ySize  number of horizontal pixels
 */
-void CMMCore::setROI(const char* label, int x, int y, int xSize, int ySize) throw (CMMError)
+void CMMCore::setROI(const char* label, int x, int y, int xSize, int ySize) MMCORE_LEGACY_THROW(CMMError)
 {
   std::shared_ptr<CameraInstance> camera = deviceManager_->GetDeviceOfType<CameraInstance>(label);
   if (camera)
@@ -4537,7 +4537,7 @@ void CMMCore::setROI(const char* label, int x, int y, int xSize, int ySize) thro
  * @param xSize  number of horizontal pixels
  * @param ySize  number of vertical pixels
  */
-void CMMCore::getROI(const char* label, int& x, int& y, int& xSize, int& ySize) throw (CMMError)
+void CMMCore::getROI(const char* label, int& x, int& y, int& xSize, int& ySize) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<CameraInstance>(label);
@@ -4560,7 +4560,7 @@ void CMMCore::getROI(const char* label, int& x, int& y, int& xSize, int& ySize) 
  * A successful call to this method will clear any images in the sequence
  * buffer, even if the ROI does not change.
  */
-void CMMCore::clearROI() throw (CMMError)
+void CMMCore::clearROI() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -4582,7 +4582,7 @@ void CMMCore::clearROI() throw (CMMError)
 /**
  * Queries the camera to determine if it supports multiple ROIs.
  */
-bool CMMCore::isMultiROISupported() throw (CMMError)
+bool CMMCore::isMultiROISupported() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
@@ -4596,7 +4596,7 @@ bool CMMCore::isMultiROISupported() throw (CMMError)
 /**
  * Queries the camera to determine if multiple ROIs are currently set.
  */
-bool CMMCore::isMultiROIEnabled() throw (CMMError)
+bool CMMCore::isMultiROIEnabled() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
@@ -4619,7 +4619,7 @@ bool CMMCore::isMultiROIEnabled() throw (CMMError)
  */
 void CMMCore::setMultiROI(std::vector<unsigned> xs, std::vector<unsigned> ys,
       std::vector<unsigned> widths,
-      std::vector<unsigned> heights) throw (CMMError)
+      std::vector<unsigned> heights) MMCORE_LEGACY_THROW(CMMError)
 {
    if (xs.size() != ys.size() ||
 	   xs.size() != widths.size() ||
@@ -4654,7 +4654,7 @@ void CMMCore::setMultiROI(std::vector<unsigned> xs, std::vector<unsigned> ys,
  */
 void CMMCore::getMultiROI(std::vector<unsigned>& xs, std::vector<unsigned>& ys,
       std::vector<unsigned>& widths,
-      std::vector<unsigned>& heights) throw (CMMError)
+      std::vector<unsigned>& heights) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<CameraInstance> camera = currentCameraDevice_.lock();
    if (!camera)
@@ -4700,7 +4700,7 @@ void CMMCore::getMultiROI(std::vector<unsigned>& xs, std::vector<unsigned>& ys,
  * @param deviceLabel  the device label
  * @param state        the new state
  */
-void CMMCore::setState(const char* deviceLabel, long state) throw (CMMError)
+void CMMCore::setState(const char* deviceLabel, long state) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
@@ -4738,7 +4738,7 @@ void CMMCore::setState(const char* deviceLabel, long state) throw (CMMError)
  * @return                the current state
  * @param deviceLabel     the device label
  */
-long CMMCore::getState(const char* deviceLabel) throw (CMMError)
+long CMMCore::getState(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
@@ -4779,7 +4779,7 @@ long CMMCore::getNumberOfStates(const char* deviceLabel)
  * @param deviceLabel     the device label
  * @param stateLabel      the state label
  */
-void CMMCore::setStateLabel(const char* deviceLabel, const char* stateLabel) throw (CMMError)
+void CMMCore::setStateLabel(const char* deviceLabel, const char* stateLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
@@ -4816,7 +4816,7 @@ void CMMCore::setStateLabel(const char* deviceLabel, const char* stateLabel) thr
  * @return   the current state's label
  * @param deviceLabel     the device label
  */
-std::string CMMCore::getStateLabel(const char* deviceLabel) throw (CMMError)
+std::string CMMCore::getStateLabel(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
@@ -4832,7 +4832,7 @@ std::string CMMCore::getStateLabel(const char* deviceLabel) throw (CMMError)
  * @param state          the state to be labeled
  * @param label          the label for the specified state
  */
-void CMMCore::defineStateLabel(const char* deviceLabel, long state, const char* label) throw (CMMError)
+void CMMCore::defineStateLabel(const char* deviceLabel, long state, const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
@@ -4893,7 +4893,7 @@ void CMMCore::defineStateLabel(const char* deviceLabel, long state, const char* 
  * @return  an array of state labels
  * @param deviceLabel       the device label
  */
-std::vector<std::string> CMMCore::getStateLabels(const char* deviceLabel) throw (CMMError)
+std::vector<std::string> CMMCore::getStateLabels(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
@@ -4914,7 +4914,7 @@ std::vector<std::string> CMMCore::getStateLabels(const char* deviceLabel) throw 
  * @param deviceLabel     the device label
  * @param stateLabel      the label for which the state is being queried
  */
-long CMMCore::getStateFromLabel(const char* deviceLabel, const char* stateLabel) throw (CMMError)
+long CMMCore::getStateFromLabel(const char* deviceLabel, const char* stateLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StateInstance> pStateDev =
       deviceManager_->GetDeviceOfType<StateInstance>(deviceLabel);
@@ -4932,7 +4932,7 @@ long CMMCore::getStateFromLabel(const char* deviceLabel, const char* stateLabel)
 /**
  * Creates an empty configuration group.
  */
-void CMMCore::defineConfigGroup(const char* groupName) throw (CMMError)
+void CMMCore::defineConfigGroup(const char* groupName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
 
@@ -4948,7 +4948,7 @@ void CMMCore::defineConfigGroup(const char* groupName) throw (CMMError)
 /**
  * Deletes an entire configuration group.
  */
-void CMMCore::deleteConfigGroup(const char* groupName) throw (CMMError)
+void CMMCore::deleteConfigGroup(const char* groupName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
 
@@ -4964,7 +4964,7 @@ void CMMCore::deleteConfigGroup(const char* groupName) throw (CMMError)
 /**
  * Renames a configuration group.
  */
-void CMMCore::renameConfigGroup(const char* oldGroupName, const char* newGroupName) throw (CMMError)
+void CMMCore::renameConfigGroup(const char* oldGroupName, const char* newGroupName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(oldGroupName);
    CheckConfigGroupName(newGroupName);
@@ -4989,7 +4989,7 @@ void CMMCore::renameConfigGroup(const char* oldGroupName, const char* newGroupNa
  * @param groupName    the configuration group name
  * @param configName   the configuration preset name
  */
-void CMMCore::defineConfig(const char* groupName, const char* configName) throw (CMMError)
+void CMMCore::defineConfig(const char* groupName, const char* configName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
    CheckConfigPresetName(configName);
@@ -5020,7 +5020,7 @@ void CMMCore::defineConfig(const char* groupName, const char* configName) throw 
  * @param propName     the property name
  * @param value        the property value
  */
-void CMMCore::defineConfig(const char* groupName, const char* configName, const char* deviceLabel, const char* propName, const char* value) throw (CMMError)
+void CMMCore::defineConfig(const char* groupName, const char* configName, const char* deviceLabel, const char* propName, const char* value) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
    CheckConfigPresetName(configName);
@@ -5058,7 +5058,7 @@ void CMMCore::defineConfig(const char* groupName, const char* configName, const 
  * @param propName property name
  * @param value property value
 */
-void CMMCore::definePixelSizeConfig(const char* resolutionID, const char* deviceLabel, const char* propName, const char* value) throw (CMMError)
+void CMMCore::definePixelSizeConfig(const char* resolutionID, const char* deviceLabel, const char* propName, const char* value) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
    CheckDeviceLabel(deviceLabel);
@@ -5076,7 +5076,7 @@ void CMMCore::definePixelSizeConfig(const char* resolutionID, const char* device
  * Defines an empty pixel size entry.
 */
 
-void CMMCore::definePixelSizeConfig(const char* resolutionID) throw (CMMError)
+void CMMCore::definePixelSizeConfig(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5091,7 +5091,7 @@ void CMMCore::definePixelSizeConfig(const char* resolutionID) throw (CMMError)
  *
  * @return true if the configuration is already defined
  */
-bool CMMCore::isPixelSizeConfigDefined(const char* resolutionID) const throw (CMMError)
+bool CMMCore::isPixelSizeConfigDefined(const char* resolutionID) const MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5101,7 +5101,7 @@ bool CMMCore::isPixelSizeConfigDefined(const char* resolutionID) const throw (CM
 /**
  * Sets pixel size in microns for the specified resolution sensing configuration preset.
  */
-void CMMCore::setPixelSizeUm(const char* resolutionID, double pixSize)  throw (CMMError)
+void CMMCore::setPixelSizeUm(const char* resolutionID, double pixSize)  MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5125,7 +5125,7 @@ void CMMCore::setPixelSizeUm(const char* resolutionID, double pixSize)  throw (C
  * Order: row[0]col[0] row[0]c[1] row[0]c[2] row[1]c[0] row[1]c[1] row[1]c[2]
  * The given vector has to have 6 doubles, or bad stuff will happen
  */
-void CMMCore::setPixelSizeAffine(const char* resolutionID, std::vector<double> affine)  throw (CMMError)
+void CMMCore::setPixelSizeAffine(const char* resolutionID, std::vector<double> affine)  MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5160,7 +5160,7 @@ void CMMCore::setPixelSizeAffine(const char* resolutionID, std::vector<double> a
  * @param resolutionID   The pixel size configuration group name
  * @param dxdz       Angle of the Z-stage axis with the camera axis (dimensionless)
  */
-void CMMCore::setPixelSizedxdz(const char* resolutionID, double dxdz)  throw (CMMError)
+void CMMCore::setPixelSizedxdz(const char* resolutionID, double dxdz)  MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5187,7 +5187,7 @@ void CMMCore::setPixelSizedxdz(const char* resolutionID, double dxdz)  throw (CM
  * @param resolutionID   The pixel size configuration group name
  * @param dydz       Angle of the Z-stage axis with the camera axis (dimensionless)
  */
-void CMMCore::setPixelSizedydz(const char* resolutionID, double dydz)  throw (CMMError)
+void CMMCore::setPixelSizedydz(const char* resolutionID, double dydz)  MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5210,7 +5210,7 @@ void CMMCore::setPixelSizedydz(const char* resolutionID, double dydz)  throw (CM
  * @param resolutionID   The pixel size configuration group name
  * @param optimalZ       Optimal z step in microns
  */
-void CMMCore::setPixelSizeOptimalZUm(const char* resolutionID, double optimalZ)  throw (CMMError)
+void CMMCore::setPixelSizeOptimalZUm(const char* resolutionID, double optimalZ)  MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5231,7 +5231,7 @@ void CMMCore::setPixelSizeOptimalZUm(const char* resolutionID, double optimalZ) 
  *
  * @param resolutionID   the pixel size configuration group name
  */
-void CMMCore::setPixelSizeConfig(const char* resolutionID) throw (CMMError)
+void CMMCore::setPixelSizeConfig(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5262,7 +5262,7 @@ void CMMCore::setPixelSizeConfig(const char* resolutionID) throw (CMMError)
  * @param groupName   the configuration group name
  * @param configName  the configuration preset name
  */
-void CMMCore::setConfig(const char* groupName, const char* configName) throw (CMMError)
+void CMMCore::setConfig(const char* groupName, const char* configName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
    CheckConfigPresetName(configName);
@@ -5296,7 +5296,7 @@ void CMMCore::setConfig(const char* groupName, const char* configName) throw (CM
  * configuration was not previously defined.
  *
  */
-void CMMCore::renameConfig(const char* groupName, const char* oldConfigName, const char* newConfigName) throw (CMMError)
+void CMMCore::renameConfig(const char* groupName, const char* oldConfigName, const char* newConfigName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
    CheckConfigPresetName(oldConfigName);
@@ -5318,7 +5318,7 @@ void CMMCore::renameConfig(const char* groupName, const char* oldConfigName, con
  * configuration was not previously defined.
  *
  */
-void CMMCore::deleteConfig(const char* groupName, const char* configName) throw (CMMError)
+void CMMCore::deleteConfig(const char* groupName, const char* configName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
    CheckConfigPresetName(configName);
@@ -5341,7 +5341,7 @@ void CMMCore::deleteConfig(const char* groupName, const char* configName) throw 
  * configuration was not previously defined.
  *
  */
-void CMMCore::deleteConfig(const char* groupName, const char* configName, const char* deviceLabel, const char* propName) throw (CMMError)
+void CMMCore::deleteConfig(const char* groupName, const char* configName, const char* deviceLabel, const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
    CheckConfigPresetName(configName);
@@ -5417,7 +5417,7 @@ std::vector<std::string> CMMCore::getAvailablePixelSizeConfigs() const
  *
  * @return The current configuration preset's name
  */
-std::string CMMCore::getCurrentConfig(const char* groupName) throw (CMMError)
+std::string CMMCore::getCurrentConfig(const char* groupName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
 
@@ -5447,7 +5447,7 @@ std::string CMMCore::getCurrentConfig(const char* groupName) throw (CMMError)
  *
  * @return The cache's current configuration preset name
  */
-std::string CMMCore::getCurrentConfigFromCache(const char* groupName) throw (CMMError)
+std::string CMMCore::getCurrentConfigFromCache(const char* groupName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
 
@@ -5473,7 +5473,7 @@ std::string CMMCore::getCurrentConfigFromCache(const char* groupName) throw (CMM
  *
  * @return The configuration object
  */
-Configuration CMMCore::getConfigData(const char* groupName, const char* configName) throw (CMMError)
+Configuration CMMCore::getConfigData(const char* groupName, const char* configName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigGroupName(groupName);
    CheckConfigPresetName(configName);
@@ -5497,7 +5497,7 @@ Configuration CMMCore::getConfigData(const char* groupName, const char* configNa
  * Returns the configuration object for a give pixel size preset.
  * @return The configuration object
  */
-Configuration CMMCore::getPixelSizeConfigData(const char* configName) throw (CMMError)
+Configuration CMMCore::getPixelSizeConfigData(const char* configName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(configName);
 
@@ -5520,7 +5520,7 @@ Configuration CMMCore::getPixelSizeConfigData(const char* configName) throw (CMM
  * configuration was not previously defined.
  *
  */
-void CMMCore::renamePixelSizeConfig(const char* oldConfigName, const char* newConfigName) throw (CMMError)
+void CMMCore::renamePixelSizeConfig(const char* oldConfigName, const char* newConfigName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(oldConfigName);
    CheckConfigPresetName(newConfigName);
@@ -5541,7 +5541,7 @@ void CMMCore::renamePixelSizeConfig(const char* oldConfigName, const char* newCo
  * configuration was not previously defined.
  *
  */
-void CMMCore::deletePixelSizeConfig(const char* configName) throw (CMMError)
+void CMMCore::deletePixelSizeConfig(const char* configName) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(configName);
 
@@ -5559,7 +5559,7 @@ void CMMCore::deletePixelSizeConfig(const char* configName) throw (CMMError)
 /**
  * Get the current pixel configuration name
  **/
-std::string CMMCore::getCurrentPixelSizeConfig() throw (CMMError)
+std::string CMMCore::getCurrentPixelSizeConfig() MMCORE_LEGACY_THROW(CMMError)
 {
 	return getCurrentPixelSizeConfig(false);
 }
@@ -5567,7 +5567,7 @@ std::string CMMCore::getCurrentPixelSizeConfig() throw (CMMError)
 /**
  * Get the current pixel configuration name
  **/
-std::string CMMCore::getCurrentPixelSizeConfig(bool cached) throw (CMMError)
+std::string CMMCore::getCurrentPixelSizeConfig(bool cached) MMCORE_LEGACY_THROW(CMMError)
 {
    // get a list of configuration names
    std::vector<std::string> cfgs = pixelSizeGroup_->GetAvailable();
@@ -5688,7 +5688,7 @@ double CMMCore::getPixelSizeUm(bool cached)
 /**
  * Returns the pixel size in um for the requested pixel size group
  */
-double CMMCore::getPixelSizeUmByID(const char* resolutionID) throw (CMMError)
+double CMMCore::getPixelSizeUmByID(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5703,7 +5703,7 @@ double CMMCore::getPixelSizeUmByID(const char* resolutionID) throw (CMMError)
  * Returns the current Affine Transform to related camera pixels with stage movement..
  * This function returns the stored affine transform corrected for binning
  */
-std::vector<double> CMMCore::getPixelSizeAffine() throw (CMMError)
+std::vector<double> CMMCore::getPixelSizeAffine() MMCORE_LEGACY_THROW(CMMError)
 {
 	 return getPixelSizeAffine(false);
 }
@@ -5713,7 +5713,7 @@ std::vector<double> CMMCore::getPixelSizeAffine() throw (CMMError)
  * This function returns the stored affine transform corrected for binning
  * and known magnification devices
  */
-std::vector<double> CMMCore::getPixelSizeAffine(bool cached) throw (CMMError)
+std::vector<double> CMMCore::getPixelSizeAffine(bool cached) MMCORE_LEGACY_THROW(CMMError)
 {
    std::string resolutionID = getCurrentPixelSizeConfig(cached);
    if (resolutionID.length() > 0)
@@ -5752,7 +5752,7 @@ std::vector<double> CMMCore::getPixelSizeAffine(bool cached) throw (CMMError)
  * The raw affine transform without correction for binning and magnification
  * will be returned.
  */
-std::vector<double> CMMCore::getPixelSizeAffineByID(const char* resolutionID) throw (CMMError)
+std::vector<double> CMMCore::getPixelSizeAffineByID(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5805,7 +5805,7 @@ double CMMCore::getMagnificationFactor() const
  *
  * @return        angle (dx/dz) of the Z-stage axis with the camera axis (dimensionless)
  */
-double CMMCore::getPixelSizedxdz() throw (CMMError)
+double CMMCore::getPixelSizedxdz() MMCORE_LEGACY_THROW(CMMError)
 {
 	 return getPixelSizedxdz(false);
 }
@@ -5823,7 +5823,7 @@ double CMMCore::getPixelSizedxdz() throw (CMMError)
  *                the hardware.
  * @return        angle (dx/dz) of the Z-stage axis with the camera axis (dimensionless)
  */
-double CMMCore::getPixelSizedxdz(bool cached) throw (CMMError)
+double CMMCore::getPixelSizedxdz(bool cached) MMCORE_LEGACY_THROW(CMMError)
 {
    std::string resolutionID;
    resolutionID = getCurrentPixelSizeConfig(cached);
@@ -5856,7 +5856,7 @@ double CMMCore::getPixelSizedxdz(bool cached) throw (CMMError)
  * @param resolutionID   The pixel size configuration group name
  * @return        Angle (dx/dz) of the Z-stage axis with the camera axis (dimensionless)
  */
-double CMMCore::getPixelSizedxdz(const char* resolutionID) throw (CMMError)
+double CMMCore::getPixelSizedxdz(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5878,7 +5878,7 @@ double CMMCore::getPixelSizedxdz(const char* resolutionID) throw (CMMError)
  *
  * @return   angle (dy/dz) of the Z-stage axis with the camera axis (dimensionless)
  */
-double CMMCore::getPixelSizedydz() throw (CMMError)
+double CMMCore::getPixelSizedydz() MMCORE_LEGACY_THROW(CMMError)
 {
 	 return getPixelSizedydz(false);
 }
@@ -5896,7 +5896,7 @@ double CMMCore::getPixelSizedydz() throw (CMMError)
  * @cached   Uses System state cache to find active pixel size config when true
  * @return   angle (dy/dz) of the Z-stage axis with the camera axis (dimensionless)
  */
-double CMMCore::getPixelSizedydz(bool cached) throw (CMMError)
+double CMMCore::getPixelSizedydz(bool cached) MMCORE_LEGACY_THROW(CMMError)
 {
    std::string resolutionID;
    resolutionID = getCurrentPixelSizeConfig(cached);
@@ -5929,7 +5929,7 @@ double CMMCore::getPixelSizedydz(bool cached) throw (CMMError)
  * @resolutionID   Name of Pixel Size configuration for this dy /dz angle
  * @return   angle (dy/dz) of the Z-stage axis with the camera axis (dimensionless)
  */
-double CMMCore::getPixelSizedydz(const char* resolutionID) throw (CMMError)
+double CMMCore::getPixelSizedydz(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -5946,7 +5946,7 @@ double CMMCore::getPixelSizedydz(const char* resolutionID) throw (CMMError)
  * communicate to the end user what the optimal Z step size is for this 
  * pixel size configuration
  */
-double CMMCore::getPixelSizeOptimalZUm() throw (CMMError)
+double CMMCore::getPixelSizeOptimalZUm() MMCORE_LEGACY_THROW(CMMError)
 {
 	 return getPixelSizeOptimalZUm(false);
 }
@@ -5959,7 +5959,7 @@ double CMMCore::getPixelSizeOptimalZUm() throw (CMMError)
  *
  * @cached   Uses System state cache to find active pixel size config when true
  */
-double CMMCore::getPixelSizeOptimalZUm(bool cached) throw (CMMError)
+double CMMCore::getPixelSizeOptimalZUm(bool cached) MMCORE_LEGACY_THROW(CMMError)
 {
    std::string resolutionID;
    resolutionID = getCurrentPixelSizeConfig(cached);
@@ -5985,7 +5985,7 @@ double CMMCore::getPixelSizeOptimalZUm(bool cached) throw (CMMError)
  * communicate to the end user what the optimal Z step size is for this 
  * pixel size configuration
  */
-double CMMCore::getPixelSizeOptimalZUm(const char* resolutionID) throw (CMMError)
+double CMMCore::getPixelSizeOptimalZUm(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckConfigPresetName(resolutionID);
 
@@ -6031,7 +6031,7 @@ void CMMCore::setSerialProperties(const char* portName,
                                   const char* delayBetweenCharsMs,
                                   const char* handshaking,
                                   const char* parity,
-                                  const char* stopBits) throw (CMMError)
+                                  const char* stopBits) MMCORE_LEGACY_THROW(CMMError)
 {
    setProperty(portName, MM::g_Keyword_AnswerTimeout, answerTimeout);
    setProperty(portName, MM::g_Keyword_BaudRate, baudRate);
@@ -6046,7 +6046,7 @@ void CMMCore::setSerialProperties(const char* portName,
  * This command blocks until it receives an answer from the device terminated by the specified
  * sequence.
  */
-void CMMCore::setSerialPortCommand(const char* portLabel, const char* command, const char* term) throw (CMMError)
+void CMMCore::setSerialPortCommand(const char* portLabel, const char* command, const char* term) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SerialInstance> pSerial =
       deviceManager_->GetDeviceOfType<SerialInstance>(portLabel);
@@ -6066,7 +6066,7 @@ void CMMCore::setSerialPortCommand(const char* portLabel, const char* command, c
 /**
  * Continuously read from the serial port until the terminating sequence is encountered.
  */
-std::string CMMCore::getSerialPortAnswer(const char* portLabel, const char* term) throw (CMMError)
+std::string CMMCore::getSerialPortAnswer(const char* portLabel, const char* term) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SerialInstance> pSerial =
       deviceManager_->GetDeviceOfType<SerialInstance>(portLabel);
@@ -6089,7 +6089,7 @@ std::string CMMCore::getSerialPortAnswer(const char* portLabel, const char* term
 /**
  * Sends an array of characters to the serial port and returns immediately.
  */
-void CMMCore::writeToSerialPort(const char* portLabel, const std::vector<char> &data) throw (CMMError)
+void CMMCore::writeToSerialPort(const char* portLabel, const std::vector<char> &data) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SerialInstance> pSerial =
       deviceManager_->GetDeviceOfType<SerialInstance>(portLabel);
@@ -6105,7 +6105,7 @@ void CMMCore::writeToSerialPort(const char* portLabel, const std::vector<char> &
 /**
  * Reads the contents of the Rx buffer.
  */
-std::vector<char> CMMCore::readFromSerialPort(const char* portLabel) throw (CMMError)
+std::vector<char> CMMCore::readFromSerialPort(const char* portLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SerialInstance> pSerial =
       deviceManager_->GetDeviceOfType<SerialInstance>(portLabel);
@@ -6132,7 +6132,7 @@ std::vector<char> CMMCore::readFromSerialPort(const char* portLabel) throw (CMME
 /**
  * Write an 8-bit monochrome image to the SLM.
  */
-void CMMCore::setSLMImage(const char* deviceLabel, unsigned char* pixels) throw (CMMError)
+void CMMCore::setSLMImage(const char* deviceLabel, unsigned char* pixels) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6150,7 +6150,7 @@ void CMMCore::setSLMImage(const char* deviceLabel, unsigned char* pixels) throw 
 /**
  * Write a 32-bit color image to the SLM.
  */
-void CMMCore::setSLMImage(const char* deviceLabel, imgRGB32 pixels) throw (CMMError)
+void CMMCore::setSLMImage(const char* deviceLabel, imgRGB32 pixels) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6168,7 +6168,7 @@ void CMMCore::setSLMImage(const char* deviceLabel, imgRGB32 pixels) throw (CMMEr
 /**
  * Set all SLM pixels to a single 8-bit intensity.
  */
-void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char intensity) throw (CMMError)
+void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char intensity) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6185,7 +6185,7 @@ void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char intensity) t
 /**
  * Set all SLM pixels to an RGB color.
  */
-void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char red, unsigned char green, unsigned char blue) throw (CMMError)
+void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char red, unsigned char green, unsigned char blue) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6202,7 +6202,7 @@ void CMMCore::setSLMPixelsTo(const char* deviceLabel, unsigned char red, unsigne
 /**
  * Display the waiting image on the SLM.
  */
-void CMMCore::displaySLMImage(const char* deviceLabel) throw (CMMError)
+void CMMCore::displaySLMImage(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6220,7 +6220,7 @@ void CMMCore::displaySLMImage(const char* deviceLabel) throw (CMMError)
  * For SLM devices with build-in light source (such as projectors)
  * this will set the exposure time, but not (yet) start the illumination
  */
-void CMMCore::setSLMExposure(const char* deviceLabel, double exposure_ms) throw (CMMError)
+void CMMCore::setSLMExposure(const char* deviceLabel, double exposure_ms) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6237,7 +6237,7 @@ void CMMCore::setSLMExposure(const char* deviceLabel, double exposure_ms) throw 
 /**
  * Returns the exposure time that will be used by the SLM for illumination
  */
-double CMMCore::getSLMExposure(const char* deviceLabel) throw (CMMError)
+double CMMCore::getSLMExposure(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6252,7 +6252,7 @@ double CMMCore::getSLMExposure(const char* deviceLabel) throw (CMMError)
  *
  * @param deviceLabel name of the SLM
  */
-unsigned CMMCore::getSLMWidth(const char* deviceLabel) throw (CMMError)
+unsigned CMMCore::getSLMWidth(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6267,7 +6267,7 @@ unsigned CMMCore::getSLMWidth(const char* deviceLabel) throw (CMMError)
  *
  * @param deviceLabel name of the SLM
  */
-unsigned CMMCore::getSLMHeight(const char* deviceLabel) throw (CMMError)
+unsigned CMMCore::getSLMHeight(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6282,7 +6282,7 @@ unsigned CMMCore::getSLMHeight(const char* deviceLabel) throw (CMMError)
  *
  * @param deviceLabel name of the SLM
  */
-unsigned CMMCore::getSLMNumberOfComponents(const char* deviceLabel) throw (CMMError)
+unsigned CMMCore::getSLMNumberOfComponents(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6296,7 +6296,7 @@ unsigned CMMCore::getSLMNumberOfComponents(const char* deviceLabel) throw (CMMEr
  *
  * @param deviceLabel name of the SLM
  */
-unsigned CMMCore::getSLMBytesPerPixel(const char* deviceLabel) throw (CMMError)
+unsigned CMMCore::getSLMBytesPerPixel(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6311,7 +6311,7 @@ unsigned CMMCore::getSLMBytesPerPixel(const char* deviceLabel) throw (CMMError)
  *
  * @param deviceLabel name of the SLM
  */
-long CMMCore::getSLMSequenceMaxLength(const char* deviceLabel) throw (CMMError)
+long CMMCore::getSLMSequenceMaxLength(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6329,7 +6329,7 @@ long CMMCore::getSLMSequenceMaxLength(const char* deviceLabel) throw (CMMError)
  *
  * @param deviceLabel name of the SLM
  */
-void CMMCore::startSLMSequence(const char* deviceLabel) throw (CMMError)
+void CMMCore::startSLMSequence(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6345,7 +6345,7 @@ void CMMCore::startSLMSequence(const char* deviceLabel) throw (CMMError)
  *
  * @param deviceLabel name of the SLM
  */
-void CMMCore::stopSLMSequence(const char* deviceLabel) throw (CMMError)
+void CMMCore::stopSLMSequence(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6362,7 +6362,7 @@ void CMMCore::stopSLMSequence(const char* deviceLabel) throw (CMMError)
  * @param deviceLabel name of the SLM
  * @param imagesequence pointers to the images to be used in the sequence
  */
-void CMMCore::loadSLMSequence(const char* deviceLabel, std::vector<unsigned char *> imageSequence) throw (CMMError)
+void CMMCore::loadSLMSequence(const char* deviceLabel, std::vector<unsigned char *> imageSequence) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<SLMInstance> pSLM =
       deviceManager_->GetDeviceOfType<SLMInstance>(deviceLabel);
@@ -6392,7 +6392,7 @@ void CMMCore::loadSLMSequence(const char* deviceLabel, std::vector<unsigned char
 /**
  * Set the Galvo to an x,y position and fire the laser for a predetermined duration.
  */
-void CMMCore::pointGalvoAndFire(const char* deviceLabel, double x, double y, double pulseTime_us) throw (CMMError)
+void CMMCore::pointGalvoAndFire(const char* deviceLabel, double x, double y, double pulseTime_us) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6408,7 +6408,7 @@ void CMMCore::pointGalvoAndFire(const char* deviceLabel, double x, double y, dou
    }
 }
 
-void CMMCore::setGalvoSpotInterval(const char* deviceLabel, double pulseTime_us) throw (CMMError)
+void CMMCore::setGalvoSpotInterval(const char* deviceLabel, double pulseTime_us) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6428,7 +6428,7 @@ void CMMCore::setGalvoSpotInterval(const char* deviceLabel, double pulseTime_us)
 /**
  * Set the Galvo to an x,y position
  */
-void CMMCore::setGalvoPosition(const char* deviceLabel, double x, double y) throw (CMMError)
+void CMMCore::setGalvoPosition(const char* deviceLabel, double x, double y) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6447,7 +6447,7 @@ void CMMCore::setGalvoPosition(const char* deviceLabel, double x, double y) thro
 /**
  * Get the Galvo x,y position
  */
-void CMMCore::getGalvoPosition(const char* deviceLabel, double &x, double &y) throw (CMMError)
+void CMMCore::getGalvoPosition(const char* deviceLabel, double &x, double &y) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6466,7 +6466,7 @@ void CMMCore::getGalvoPosition(const char* deviceLabel, double &x, double &y) th
 /**
  * Set the galvo's illumination state to on or off
  */
-void CMMCore::setGalvoIlluminationState(const char* deviceLabel, bool on) throw (CMMError)
+void CMMCore::setGalvoIlluminationState(const char* deviceLabel, bool on) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6487,7 +6487,7 @@ void CMMCore::setGalvoIlluminationState(const char* deviceLabel, bool on) throw 
 /**
  * Get the Galvo x range
  */
-double CMMCore::getGalvoXRange(const char* deviceLabel) throw (CMMError)
+double CMMCore::getGalvoXRange(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6499,7 +6499,7 @@ double CMMCore::getGalvoXRange(const char* deviceLabel) throw (CMMError)
 /**
  * Get the Galvo x minimum
  */
-double CMMCore::getGalvoXMinimum(const char* deviceLabel) throw (CMMError)
+double CMMCore::getGalvoXMinimum(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6511,7 +6511,7 @@ double CMMCore::getGalvoXMinimum(const char* deviceLabel) throw (CMMError)
 /**
  * Get the Galvo y range
  */
-double CMMCore::getGalvoYRange(const char* deviceLabel) throw (CMMError)
+double CMMCore::getGalvoYRange(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6523,7 +6523,7 @@ double CMMCore::getGalvoYRange(const char* deviceLabel) throw (CMMError)
 /**
  * Get the Galvo y minimum
  */
-double CMMCore::getGalvoYMinimum(const char* deviceLabel) throw (CMMError)
+double CMMCore::getGalvoYMinimum(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6535,7 +6535,7 @@ double CMMCore::getGalvoYMinimum(const char* deviceLabel) throw (CMMError)
 /**
  * Add a vertex to a galvo polygon.
  */
-void CMMCore::addGalvoPolygonVertex(const char* deviceLabel, int polygonIndex, double x, double y) throw (CMMError)
+void CMMCore::addGalvoPolygonVertex(const char* deviceLabel, int polygonIndex, double x, double y) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6554,7 +6554,7 @@ void CMMCore::addGalvoPolygonVertex(const char* deviceLabel, int polygonIndex, d
 /**
  * Remove all added polygons
  */
-void CMMCore::deleteGalvoPolygons(const char* deviceLabel) throw (CMMError)
+void CMMCore::deleteGalvoPolygons(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6574,7 +6574,7 @@ void CMMCore::deleteGalvoPolygons(const char* deviceLabel) throw (CMMError)
 /**
  * Load a set of galvo polygons to the device
  */
-void CMMCore::loadGalvoPolygons(const char* deviceLabel) throw (CMMError)
+void CMMCore::loadGalvoPolygons(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6593,7 +6593,7 @@ void CMMCore::loadGalvoPolygons(const char* deviceLabel) throw (CMMError)
 /**
  * Set the number of times to loop galvo polygons
  */
-void CMMCore::setGalvoPolygonRepetitions(const char* deviceLabel, int repetitions) throw (CMMError)
+void CMMCore::setGalvoPolygonRepetitions(const char* deviceLabel, int repetitions) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6613,7 +6613,7 @@ void CMMCore::setGalvoPolygonRepetitions(const char* deviceLabel, int repetition
 /**
  * Run a loop of galvo polygons
  */
-void CMMCore::runGalvoPolygons(const char* deviceLabel) throw (CMMError)
+void CMMCore::runGalvoPolygons(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6632,7 +6632,7 @@ void CMMCore::runGalvoPolygons(const char* deviceLabel) throw (CMMError)
 /**
  * Run a sequence of galvo positions
  */
-void CMMCore::runGalvoSequence(const char* deviceLabel) throw (CMMError)
+void CMMCore::runGalvoSequence(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6651,7 +6651,7 @@ void CMMCore::runGalvoSequence(const char* deviceLabel) throw (CMMError)
 /**
  * Get the name of the active galvo channel (for a multi-laser galvo device).
  */
-std::string CMMCore::getGalvoChannel(const char* deviceLabel) throw (CMMError)
+std::string CMMCore::getGalvoChannel(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<GalvoInstance> pGalvo =
       deviceManager_->GetDeviceOfType<GalvoInstance>(deviceLabel);
@@ -6668,7 +6668,7 @@ std::string CMMCore::getGalvoChannel(const char* deviceLabel) throw (CMMError)
 /**
 * Stops the pressure pump
 */
-void CMMCore::pressurePumpStop(const char* deviceLabel) throw (CMMError)
+void CMMCore::pressurePumpStop(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<PressurePumpInstance> pPump =
         deviceManager_->GetDeviceOfType<PressurePumpInstance>(deviceLabel);
@@ -6686,7 +6686,7 @@ void CMMCore::pressurePumpStop(const char* deviceLabel) throw (CMMError)
 /**
 * Calibrates the pump
 */
-void CMMCore::pressurePumpCalibrate(const char* deviceLabel) throw (CMMError)
+void CMMCore::pressurePumpCalibrate(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<PressurePumpInstance> pPump =
         deviceManager_->GetDeviceOfType<PressurePumpInstance>(deviceLabel);
@@ -6704,7 +6704,7 @@ void CMMCore::pressurePumpCalibrate(const char* deviceLabel) throw (CMMError)
 /**
 * Returns boolean whether the pump is operational before calibration
 */
-bool CMMCore::pressurePumpRequiresCalibration(const char* deviceLabel) throw (CMMError)
+bool CMMCore::pressurePumpRequiresCalibration(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<PressurePumpInstance> pPump =
         deviceManager_->GetDeviceOfType<PressurePumpInstance>(deviceLabel);
@@ -6716,7 +6716,7 @@ bool CMMCore::pressurePumpRequiresCalibration(const char* deviceLabel) throw (CM
 /**
 * Gets the pressure of the pump in kPa
 */
-double CMMCore::getPumpPressureKPa(const char* deviceLabel) throw (CMMError)
+double CMMCore::getPumpPressureKPa(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<PressurePumpInstance> pPump =
         deviceManager_->GetDeviceOfType<PressurePumpInstance>(deviceLabel);
@@ -6736,7 +6736,7 @@ double CMMCore::getPumpPressureKPa(const char* deviceLabel) throw (CMMError)
 /**
 * Sets the pressure of the pump in kPa
 */
-void CMMCore::setPumpPressureKPa(const char* deviceLabel, double pressurekPa) throw (CMMError)
+void CMMCore::setPumpPressureKPa(const char* deviceLabel, double pressurekPa) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<PressurePumpInstance> pPump =
         deviceManager_->GetDeviceOfType<PressurePumpInstance>(deviceLabel);
@@ -6754,7 +6754,7 @@ void CMMCore::setPumpPressureKPa(const char* deviceLabel, double pressurekPa) th
 /**
 * Stops the volumetric pump
 */
-void CMMCore::volumetricPumpStop(const char* deviceLabel) throw (CMMError)
+void CMMCore::volumetricPumpStop(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6772,7 +6772,7 @@ void CMMCore::volumetricPumpStop(const char* deviceLabel) throw (CMMError)
 /**
 * Homes the pump
 */
-void CMMCore::volumetricPumpHome(const char* deviceLabel) throw (CMMError)
+void CMMCore::volumetricPumpHome(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6787,7 +6787,7 @@ void CMMCore::volumetricPumpHome(const char* deviceLabel) throw (CMMError)
     }
 }
 
-bool CMMCore::volumetricPumpRequiresHoming(const char* deviceLabel) throw (CMMError)
+bool CMMCore::volumetricPumpRequiresHoming(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6799,7 +6799,7 @@ bool CMMCore::volumetricPumpRequiresHoming(const char* deviceLabel) throw (CMMEr
 /**
 * Sets whether the pump direction needs to be inverted
 */
-void CMMCore::invertPumpDirection(const char* deviceLabel, bool invert) throw (CMMError)
+void CMMCore::invertPumpDirection(const char* deviceLabel, bool invert) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6817,7 +6817,7 @@ void CMMCore::invertPumpDirection(const char* deviceLabel, bool invert) throw (C
 /**
 * Gets whether the pump direction needs to be inverted
 */
-bool CMMCore::isPumpDirectionInverted(const char* deviceLabel) throw (CMMError)
+bool CMMCore::isPumpDirectionInverted(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6838,7 +6838,7 @@ bool CMMCore::isPumpDirectionInverted(const char* deviceLabel) throw (CMMError)
 * Sets the volume of fluid in the pump in uL. Note it does not withdraw upto
 * this amount. It is merely to inform MM of the volume in a prefilled pump.
 */
-void CMMCore::setPumpVolume(const char* deviceLabel, double volUl) throw (CMMError)
+void CMMCore::setPumpVolume(const char* deviceLabel, double volUl) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6856,7 +6856,7 @@ void CMMCore::setPumpVolume(const char* deviceLabel, double volUl) throw (CMMErr
 /**
 * Get the fluid volume in the pump in uL
 */
-double CMMCore::getPumpVolume(const char* deviceLabel) throw (CMMError)
+double CMMCore::getPumpVolume(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6876,7 +6876,7 @@ double CMMCore::getPumpVolume(const char* deviceLabel) throw (CMMError)
 /**
 * Sets the max volume of the pump in uL
 */
-void CMMCore::setPumpMaxVolume(const char* deviceLabel, double volUl) throw (CMMError)
+void CMMCore::setPumpMaxVolume(const char* deviceLabel, double volUl) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6894,7 +6894,7 @@ void CMMCore::setPumpMaxVolume(const char* deviceLabel, double volUl) throw (CMM
 /**
 * Gets the max volume of the pump in uL
 */
-double CMMCore::getPumpMaxVolume(const char* deviceLabel) throw (CMMError)
+double CMMCore::getPumpMaxVolume(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6914,7 +6914,7 @@ double CMMCore::getPumpMaxVolume(const char* deviceLabel) throw (CMMError)
 /**
 * Sets the flowrate of the pump in uL per second
 */
-void CMMCore::setPumpFlowrate(const char* deviceLabel, double UlperSec) throw (CMMError)
+void CMMCore::setPumpFlowrate(const char* deviceLabel, double UlperSec) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6932,7 +6932,7 @@ void CMMCore::setPumpFlowrate(const char* deviceLabel, double UlperSec) throw (C
 /**
 * Gets the flowrate of the pump in uL per second
 */
-double CMMCore::getPumpFlowrate(const char* deviceLabel) throw (CMMError)
+double CMMCore::getPumpFlowrate(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6953,7 +6953,7 @@ double CMMCore::getPumpFlowrate(const char* deviceLabel) throw (CMMError)
 * Start dispensing at the set flowrate until syringe is empty, or manually
 * stopped (whichever occurs first).
 */
-void CMMCore::pumpStart(const char* deviceLabel) throw (CMMError)
+void CMMCore::pumpStart(const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6971,7 +6971,7 @@ void CMMCore::pumpStart(const char* deviceLabel) throw (CMMError)
 /**
 * Dispenses for the provided duration (in seconds) at the set flowrate
 */
-void CMMCore::pumpDispenseDurationSeconds(const char* deviceLabel, double seconds) throw (CMMError)
+void CMMCore::pumpDispenseDurationSeconds(const char* deviceLabel, double seconds) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -6989,7 +6989,7 @@ void CMMCore::pumpDispenseDurationSeconds(const char* deviceLabel, double second
 /**
 * Dispenses the provided volume (in uL) at the set flowrate
 */
-void CMMCore::pumpDispenseVolumeUl(const char* deviceLabel, double microLiter) throw (CMMError)
+void CMMCore::pumpDispenseVolumeUl(const char* deviceLabel, double microLiter) MMCORE_LEGACY_THROW(CMMError)
 {
     std::shared_ptr<VolumetricPumpInstance> pPump =
         deviceManager_->GetDeviceOfType<VolumetricPumpInstance>(deviceLabel);
@@ -7012,7 +7012,7 @@ void CMMCore::pumpDispenseVolumeUl(const char* deviceLabel, double microLiter) t
  * The file records only read-write properties.
  * The file format is directly readable by the complementary loadSystemState() command.
  */
-void CMMCore::saveSystemState(const char* fileName) throw (CMMError)
+void CMMCore::saveSystemState(const char* fileName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!fileName)
       throw CMMError("Null filename");
@@ -7046,7 +7046,7 @@ void CMMCore::saveSystemState(const char* fileName) throw (CMMError)
  *
  * Format specification: the same as in loadSystemConfiguration() command
  */
-void CMMCore::loadSystemState(const char* fileName) throw (CMMError)
+void CMMCore::loadSystemState(const char* fileName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!fileName)
       throw CMMError("Null filename");
@@ -7118,7 +7118,7 @@ void CMMCore::loadSystemState(const char* fileName) throw (CMMError)
  * setup: devices, labels, pre-initialization properties, and configurations.
  * The file format is the same as for the system state.
  */
-void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
+void CMMCore::saveSystemConfiguration(const char* fileName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!fileName)
       throw CMMError("Null filename");
@@ -7338,7 +7338,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
  *
  * This function is not thread-safe.
  */
-void CMMCore::loadSystemConfiguration(const char* fileName) throw (CMMError)
+void CMMCore::loadSystemConfiguration(const char* fileName) MMCORE_LEGACY_THROW(CMMError)
 {
    try
    {
@@ -7379,7 +7379,7 @@ void CMMCore::loadSystemConfiguration(const char* fileName) throw (CMMError)
 }
 
 
-void CMMCore::loadSystemConfigurationImpl(const char* fileName) throw (CMMError)
+void CMMCore::loadSystemConfigurationImpl(const char* fileName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!fileName)
       throw CMMError("Null filename");
@@ -7712,7 +7712,7 @@ double CMMCore::getCurrentFocusScore()
 /**
  * Enables or disables the operation of the continuous focusing hardware device.
  */
-void CMMCore::enableContinuousFocus(bool enable) throw (CMMError)
+void CMMCore::enableContinuousFocus(bool enable) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
@@ -7742,7 +7742,7 @@ void CMMCore::enableContinuousFocus(bool enable) throw (CMMError)
 /**
  * Checks if the continuous focusing hardware device is ON or OFF.
  */
-bool CMMCore::isContinuousFocusEnabled() throw (CMMError)
+bool CMMCore::isContinuousFocusEnabled() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
@@ -7765,7 +7765,7 @@ bool CMMCore::isContinuousFocusEnabled() throw (CMMError)
 /**
 * Returns the lock-in status of the continuous focusing device.
 */
-bool CMMCore::isContinuousFocusLocked() throw (CMMError)
+bool CMMCore::isContinuousFocusLocked() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
@@ -7783,7 +7783,7 @@ bool CMMCore::isContinuousFocusLocked() throw (CMMError)
 /**
  * Check if a stage has continuous focusing capability (positions can be set while continuous focus runs).
  */
-bool CMMCore::isContinuousFocusDrive(const char* stageLabel) throw (CMMError)
+bool CMMCore::isContinuousFocusDrive(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<StageInstance> pStage =
       deviceManager_->GetDeviceOfType<StageInstance>(stageLabel);
@@ -7796,7 +7796,7 @@ bool CMMCore::isContinuousFocusDrive(const char* stageLabel) throw (CMMError)
 /**
  * Performs focus acquisition and lock for the one-shot focusing device.
  */
-void CMMCore::fullFocus() throw (CMMError)
+void CMMCore::fullFocus() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
@@ -7819,7 +7819,7 @@ void CMMCore::fullFocus() throw (CMMError)
 /**
  * Performs incremental focus for the one-shot focusing device.
  */
-void CMMCore::incrementalFocus() throw (CMMError)
+void CMMCore::incrementalFocus() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
@@ -7843,7 +7843,7 @@ void CMMCore::incrementalFocus() throw (CMMError)
 /**
  * Applies offset the one-shot focusing device.
  */
-void CMMCore::setAutoFocusOffset(double offset) throw (CMMError)
+void CMMCore::setAutoFocusOffset(double offset) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
@@ -7866,7 +7866,7 @@ void CMMCore::setAutoFocusOffset(double offset) throw (CMMError)
 /**
  * Measures offset for the one-shot focusing device.
  */
-double CMMCore::getAutoFocusOffset() throw (CMMError)
+double CMMCore::getAutoFocusOffset() MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<AutoFocusInstance> autofocus =
       currentAutofocusDevice_.lock();
@@ -8019,7 +8019,7 @@ static bool ContainsForbiddenCharacters(const std::string& str)
    return (std::string::npos != str.find_first_of(MM::g_FieldDelimiters));
 }
 
-void CMMCore::CheckDeviceLabel(const char* label) throw (CMMError)
+void CMMCore::CheckDeviceLabel(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!label)
       throw CMMError("Null device label", MMERR_NullPointerException);
@@ -8030,7 +8030,7 @@ void CMMCore::CheckDeviceLabel(const char* label) throw (CMMError)
             MMERR_InvalidContents);
 }
 
-void CMMCore::CheckPropertyName(const char* propName) throw (CMMError)
+void CMMCore::CheckPropertyName(const char* propName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!propName)
       throw CMMError("Null property name", MMERR_NullPointerException);
@@ -8039,7 +8039,7 @@ void CMMCore::CheckPropertyName(const char* propName) throw (CMMError)
             MMERR_InvalidContents);
 }
 
-void CMMCore::CheckPropertyValue(const char* value) throw (CMMError)
+void CMMCore::CheckPropertyValue(const char* value) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!value)
       throw CMMError("Null property value", MMERR_NullPointerException);
@@ -8048,7 +8048,7 @@ void CMMCore::CheckPropertyValue(const char* value) throw (CMMError)
             MMERR_InvalidContents);
 }
 
-void CMMCore::CheckStateLabel(const char* stateLabel) throw (CMMError)
+void CMMCore::CheckStateLabel(const char* stateLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!stateLabel)
       throw CMMError("Null state label", MMERR_NullPointerException);
@@ -8057,7 +8057,7 @@ void CMMCore::CheckStateLabel(const char* stateLabel) throw (CMMError)
             MMERR_InvalidContents);
 }
 
-void CMMCore::CheckConfigGroupName(const char* groupName) throw (CMMError)
+void CMMCore::CheckConfigGroupName(const char* groupName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!groupName)
       throw CMMError("Null configuration group name", MMERR_NullPointerException);
@@ -8066,7 +8066,7 @@ void CMMCore::CheckConfigGroupName(const char* groupName) throw (CMMError)
             MMERR_InvalidContents);
 }
 
-void CMMCore::CheckConfigPresetName(const char* presetName) throw (CMMError)
+void CMMCore::CheckConfigPresetName(const char* presetName) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!presetName)
       throw CMMError("Null configuration preset name", MMERR_NullPointerException);
@@ -8079,7 +8079,7 @@ void CMMCore::CheckConfigPresetName(const char* presetName) throw (CMMError)
             MMERR_BadConfigName);
 }
 
-bool CMMCore::IsCoreDeviceLabel(const char* label) const throw (CMMError)
+bool CMMCore::IsCoreDeviceLabel(const char* label) const MMCORE_LEGACY_THROW(CMMError)
 {
    if (!label)
       throw CMMError("Null device label", MMERR_NullPointerException);
@@ -8092,7 +8092,7 @@ bool CMMCore::IsCoreDeviceLabel(const char* label) const throw (CMMError)
  * until all success or no more change takes place
  * If errors remain, throw an error
  */
-void CMMCore::applyConfiguration(const Configuration& config) throw (CMMError)
+void CMMCore::applyConfiguration(const Configuration& config) MMCORE_LEGACY_THROW(CMMError)
 {
    std::ostringstream sall;
    bool error = false;
@@ -8388,7 +8388,7 @@ MM::DeviceDetectionStatus CMMCore::detectDevice(const char* label)
  *
  * @param hubDeviceLabel    the label for the device of type Hub
  */
-std::vector<std::string> CMMCore::getInstalledDevices(const char* hubDeviceLabel) throw (CMMError)
+std::vector<std::string> CMMCore::getInstalledDevices(const char* hubDeviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<HubInstance> pHub =
       deviceManager_->GetDeviceOfType<HubInstance>(hubDeviceLabel);
@@ -8397,13 +8397,13 @@ std::vector<std::string> CMMCore::getInstalledDevices(const char* hubDeviceLabel
    return pHub->GetInstalledPeripheralNames();
 }
 
-std::vector<std::string> CMMCore::getLoadedPeripheralDevices(const char* hubLabel) throw (CMMError)
+std::vector<std::string> CMMCore::getLoadedPeripheralDevices(const char* hubLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    CheckDeviceLabel(hubLabel);
    return deviceManager_->GetLoadedPeripherals(hubLabel);
 }
 
-std::string CMMCore::getInstalledDeviceDescription(const char* hubLabel, const char* deviceLabel) throw (CMMError)
+std::string CMMCore::getInstalledDeviceDescription(const char* hubLabel, const char* deviceLabel) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<HubInstance> pHub =
       deviceManager_->GetDeviceOfType<HubInstance>(hubLabel);
@@ -8431,7 +8431,7 @@ std::string CMMCore::getInstalledDeviceDescription(const char* hubLabel, const c
  * not recommended.)
  */
 void CMMCore::loadMockDeviceAdapter(const char* name,
-      MockDeviceAdapter* implementation) throw (CMMError)
+      MockDeviceAdapter* implementation) MMCORE_LEGACY_THROW(CMMError)
 {
    if (!name)
       throw CMMError("Null device adapter name");

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -140,24 +140,24 @@ public:
 
    /** \name Core feature control. */
    ///@{
-   static void enableFeature(const char* name, bool enable) throw (CMMError);
-   static bool isFeatureEnabled(const char* name) throw (CMMError);
+   static void enableFeature(const char* name, bool enable) MMCORE_LEGACY_THROW(CMMError);
+   static bool isFeatureEnabled(const char* name) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name Initialization and setup. */
    ///@{
    void loadDevice(const char* label, const char* moduleName,
-         const char* deviceName) throw (CMMError);
-   void unloadDevice(const char* label) throw (CMMError);
-   void unloadAllDevices() throw (CMMError);
-   void initializeAllDevices() throw (CMMError);
-   void initializeDevice(const char* label) throw (CMMError);
-   DeviceInitializationState getDeviceInitializationState(const char* label) const throw (CMMError);
-   void reset() throw (CMMError);
+         const char* deviceName) MMCORE_LEGACY_THROW(CMMError);
+   void unloadDevice(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   void unloadAllDevices() MMCORE_LEGACY_THROW(CMMError);
+   void initializeAllDevices() MMCORE_LEGACY_THROW(CMMError);
+   void initializeDevice(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   DeviceInitializationState getDeviceInitializationState(const char* label) const MMCORE_LEGACY_THROW(CMMError);
+   void reset() MMCORE_LEGACY_THROW(CMMError);
 
-   void unloadLibrary(const char* moduleName) throw (CMMError);
+   void unloadLibrary(const char* moduleName) MMCORE_LEGACY_THROW(CMMError);
 
-   void updateCoreProperties() throw (CMMError);
+   void updateCoreProperties() MMCORE_LEGACY_THROW(CMMError);
 
    std::string getCoreErrorText(int code) const;
 
@@ -178,18 +178,18 @@ public:
 
    Configuration getSystemState();
    void setSystemState(const Configuration& conf);
-   Configuration getConfigState(const char* group, const char* config) throw (CMMError);
-   Configuration getConfigGroupState(const char* group) throw (CMMError);
-   void saveSystemState(const char* fileName) throw (CMMError);
-   void loadSystemState(const char* fileName) throw (CMMError);
-   void saveSystemConfiguration(const char* fileName) throw (CMMError);
-   void loadSystemConfiguration(const char* fileName) throw (CMMError);
+   Configuration getConfigState(const char* group, const char* config) MMCORE_LEGACY_THROW(CMMError);
+   Configuration getConfigGroupState(const char* group) MMCORE_LEGACY_THROW(CMMError);
+   void saveSystemState(const char* fileName) MMCORE_LEGACY_THROW(CMMError);
+   void loadSystemState(const char* fileName) MMCORE_LEGACY_THROW(CMMError);
+   void saveSystemConfiguration(const char* fileName) MMCORE_LEGACY_THROW(CMMError);
+   void loadSystemConfiguration(const char* fileName) MMCORE_LEGACY_THROW(CMMError);
    void registerCallback(MMEventCallback* cb);
    ///@}
 
    /** \name Logging and log management. */
    ///@{
-   void setPrimaryLogFile(const char* filename, bool truncate = false) throw (CMMError);
+   void setPrimaryLogFile(const char* filename, bool truncate = false) MMCORE_LEGACY_THROW(CMMError);
    std::string getPrimaryLogFile() const;
 
    void logMessage(const char* msg);
@@ -200,8 +200,8 @@ public:
    bool stderrLogEnabled();
 
    int startSecondaryLogFile(const char* filename, bool enableDebug,
-         bool truncate = true, bool synchronous = false) throw (CMMError);
-   void stopSecondaryLogFile(int handle) throw (CMMError);
+         bool truncate = true, bool synchronous = false) MMCORE_LEGACY_THROW(CMMError);
+   void stopSecondaryLogFile(int handle) MMCORE_LEGACY_THROW(CMMError);
 
    ///@}
 
@@ -210,11 +210,11 @@ public:
    std::vector<std::string> getDeviceAdapterSearchPaths();
    void setDeviceAdapterSearchPaths(const std::vector<std::string>& paths);
 
-   std::vector<std::string> getDeviceAdapterNames() throw (CMMError);
+   std::vector<std::string> getDeviceAdapterNames() MMCORE_LEGACY_THROW(CMMError);
 
-   std::vector<std::string> getAvailableDevices(const char* library) throw (CMMError);
-   std::vector<std::string> getAvailableDeviceDescriptions(const char* library) throw (CMMError);
-   std::vector<long> getAvailableDeviceTypes(const char* library) throw (CMMError);
+   std::vector<std::string> getAvailableDevices(const char* library) MMCORE_LEGACY_THROW(CMMError);
+   std::vector<std::string> getAvailableDeviceDescriptions(const char* library) MMCORE_LEGACY_THROW(CMMError);
+   std::vector<long> getAvailableDeviceTypes(const char* library) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name Generic device control.
@@ -224,45 +224,45 @@ public:
    ///@{
    std::vector<std::string> getLoadedDevices() const;
    std::vector<std::string> getLoadedDevicesOfType(MM::DeviceType devType) const;
-   MM::DeviceType getDeviceType(const char* label) throw (CMMError);
-   std::string getDeviceLibrary(const char* label) throw (CMMError);
-   std::string getDeviceName(const char* label) throw (CMMError);
-   std::string getDeviceDescription(const char* label) throw (CMMError);
+   MM::DeviceType getDeviceType(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   std::string getDeviceLibrary(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   std::string getDeviceName(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   std::string getDeviceDescription(const char* label) MMCORE_LEGACY_THROW(CMMError);
 
-   std::vector<std::string> getDevicePropertyNames(const char* label) throw (CMMError);
-   bool hasProperty(const char* label, const char* propName) throw (CMMError);
-   std::string getProperty(const char* label, const char* propName) throw (CMMError);
-   void setProperty(const char* label, const char* propName, const char* propValue) throw (CMMError);
-   void setProperty(const char* label, const char* propName, const bool propValue) throw (CMMError);
-   void setProperty(const char* label, const char* propName, const long propValue) throw (CMMError);
-   void setProperty(const char* label, const char* propName, const float propValue) throw (CMMError);
-   void setProperty(const char* label, const char* propName, const double propValue) throw (CMMError);
+   std::vector<std::string> getDevicePropertyNames(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   bool hasProperty(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   std::string getProperty(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   void setProperty(const char* label, const char* propName, const char* propValue) MMCORE_LEGACY_THROW(CMMError);
+   void setProperty(const char* label, const char* propName, const bool propValue) MMCORE_LEGACY_THROW(CMMError);
+   void setProperty(const char* label, const char* propName, const long propValue) MMCORE_LEGACY_THROW(CMMError);
+   void setProperty(const char* label, const char* propName, const float propValue) MMCORE_LEGACY_THROW(CMMError);
+   void setProperty(const char* label, const char* propName, const double propValue) MMCORE_LEGACY_THROW(CMMError);
 
-   std::vector<std::string> getAllowedPropertyValues(const char* label, const char* propName) throw (CMMError);
-   bool isPropertyReadOnly(const char* label, const char* propName) throw (CMMError);
-   bool isPropertyPreInit(const char* label, const char* propName) throw (CMMError);
-   bool isPropertySequenceable(const char* label, const char* propName) throw (CMMError);
-   bool hasPropertyLimits(const char* label, const char* propName) throw (CMMError);
-   double getPropertyLowerLimit(const char* label, const char* propName) throw (CMMError);
-   double getPropertyUpperLimit(const char* label, const char* propName) throw (CMMError);
-   MM::PropertyType getPropertyType(const char* label, const char* propName) throw (CMMError);
+   std::vector<std::string> getAllowedPropertyValues(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   bool isPropertyReadOnly(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   bool isPropertyPreInit(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   bool isPropertySequenceable(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   bool hasPropertyLimits(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   double getPropertyLowerLimit(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   double getPropertyUpperLimit(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   MM::PropertyType getPropertyType(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
 
-   void startPropertySequence(const char* label, const char* propName) throw (CMMError);
-   void stopPropertySequence(const char* label, const char* propName) throw (CMMError);
-   long getPropertySequenceMaxLength(const char* label, const char* propName) throw (CMMError);
-   void loadPropertySequence(const char* label, const char* propName, std::vector<std::string> eventSequence) throw (CMMError);
+   void startPropertySequence(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   void stopPropertySequence(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   long getPropertySequenceMaxLength(const char* label, const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   void loadPropertySequence(const char* label, const char* propName, std::vector<std::string> eventSequence) MMCORE_LEGACY_THROW(CMMError);
 
-   bool deviceBusy(const char* label) throw (CMMError);
-   void waitForDevice(const char* label) throw (CMMError);
-   void waitForConfig(const char* group, const char* configName) throw (CMMError);
-   bool systemBusy() throw (CMMError);
-   void waitForSystem() throw (CMMError);
-   bool deviceTypeBusy(MM::DeviceType devType) throw (CMMError);
-   void waitForDeviceType(MM::DeviceType devType) throw (CMMError);
+   bool deviceBusy(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   void waitForDevice(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   void waitForConfig(const char* group, const char* configName) MMCORE_LEGACY_THROW(CMMError);
+   bool systemBusy() MMCORE_LEGACY_THROW(CMMError);
+   void waitForSystem() MMCORE_LEGACY_THROW(CMMError);
+   bool deviceTypeBusy(MM::DeviceType devType) MMCORE_LEGACY_THROW(CMMError);
+   void waitForDeviceType(MM::DeviceType devType) MMCORE_LEGACY_THROW(CMMError);
 
-   double getDeviceDelayMs(const char* label) throw (CMMError);
-   void setDeviceDelayMs(const char* label, double delayMs) throw (CMMError);
-   bool usesDeviceDelay(const char* label) throw (CMMError);
+   double getDeviceDelayMs(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   void setDeviceDelayMs(const char* label, double delayMs) MMCORE_LEGACY_THROW(CMMError);
+   bool usesDeviceDelay(const char* label) MMCORE_LEGACY_THROW(CMMError);
 
    void setTimeoutMs(long timeoutMs) {if (timeoutMs > 0) timeoutMs_ = timeoutMs;}
    long getTimeoutMs() { return timeoutMs_;}
@@ -281,15 +281,15 @@ public:
    std::string getSLMDevice();
    std::string getGalvoDevice();
    std::string getChannelGroup();
-   void setCameraDevice(const char* cameraLabel) throw (CMMError);
-   void setShutterDevice(const char* shutterLabel) throw (CMMError);
-   void setFocusDevice(const char* focusLabel) throw (CMMError);
-   void setXYStageDevice(const char* xyStageLabel) throw (CMMError);
-   void setAutoFocusDevice(const char* focusLabel) throw (CMMError);
-   void setImageProcessorDevice(const char* procLabel) throw (CMMError);
-   void setSLMDevice(const char* slmLabel) throw (CMMError);
-   void setGalvoDevice(const char* galvoLabel) throw (CMMError);
-   void setChannelGroup(const char* channelGroup) throw (CMMError);
+   void setCameraDevice(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setShutterDevice(const char* shutterLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setFocusDevice(const char* focusLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setXYStageDevice(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setAutoFocusDevice(const char* focusLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setImageProcessorDevice(const char* procLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setSLMDevice(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setGalvoDevice(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setChannelGroup(const char* channelGroup) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name System state cache.
@@ -301,99 +301,99 @@ public:
    Configuration getSystemStateCache() const;
    void updateSystemStateCache();
    std::string getPropertyFromCache(const char* deviceLabel,
-         const char* propName) const throw (CMMError);
-   std::string getCurrentConfigFromCache(const char* groupName) throw (CMMError);
-   Configuration getConfigGroupStateFromCache(const char* group) throw (CMMError);
+         const char* propName) const MMCORE_LEGACY_THROW(CMMError);
+   std::string getCurrentConfigFromCache(const char* groupName) MMCORE_LEGACY_THROW(CMMError);
+   Configuration getConfigGroupStateFromCache(const char* group) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name Configuration groups. */
    ///@{
-   void defineConfig(const char* groupName, const char* configName) throw (CMMError);
+   void defineConfig(const char* groupName, const char* configName) MMCORE_LEGACY_THROW(CMMError);
    void defineConfig(const char* groupName, const char* configName,
          const char* deviceLabel, const char* propName,
-         const char* value) throw (CMMError);
-   void defineConfigGroup(const char* groupName) throw (CMMError);
-   void deleteConfigGroup(const char* groupName) throw (CMMError);
+         const char* value) MMCORE_LEGACY_THROW(CMMError);
+   void defineConfigGroup(const char* groupName) MMCORE_LEGACY_THROW(CMMError);
+   void deleteConfigGroup(const char* groupName) MMCORE_LEGACY_THROW(CMMError);
    void renameConfigGroup(const char* oldGroupName,
-         const char* newGroupName) throw (CMMError);
+         const char* newGroupName) MMCORE_LEGACY_THROW(CMMError);
    bool isGroupDefined(const char* groupName);
    bool isConfigDefined(const char* groupName, const char* configName);
-   void setConfig(const char* groupName, const char* configName) throw (CMMError);
-   void deleteConfig(const char* groupName, const char* configName) throw (CMMError);
+   void setConfig(const char* groupName, const char* configName) MMCORE_LEGACY_THROW(CMMError);
+   void deleteConfig(const char* groupName, const char* configName) MMCORE_LEGACY_THROW(CMMError);
    void deleteConfig(const char* groupName, const char* configName,
-         const char* deviceLabel, const char* propName) throw (CMMError);
+         const char* deviceLabel, const char* propName) MMCORE_LEGACY_THROW(CMMError);
    void renameConfig(const char* groupName, const char* oldConfigName,
-         const char* newConfigName) throw (CMMError);
+         const char* newConfigName) MMCORE_LEGACY_THROW(CMMError);
    std::vector<std::string> getAvailableConfigGroups() const;
    std::vector<std::string> getAvailableConfigs(const char* configGroup) const;
-   std::string getCurrentConfig(const char* groupName) throw (CMMError);
+   std::string getCurrentConfig(const char* groupName) MMCORE_LEGACY_THROW(CMMError);
    Configuration getConfigData(const char* configGroup,
-         const char* configName) throw (CMMError);
+         const char* configName) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name The pixel size configuration group. */
    ///@{
-   std::string getCurrentPixelSizeConfig() throw (CMMError);
-   std::string getCurrentPixelSizeConfig(bool cached) throw (CMMError);
+   std::string getCurrentPixelSizeConfig() MMCORE_LEGACY_THROW(CMMError);
+   std::string getCurrentPixelSizeConfig(bool cached) MMCORE_LEGACY_THROW(CMMError);
    double getPixelSizeUm();
    double getPixelSizeUm(bool cached);
-   double getPixelSizeUmByID(const char* resolutionID) throw (CMMError);
-   std::vector<double> getPixelSizeAffine() throw (CMMError);
-   std::vector<double> getPixelSizeAffine(bool cached) throw (CMMError);
-   std::vector<double> getPixelSizeAffineByID(const char* resolutionID) throw (CMMError);
-   double getPixelSizedxdz() throw (CMMError);
-   double getPixelSizedxdz(bool cached) throw (CMMError);
-   double getPixelSizedxdz(const char* resolutionID) throw (CMMError);
-   double getPixelSizedydz() throw (CMMError);
-   double getPixelSizedydz(bool cached) throw (CMMError);
-   double getPixelSizedydz(const char* resolutionID) throw (CMMError);
-   double getPixelSizeOptimalZUm() throw (CMMError);
-   double getPixelSizeOptimalZUm(bool cached) throw (CMMError);
-   double getPixelSizeOptimalZUm(const char* resolutionID) throw (CMMError);
+   double getPixelSizeUmByID(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError);
+   std::vector<double> getPixelSizeAffine() MMCORE_LEGACY_THROW(CMMError);
+   std::vector<double> getPixelSizeAffine(bool cached) MMCORE_LEGACY_THROW(CMMError);
+   std::vector<double> getPixelSizeAffineByID(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError);
+   double getPixelSizedxdz() MMCORE_LEGACY_THROW(CMMError);
+   double getPixelSizedxdz(bool cached) MMCORE_LEGACY_THROW(CMMError);
+   double getPixelSizedxdz(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError);
+   double getPixelSizedydz() MMCORE_LEGACY_THROW(CMMError);
+   double getPixelSizedydz(bool cached) MMCORE_LEGACY_THROW(CMMError);
+   double getPixelSizedydz(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError);
+   double getPixelSizeOptimalZUm() MMCORE_LEGACY_THROW(CMMError);
+   double getPixelSizeOptimalZUm(bool cached) MMCORE_LEGACY_THROW(CMMError);
+   double getPixelSizeOptimalZUm(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError);
    double getMagnificationFactor() const;
-   void setPixelSizeUm(const char* resolutionID, double pixSize)  throw (CMMError);
-   void setPixelSizeAffine(const char* resolutionID, std::vector<double> affine)  throw (CMMError);
-   void setPixelSizedxdz(const char* resolutionID, double dXdZ)  throw (CMMError);
-   void setPixelSizedydz(const char* resolutionID, double dYdZ)  throw (CMMError);
-   void setPixelSizeOptimalZUm(const char* resolutionID, double optimalZ)  throw (CMMError);
+   void setPixelSizeUm(const char* resolutionID, double pixSize)  MMCORE_LEGACY_THROW(CMMError);
+   void setPixelSizeAffine(const char* resolutionID, std::vector<double> affine)  MMCORE_LEGACY_THROW(CMMError);
+   void setPixelSizedxdz(const char* resolutionID, double dXdZ)  MMCORE_LEGACY_THROW(CMMError);
+   void setPixelSizedydz(const char* resolutionID, double dYdZ)  MMCORE_LEGACY_THROW(CMMError);
+   void setPixelSizeOptimalZUm(const char* resolutionID, double optimalZ)  MMCORE_LEGACY_THROW(CMMError);
    void definePixelSizeConfig(const char* resolutionID,
          const char* deviceLabel, const char* propName,
-         const char* value) throw (CMMError);
-   void definePixelSizeConfig(const char* resolutionID) throw (CMMError);
+         const char* value) MMCORE_LEGACY_THROW(CMMError);
+   void definePixelSizeConfig(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError);
    std::vector<std::string> getAvailablePixelSizeConfigs() const;
-   bool isPixelSizeConfigDefined(const char* resolutionID) const throw (CMMError);
-   void setPixelSizeConfig(const char* resolutionID) throw (CMMError);
+   bool isPixelSizeConfigDefined(const char* resolutionID) const MMCORE_LEGACY_THROW(CMMError);
+   void setPixelSizeConfig(const char* resolutionID) MMCORE_LEGACY_THROW(CMMError);
    void renamePixelSizeConfig(const char* oldConfigName,
-         const char* newConfigName) throw (CMMError);
-   void deletePixelSizeConfig(const char* configName) throw (CMMError);
-   Configuration getPixelSizeConfigData(const char* configName) throw (CMMError);
+         const char* newConfigName) MMCORE_LEGACY_THROW(CMMError);
+   void deletePixelSizeConfig(const char* configName) MMCORE_LEGACY_THROW(CMMError);
+   Configuration getPixelSizeConfigData(const char* configName) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name Image acquisition. */
    ///@{
-   void setROI(int x, int y, int xSize, int ySize) throw (CMMError);
-   void setROI(const char* label, int x, int y, int xSize, int ySize) throw (CMMError);
-   void getROI(int& x, int& y, int& xSize, int& ySize) throw (CMMError);
-   void getROI(const char* label, int& x, int& y, int& xSize, int& ySize) throw (CMMError);
-   void clearROI() throw (CMMError);
+   void setROI(int x, int y, int xSize, int ySize) MMCORE_LEGACY_THROW(CMMError);
+   void setROI(const char* label, int x, int y, int xSize, int ySize) MMCORE_LEGACY_THROW(CMMError);
+   void getROI(int& x, int& y, int& xSize, int& ySize) MMCORE_LEGACY_THROW(CMMError);
+   void getROI(const char* label, int& x, int& y, int& xSize, int& ySize) MMCORE_LEGACY_THROW(CMMError);
+   void clearROI() MMCORE_LEGACY_THROW(CMMError);
 
-   bool isMultiROISupported() throw (CMMError);
-   bool isMultiROIEnabled() throw (CMMError);
+   bool isMultiROISupported() MMCORE_LEGACY_THROW(CMMError);
+   bool isMultiROIEnabled() MMCORE_LEGACY_THROW(CMMError);
    void setMultiROI(std::vector<unsigned> xs, std::vector<unsigned> ys,
            std::vector<unsigned> widths,
-           std::vector<unsigned> heights) throw (CMMError);
+           std::vector<unsigned> heights) MMCORE_LEGACY_THROW(CMMError);
    void getMultiROI(std::vector<unsigned>& xs, std::vector<unsigned>& ys,
            std::vector<unsigned>& widths,
-           std::vector<unsigned>& heights) throw (CMMError);
+           std::vector<unsigned>& heights) MMCORE_LEGACY_THROW(CMMError);
 
-   void setExposure(double exp) throw (CMMError);
-   void setExposure(const char* cameraLabel, double dExp) throw (CMMError);
-   double getExposure() throw (CMMError);
-   double getExposure(const char* label) throw (CMMError);
+   void setExposure(double exp) MMCORE_LEGACY_THROW(CMMError);
+   void setExposure(const char* cameraLabel, double dExp) MMCORE_LEGACY_THROW(CMMError);
+   double getExposure() MMCORE_LEGACY_THROW(CMMError);
+   double getExposure(const char* label) MMCORE_LEGACY_THROW(CMMError);
 
-   void snapImage() throw (CMMError);
-   void* getImage() throw (CMMError);
-   void* getImage(unsigned numChannel) throw (CMMError);
+   void snapImage() MMCORE_LEGACY_THROW(CMMError);
+   void* getImage() MMCORE_LEGACY_THROW(CMMError);
+   void* getImage(unsigned numChannel) MMCORE_LEGACY_THROW(CMMError);
 
    unsigned getImageWidth();
    unsigned getImageHeight();
@@ -406,140 +406,140 @@ public:
 
    void setAutoShutter(bool state);
    bool getAutoShutter();
-   void setShutterOpen(bool state) throw (CMMError);
-   bool getShutterOpen() throw (CMMError);
-   void setShutterOpen(const char* shutterLabel, bool state) throw (CMMError);
-   bool getShutterOpen(const char* shutterLabel) throw (CMMError);
+   void setShutterOpen(bool state) MMCORE_LEGACY_THROW(CMMError);
+   bool getShutterOpen() MMCORE_LEGACY_THROW(CMMError);
+   void setShutterOpen(const char* shutterLabel, bool state) MMCORE_LEGACY_THROW(CMMError);
+   bool getShutterOpen(const char* shutterLabel) MMCORE_LEGACY_THROW(CMMError);
 
    void startSequenceAcquisition(long numImages, double intervalMs,
-         bool stopOnOverflow) throw (CMMError);
+         bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError);
    void startSequenceAcquisition(const char* cameraLabel, long numImages,
-         double intervalMs, bool stopOnOverflow) throw (CMMError);
-   void prepareSequenceAcquisition(const char* cameraLabel) throw (CMMError);
-   void startContinuousSequenceAcquisition(double intervalMs) throw (CMMError);
-   void stopSequenceAcquisition() throw (CMMError);
-   void stopSequenceAcquisition(const char* cameraLabel) throw (CMMError);
-   bool isSequenceRunning() throw ();
-   bool isSequenceRunning(const char* cameraLabel) throw (CMMError);
+         double intervalMs, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError);
+   void prepareSequenceAcquisition(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
+   void startContinuousSequenceAcquisition(double intervalMs) MMCORE_LEGACY_THROW(CMMError);
+   void stopSequenceAcquisition() MMCORE_LEGACY_THROW(CMMError);
+   void stopSequenceAcquisition(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
+   bool isSequenceRunning() MMCORE_NOEXCEPT;
+   bool isSequenceRunning(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
 
-   void* getLastImage() throw (CMMError);
-   void* popNextImage() throw (CMMError);
+   void* getLastImage() MMCORE_LEGACY_THROW(CMMError);
+   void* popNextImage() MMCORE_LEGACY_THROW(CMMError);
    void* getLastImageMD(unsigned channel, unsigned slice, Metadata& md)
-      const throw (CMMError);
+      const MMCORE_LEGACY_THROW(CMMError);
    void* popNextImageMD(unsigned channel, unsigned slice, Metadata& md)
-      throw (CMMError);
-   void* getLastImageMD(Metadata& md) const throw (CMMError);
+      MMCORE_LEGACY_THROW(CMMError);
+   void* getLastImageMD(Metadata& md) const MMCORE_LEGACY_THROW(CMMError);
    void* getNBeforeLastImageMD(unsigned long n, Metadata& md)
-      const throw (CMMError);
-   void* popNextImageMD(Metadata& md) throw (CMMError);
+      const MMCORE_LEGACY_THROW(CMMError);
+   void* popNextImageMD(Metadata& md) MMCORE_LEGACY_THROW(CMMError);
 
    long getRemainingImageCount();
    long getBufferTotalCapacity();
    long getBufferFreeCapacity();
    bool isBufferOverflowed() const;
-   void setCircularBufferMemoryFootprint(unsigned sizeMB) throw (CMMError);
+   void setCircularBufferMemoryFootprint(unsigned sizeMB) MMCORE_LEGACY_THROW(CMMError);
    unsigned getCircularBufferMemoryFootprint();
-   void initializeCircularBuffer() throw (CMMError);
-   void clearCircularBuffer() throw (CMMError);
+   void initializeCircularBuffer() MMCORE_LEGACY_THROW(CMMError);
+   void clearCircularBuffer() MMCORE_LEGACY_THROW(CMMError);
 
-   bool isExposureSequenceable(const char* cameraLabel) throw (CMMError);
-   void startExposureSequence(const char* cameraLabel) throw (CMMError);
-   void stopExposureSequence(const char* cameraLabel) throw (CMMError);
-   long getExposureSequenceMaxLength(const char* cameraLabel) throw (CMMError);
+   bool isExposureSequenceable(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
+   void startExposureSequence(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
+   void stopExposureSequence(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
+   long getExposureSequenceMaxLength(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
    void loadExposureSequence(const char* cameraLabel,
-         std::vector<double> exposureSequence_ms) throw (CMMError);
+         std::vector<double> exposureSequence_ms) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name Autofocus control. */
    ///@{
    double getLastFocusScore();
    double getCurrentFocusScore();
-   void enableContinuousFocus(bool enable) throw (CMMError);
-   bool isContinuousFocusEnabled() throw (CMMError);
-   bool isContinuousFocusLocked() throw (CMMError);
-   bool isContinuousFocusDrive(const char* stageLabel) throw (CMMError);
-   void fullFocus() throw (CMMError);
-   void incrementalFocus() throw (CMMError);
-   void setAutoFocusOffset(double offset) throw (CMMError);
-   double getAutoFocusOffset() throw (CMMError);
+   void enableContinuousFocus(bool enable) MMCORE_LEGACY_THROW(CMMError);
+   bool isContinuousFocusEnabled() MMCORE_LEGACY_THROW(CMMError);
+   bool isContinuousFocusLocked() MMCORE_LEGACY_THROW(CMMError);
+   bool isContinuousFocusDrive(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void fullFocus() MMCORE_LEGACY_THROW(CMMError);
+   void incrementalFocus() MMCORE_LEGACY_THROW(CMMError);
+   void setAutoFocusOffset(double offset) MMCORE_LEGACY_THROW(CMMError);
+   double getAutoFocusOffset() MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name State device control. */
    ///@{
-   void setState(const char* stateDeviceLabel, long state) throw (CMMError);
-   long getState(const char* stateDeviceLabel) throw (CMMError);
+   void setState(const char* stateDeviceLabel, long state) MMCORE_LEGACY_THROW(CMMError);
+   long getState(const char* stateDeviceLabel) MMCORE_LEGACY_THROW(CMMError);
    long getNumberOfStates(const char* stateDeviceLabel);
    void setStateLabel(const char* stateDeviceLabel,
-         const char* stateLabel) throw (CMMError);
-   std::string getStateLabel(const char* stateDeviceLabel) throw (CMMError);
+         const char* stateLabel) MMCORE_LEGACY_THROW(CMMError);
+   std::string getStateLabel(const char* stateDeviceLabel) MMCORE_LEGACY_THROW(CMMError);
    void defineStateLabel(const char* stateDeviceLabel,
-         long state, const char* stateLabel) throw (CMMError);
+         long state, const char* stateLabel) MMCORE_LEGACY_THROW(CMMError);
    std::vector<std::string> getStateLabels(const char* stateDeviceLabel)
-      throw (CMMError);
+      MMCORE_LEGACY_THROW(CMMError);
    long getStateFromLabel(const char* stateDeviceLabel,
-         const char* stateLabel) throw (CMMError);
+         const char* stateLabel) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name Focus (Z) stage control. */
    ///@{
-   void setPosition(const char* stageLabel, double position) throw (CMMError);
-   void setPosition(double position) throw (CMMError);
-   double getPosition(const char* stageLabel) throw (CMMError);
-   double getPosition() throw (CMMError);
-   void setRelativePosition(const char* stageLabel, double d) throw (CMMError);
-   void setRelativePosition(double d) throw (CMMError);
-   void setOrigin(const char* stageLabel) throw (CMMError);
-   void setOrigin() throw (CMMError);
-   void setAdapterOrigin(const char* stageLabel, double newZUm) throw (CMMError);
-   void setAdapterOrigin(double newZUm) throw (CMMError);
+   void setPosition(const char* stageLabel, double position) MMCORE_LEGACY_THROW(CMMError);
+   void setPosition(double position) MMCORE_LEGACY_THROW(CMMError);
+   double getPosition(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError);
+   double getPosition() MMCORE_LEGACY_THROW(CMMError);
+   void setRelativePosition(const char* stageLabel, double d) MMCORE_LEGACY_THROW(CMMError);
+   void setRelativePosition(double d) MMCORE_LEGACY_THROW(CMMError);
+   void setOrigin(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setOrigin() MMCORE_LEGACY_THROW(CMMError);
+   void setAdapterOrigin(const char* stageLabel, double newZUm) MMCORE_LEGACY_THROW(CMMError);
+   void setAdapterOrigin(double newZUm) MMCORE_LEGACY_THROW(CMMError);
 
    void setFocusDirection(const char* stageLabel, int sign);
-   int getFocusDirection(const char* stageLabel) throw (CMMError);
+   int getFocusDirection(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError);
 
-   bool isStageSequenceable(const char* stageLabel) throw (CMMError);
-   bool isStageLinearSequenceable(const char* stageLabel) throw (CMMError);
-   void startStageSequence(const char* stageLabel) throw (CMMError);
-   void stopStageSequence(const char* stageLabel) throw (CMMError);
-   long getStageSequenceMaxLength(const char* stageLabel) throw (CMMError);
+   bool isStageSequenceable(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError);
+   bool isStageLinearSequenceable(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void startStageSequence(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void stopStageSequence(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError);
+   long getStageSequenceMaxLength(const char* stageLabel) MMCORE_LEGACY_THROW(CMMError);
    void loadStageSequence(const char* stageLabel,
-         std::vector<double> positionSequence) throw (CMMError);
-   void setStageLinearSequence(const char* stageLabel, double dZ_um, int nSlices) throw (CMMError);
+         std::vector<double> positionSequence) MMCORE_LEGACY_THROW(CMMError);
+   void setStageLinearSequence(const char* stageLabel, double dZ_um, int nSlices) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name XY stage control. */
    ///@{
    void setXYPosition(const char* xyStageLabel,
-         double x, double y) throw (CMMError);
-   void setXYPosition(double x, double y) throw (CMMError);
+         double x, double y) MMCORE_LEGACY_THROW(CMMError);
+   void setXYPosition(double x, double y) MMCORE_LEGACY_THROW(CMMError);
    void setRelativeXYPosition(const char* xyStageLabel,
-         double dx, double dy) throw (CMMError);
-   void setRelativeXYPosition(double dx, double dy) throw (CMMError);
+         double dx, double dy) MMCORE_LEGACY_THROW(CMMError);
+   void setRelativeXYPosition(double dx, double dy) MMCORE_LEGACY_THROW(CMMError);
    void getXYPosition(const char* xyStageLabel,
-         double &x_stage, double &y_stage) throw (CMMError);
-   void getXYPosition(double &x_stage, double &y_stage) throw (CMMError);
-   double getXPosition(const char* xyStageLabel) throw (CMMError);
-   double getYPosition(const char* xyStageLabel) throw (CMMError);
-   double getXPosition() throw (CMMError);
-   double getYPosition() throw (CMMError);
-   void stop(const char* xyOrZStageLabel) throw (CMMError);
-   void home(const char* xyOrZStageLabel) throw (CMMError);
-   void setOriginXY(const char* xyStageLabel) throw (CMMError);
-   void setOriginXY() throw (CMMError);
-   void setOriginX(const char* xyStageLabel) throw (CMMError);
-   void setOriginX() throw (CMMError);
-   void setOriginY(const char* xyStageLabel) throw (CMMError);
-   void setOriginY() throw (CMMError);
+         double &x_stage, double &y_stage) MMCORE_LEGACY_THROW(CMMError);
+   void getXYPosition(double &x_stage, double &y_stage) MMCORE_LEGACY_THROW(CMMError);
+   double getXPosition(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   double getYPosition(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   double getXPosition() MMCORE_LEGACY_THROW(CMMError);
+   double getYPosition() MMCORE_LEGACY_THROW(CMMError);
+   void stop(const char* xyOrZStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void home(const char* xyOrZStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setOriginXY(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setOriginXY() MMCORE_LEGACY_THROW(CMMError);
+   void setOriginX(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setOriginX() MMCORE_LEGACY_THROW(CMMError);
+   void setOriginY(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setOriginY() MMCORE_LEGACY_THROW(CMMError);
    void setAdapterOriginXY(const char* xyStageLabel,
-         double newXUm, double newYUm) throw (CMMError);
-   void setAdapterOriginXY(double newXUm, double newYUm) throw (CMMError);
+         double newXUm, double newYUm) MMCORE_LEGACY_THROW(CMMError);
+   void setAdapterOriginXY(double newXUm, double newYUm) MMCORE_LEGACY_THROW(CMMError);
 
-   bool isXYStageSequenceable(const char* xyStageLabel) throw (CMMError);
-   void startXYStageSequence(const char* xyStageLabel) throw (CMMError);
-   void stopXYStageSequence(const char* xyStageLabel) throw (CMMError);
-   long getXYStageSequenceMaxLength(const char* xyStageLabel) throw (CMMError);
+   bool isXYStageSequenceable(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void startXYStageSequence(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   void stopXYStageSequence(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
+   long getXYStageSequenceMaxLength(const char* xyStageLabel) MMCORE_LEGACY_THROW(CMMError);
    void loadXYStageSequence(const char* xyStageLabel,
          std::vector<double> xSequence,
-         std::vector<double> ySequence) throw (CMMError);
+         std::vector<double> ySequence) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name Serial port control. */
@@ -550,16 +550,16 @@ public:
       const char* delayBetweenCharsMs,
       const char* handshaking,
       const char* parity,
-      const char* stopBits) throw (CMMError);
+      const char* stopBits) MMCORE_LEGACY_THROW(CMMError);
 
    void setSerialPortCommand(const char* portLabel, const char* command,
-         const char* term) throw (CMMError);
+         const char* term) MMCORE_LEGACY_THROW(CMMError);
    std::string getSerialPortAnswer(const char* portLabel,
-         const char* term) throw (CMMError);
+         const char* term) MMCORE_LEGACY_THROW(CMMError);
    void writeToSerialPort(const char* portLabel,
-         const std::vector<char> &data) throw (CMMError);
+         const std::vector<char> &data) MMCORE_LEGACY_THROW(CMMError);
    std::vector<char> readFromSerialPort(const char* portLabel)
-      throw (CMMError);
+      MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name SLM control.
@@ -569,27 +569,27 @@ public:
     */
    ///@{
    void setSLMImage(const char* slmLabel,
-         unsigned char * pixels) throw (CMMError);
-   void setSLMImage(const char* slmLabel, imgRGB32 pixels) throw (CMMError);
+         unsigned char * pixels) MMCORE_LEGACY_THROW(CMMError);
+   void setSLMImage(const char* slmLabel, imgRGB32 pixels) MMCORE_LEGACY_THROW(CMMError);
    void setSLMPixelsTo(const char* slmLabel,
-         unsigned char intensity) throw (CMMError);
+         unsigned char intensity) MMCORE_LEGACY_THROW(CMMError);
    void setSLMPixelsTo(const char* slmLabel,
          unsigned char red, unsigned char green,
-         unsigned char blue) throw (CMMError);
-   void displaySLMImage(const char* slmLabel) throw (CMMError);
+         unsigned char blue) MMCORE_LEGACY_THROW(CMMError);
+   void displaySLMImage(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
    void setSLMExposure(const char* slmLabel, double exposure_ms)
-      throw (CMMError);
-   double getSLMExposure(const char* slmLabel) throw (CMMError);
-   unsigned getSLMWidth(const char* slmLabel) throw (CMMError);
-   unsigned getSLMHeight(const char* slmLabel) throw (CMMError);
-   unsigned getSLMNumberOfComponents(const char* slmLabel) throw (CMMError);
-   unsigned getSLMBytesPerPixel(const char* slmLabel) throw (CMMError);
+      MMCORE_LEGACY_THROW(CMMError);
+   double getSLMExposure(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
+   unsigned getSLMWidth(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
+   unsigned getSLMHeight(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
+   unsigned getSLMNumberOfComponents(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
+   unsigned getSLMBytesPerPixel(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
 
-   long getSLMSequenceMaxLength(const char* slmLabel) throw (CMMError);
-   void startSLMSequence(const char* slmLabel) throw (CMMError);
-   void stopSLMSequence(const char* slmLabel) throw (CMMError);
+   long getSLMSequenceMaxLength(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
+   void startSLMSequence(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
+   void stopSLMSequence(const char* slmLabel) MMCORE_LEGACY_THROW(CMMError);
    void loadSLMSequence(const char* slmLabel,
-         std::vector<unsigned char*> imageSequence) throw (CMMError);
+         std::vector<unsigned char*> imageSequence) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name Galvo control.
@@ -598,28 +598,28 @@ public:
     */
    ///@{
    void pointGalvoAndFire(const char* galvoLabel, double x, double y,
-         double pulseTime_us) throw (CMMError);
+         double pulseTime_us) MMCORE_LEGACY_THROW(CMMError);
    void setGalvoSpotInterval(const char* galvoLabel,
-         double pulseTime_us) throw (CMMError);
+         double pulseTime_us) MMCORE_LEGACY_THROW(CMMError);
    void setGalvoPosition(const char* galvoLabel, double x, double y)
-      throw (CMMError);
+      MMCORE_LEGACY_THROW(CMMError);
    void getGalvoPosition(const char* galvoLabel,
-         double &x_stage, double &y_stage) throw (CMMError); // using x_stage to get swig to work
+         double &x_stage, double &y_stage) MMCORE_LEGACY_THROW(CMMError); // using x_stage to get swig to work
    void setGalvoIlluminationState(const char* galvoLabel, bool on)
-      throw (CMMError);
-   double getGalvoXRange(const char* galvoLabel) throw (CMMError);
-   double getGalvoXMinimum(const char* galvoLabel) throw (CMMError);
-   double getGalvoYRange(const char* galvoLabel) throw (CMMError);
-   double getGalvoYMinimum(const char* galvoLabel) throw (CMMError);
+      MMCORE_LEGACY_THROW(CMMError);
+   double getGalvoXRange(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
+   double getGalvoXMinimum(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
+   double getGalvoYRange(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
+   double getGalvoYMinimum(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
    void addGalvoPolygonVertex(const char* galvoLabel, int polygonIndex,
-         double x, double y) throw (CMMError);
-   void deleteGalvoPolygons(const char* galvoLabel) throw (CMMError);
-   void loadGalvoPolygons(const char* galvoLabel) throw (CMMError);
+         double x, double y) MMCORE_LEGACY_THROW(CMMError);
+   void deleteGalvoPolygons(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
+   void loadGalvoPolygons(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
    void setGalvoPolygonRepetitions(const char* galvoLabel, int repetitions)
-      throw (CMMError);
-   void runGalvoPolygons(const char* galvoLabel) throw (CMMError);
-   void runGalvoSequence(const char* galvoLabel) throw (CMMError);
-   std::string getGalvoChannel(const char* galvoLabel) throw (CMMError);
+      MMCORE_LEGACY_THROW(CMMError);
+   void runGalvoPolygons(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
+   void runGalvoSequence(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
+   std::string getGalvoChannel(const char* galvoLabel) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name PressurePump control
@@ -627,11 +627,11 @@ public:
    * Control of pressure pumps
    */
    ///@{
-   void pressurePumpStop(const char* pumpLabel) throw (CMMError);
-   void pressurePumpCalibrate(const char* pumpLabel) throw (CMMError);
-   bool pressurePumpRequiresCalibration(const char* pumpLabel) throw (CMMError);
-   void setPumpPressureKPa(const char* pumplabel, double pressure) throw (CMMError);
-   double getPumpPressureKPa(const char* pumplabel) throw (CMMError);
+   void pressurePumpStop(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   void pressurePumpCalibrate(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   bool pressurePumpRequiresCalibration(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setPumpPressureKPa(const char* pumplabel, double pressure) MMCORE_LEGACY_THROW(CMMError);
+   double getPumpPressureKPa(const char* pumplabel) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name VolumetricPump control
@@ -639,20 +639,20 @@ public:
    * Control of volumetric pumps
    */
    ///@{
-   void volumetricPumpStop(const char* pumpLabel) throw (CMMError);
-   void volumetricPumpHome(const char* pumpLabel) throw (CMMError);
-   bool volumetricPumpRequiresHoming(const char* pumpLabel) throw (CMMError);
-   void invertPumpDirection(const char* pumpLabel, bool invert) throw (CMMError);
-   bool isPumpDirectionInverted(const char* pumpLabel) throw (CMMError);
-   void setPumpVolume(const char* pumpLabel, double volume) throw (CMMError);
-   double getPumpVolume(const char* pumpLabel) throw (CMMError);
-   void setPumpMaxVolume(const char* pumpLabel, double volume) throw (CMMError);
-   double getPumpMaxVolume(const char* pumpLabel) throw (CMMError);
-   void setPumpFlowrate(const char* pumpLabel, double volume) throw (CMMError);
-   double getPumpFlowrate(const char* pumpLabel) throw (CMMError);
-   void pumpStart(const char* pumpLabel) throw (CMMError);
-   void pumpDispenseDurationSeconds(const char* pumpLabel, double seconds) throw (CMMError);
-   void pumpDispenseVolumeUl(const char* pumpLabel, double microLiter) throw (CMMError);
+   void volumetricPumpStop(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   void volumetricPumpHome(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   bool volumetricPumpRequiresHoming(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   void invertPumpDirection(const char* pumpLabel, bool invert) MMCORE_LEGACY_THROW(CMMError);
+   bool isPumpDirectionInverted(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setPumpVolume(const char* pumpLabel, double volume) MMCORE_LEGACY_THROW(CMMError);
+   double getPumpVolume(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setPumpMaxVolume(const char* pumpLabel, double volume) MMCORE_LEGACY_THROW(CMMError);
+   double getPumpMaxVolume(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   void setPumpFlowrate(const char* pumpLabel, double volume) MMCORE_LEGACY_THROW(CMMError);
+   double getPumpFlowrate(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   void pumpStart(const char* pumpLabel) MMCORE_LEGACY_THROW(CMMError);
+   void pumpDispenseDurationSeconds(const char* pumpLabel, double seconds) MMCORE_LEGACY_THROW(CMMError);
+   void pumpDispenseVolumeUl(const char* pumpLabel, double microLiter) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
    /** \name Device discovery. */
@@ -663,21 +663,21 @@ public:
 
    /** \name Hub and peripheral devices. */
    ///@{
-   std::string getParentLabel(const char* peripheralLabel) throw (CMMError);
+   std::string getParentLabel(const char* peripheralLabel) MMCORE_LEGACY_THROW(CMMError);
    void setParentLabel(const char* deviceLabel,
-         const char* parentHubLabel) throw (CMMError);
+         const char* parentHubLabel) MMCORE_LEGACY_THROW(CMMError);
 
-   std::vector<std::string> getInstalledDevices(const char* hubLabel) throw (CMMError);
+   std::vector<std::string> getInstalledDevices(const char* hubLabel) MMCORE_LEGACY_THROW(CMMError);
    std::string getInstalledDeviceDescription(const char* hubLabel,
-         const char* peripheralLabel) throw (CMMError);
-   std::vector<std::string> getLoadedPeripheralDevices(const char* hubLabel) throw (CMMError);
+         const char* peripheralLabel) MMCORE_LEGACY_THROW(CMMError);
+   std::vector<std::string> getLoadedPeripheralDevices(const char* hubLabel) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 
 #if !defined(SWIGJAVA) && !defined(SWIGPYTHON)
    /** \name Testing */
    ///@{
    void loadMockDeviceAdapter(const char* name,
-         MockDeviceAdapter* implementation) throw (CMMError);
+         MockDeviceAdapter* implementation) MMCORE_LEGACY_THROW(CMMError);
    ///@}
 #endif
 
@@ -737,26 +737,26 @@ private:
    void CreateCoreProperties();
 
    // Parameter/value validation
-   static void CheckDeviceLabel(const char* label) throw (CMMError);
-   static void CheckPropertyName(const char* propName) throw (CMMError);
-   static void CheckPropertyValue(const char* propValue) throw (CMMError);
-   static void CheckStateLabel(const char* stateLabel) throw (CMMError);
-   static void CheckConfigGroupName(const char* groupName) throw (CMMError);
-   static void CheckConfigPresetName(const char* presetName) throw (CMMError);
-   bool IsCoreDeviceLabel(const char* label) const throw (CMMError);
+   static void CheckDeviceLabel(const char* label) MMCORE_LEGACY_THROW(CMMError);
+   static void CheckPropertyName(const char* propName) MMCORE_LEGACY_THROW(CMMError);
+   static void CheckPropertyValue(const char* propValue) MMCORE_LEGACY_THROW(CMMError);
+   static void CheckStateLabel(const char* stateLabel) MMCORE_LEGACY_THROW(CMMError);
+   static void CheckConfigGroupName(const char* groupName) MMCORE_LEGACY_THROW(CMMError);
+   static void CheckConfigPresetName(const char* presetName) MMCORE_LEGACY_THROW(CMMError);
+   bool IsCoreDeviceLabel(const char* label) const MMCORE_LEGACY_THROW(CMMError);
 
-   void applyConfiguration(const Configuration& config) throw (CMMError);
+   void applyConfiguration(const Configuration& config) MMCORE_LEGACY_THROW(CMMError);
    int applyProperties(std::vector<PropertySetting>& props, std::string& lastError);
-   void waitForDevice(std::shared_ptr<DeviceInstance> pDev) throw (CMMError);
-   Configuration getConfigGroupState(const char* group, bool fromCache) throw (CMMError);
+   void waitForDevice(std::shared_ptr<DeviceInstance> pDev) MMCORE_LEGACY_THROW(CMMError);
+   Configuration getConfigGroupState(const char* group, bool fromCache) MMCORE_LEGACY_THROW(CMMError);
    std::string getDeviceErrorText(int deviceCode, std::shared_ptr<DeviceInstance> pDevice);
    std::string getDeviceName(std::shared_ptr<DeviceInstance> pDev);
    void logError(const char* device, const char* msg);
    void updateAllowedChannelGroups();
    void assignDefaultRole(std::shared_ptr<DeviceInstance> pDev);
-   void updateCoreProperty(const char* propName, MM::DeviceType devType) throw (CMMError);
-   void loadSystemConfigurationImpl(const char* fileName) throw (CMMError);
-   void initializeAllDevicesSerial() throw (CMMError);
-   void initializeAllDevicesParallel() throw (CMMError);
+   void updateCoreProperty(const char* propName, MM::DeviceType devType) MMCORE_LEGACY_THROW(CMMError);
+   void loadSystemConfigurationImpl(const char* fileName) MMCORE_LEGACY_THROW(CMMError);
+   void initializeAllDevicesSerial() MMCORE_LEGACY_THROW(CMMError);
+   void initializeAllDevicesParallel() MMCORE_LEGACY_THROW(CMMError);
    int initializeVectorOfDevices(std::vector<std::pair<std::shared_ptr<DeviceInstance>, std::string> > pDevices);
 };

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -45,19 +45,6 @@
  * file (MMCore.cpp).
  */
 
-// We use exception specifications to instruct SWIG to generate the correct
-// exception specifications for Java.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4290) // 'C++ exception specification ignored'
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-// 'dynamic exception specifications are deprecated in C++11 [-Wdeprecated]'
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#endif
-
 #include "../MMDevice/DeviceThreads.h"
 #include "../MMDevice/MMDevice.h"
 #include "../MMDevice/MMDeviceConstants.h"
@@ -773,11 +760,3 @@ private:
    void initializeAllDevicesParallel() throw (CMMError);
    int initializeVectorOfDevices(std::vector<std::pair<std::shared_ptr<DeviceInstance>, std::string> > pDevices);
 };
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -917,6 +917,7 @@
 
 %{
 #include "../MMDevice/MMDeviceConstants.h"
+#include "../MMCore/Error.h"
 #include "../MMCore/Configuration.h"
 #include "../MMDevice/ImageMetadata.h"
 #include "../MMCore/MMEventCallback.h"
@@ -1235,8 +1236,9 @@ namespace std {
 
 
 %include "../MMDevice/MMDeviceConstants.h"
+%include "../MMCore/Error.h"
 %include "../MMCore/Configuration.h"
-%include "../MMCore/MMCore.h"
 %include "../MMDevice/ImageMetadata.h"
 %include "../MMCore/MMEventCallback.h"
+%include "../MMCore/MMCore.h"
 


### PR DESCRIPTION
While preserving compatibility with Swig 2/3 for MMCoreJ.

Note that this (probably) won't allow the generated C++ for MMCoreJ to be compiled under C++17.

This is so that the code can be compiled together with other dependencies (nanobind) that require C++17; MMCore code must continue to also compile under C++17.

Closes #682.

Still need to
- [x] Actually test MMCore compilation under C++17
    - [x] Linux
    - [x] macOS
    - [x] Windows
- [x] Confirm that MMCoreJ API does not change
- [x] Confirm that pymmcore (SWIG) compiles