### PR TITLE
CI: Sync MMDevice and MMCore to mirror repos

### DIFF
--- a/.github/workflows/sync-components.yml
+++ b/.github/workflows/sync-components.yml
@@ -1,0 +1,88 @@
+# When the main branch of this repo has a push, push corresponding history in
+# the repos mirroring subdirectories of this repo.
+
+name: Sync component mirror repos
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-component-mirrors:
+    name: Sync component mirrors
+    if: github.repository == 'micro-manager/mmCoreAndDevices'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: mmCoreAndDevices
+
+      - run: pip install git-filter-repo
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+
+          # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+          cat >> ~/.ssh/known_hosts <<EOF
+          github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+          EOF
+
+          cat >> ~/.ssh/config <<EOF
+          Host github.com
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/deploy_key
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Rewrite history using road-not-taken tag
+        run: |
+          cd mmCoreAndDevices
+          # "Rebase" onto road-not-taken (0719c75); see mmCoreAndDevices #691.
+          git filter-repo --commit-callback '
+            if commit.original_id == b"6c996be297b40eed03b8f8a8532e86b1b7d265aa":
+              commit.parents = [b"0719c750d34ca957ab5739ab144e25a27e92ab1e"]
+          '
+
+      - name: Extract mmdevice history
+        run: |
+          cp -R mmCoreAndDevices mmdevice
+          cd mmdevice
+          git filter-repo --subdirectory-filter MMDevice
+          git checkout main
+          git branch |grep -v '^\*' |xargs git branch -D
+          git tag |grep -v '^device-interface-' |xargs git tag -d
+
+      - name: Extract mmcore history
+        run: |
+          cp -R mmCoreAndDevices mmcore
+          cd mmcore
+          git filter-repo --subdirectory-filter MMCore
+          git checkout main
+          git branch |grep -v '^\*' |xargs git branch -D
+          git tag |xargs git tag -d
+
+      - name: Push mmdevice
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_KEY_DEPLOY_TO_MMDEVICE }}
+        run: |
+          echo "$SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+          cd mmdevice
+          git remote add origin git@github.com:micro-manager/mmdevice.git
+          git push -u origin main --follow-tags
+
+      - name: Push mmcore
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_KEY_DEPLOY_TO_MMCORE }}
+        run: |
+          echo "$SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+          cd mmcore
+          git remote add origin git@github.com:micro-manager/mmcore.git
+          git push -u origin main


### PR DESCRIPTION
This syncs MMDevice/ and MMCore/ history to the mmdevice and mmcore repositories, respectively.

Closes #687.