### PR TITLE
Add mmdevice.wrap for MMCore Meson build

### DIFF
--- a/.github/workflows/ci-mmdevice-mmcore.yml
+++ b/.github/workflows/ci-mmdevice-mmcore.yml
@@ -64,7 +64,9 @@ jobs:
         shell: bash
         run: |
           git clean -dxf
-          cp -R MMDevice MMCore/subprojects
+          # Manually populate the mmdevice subproject to avoid fetching via
+          # wrap from the mmdevice mirror repository.
+          cp -R MMDevice MMCore/subprojects/mmdevice
       - name: Build and test MMCore
         run: |
           cd MMCore

--- a/MMCore/README.md
+++ b/MMCore/README.md
@@ -1,0 +1,53 @@
+# MMCore
+
+MMCore is Micro-Manager's hardware abstraction layer, written in C++.
+
+It provides APIs to load device adapters, control devices, and acquire data. It
+also implements buffering for image acquisition.
+
+Currently, MMCore is mainly intended to be used from Python (via pymmcore) or
+Java (via MMCoreJ), but it can be used as a C++ library as well.
+
+## Repositories
+
+This code is available in two Git repositories:
+
+- https://github.com/micro-manager/mmCoreAndDevices, in subdirectory `MMCore`.
+  This is the official source for MMCore.
+
+- https://github.com/micro-manager/mmcore, which is a mirror of the above; we
+  do not currently accept pull requests or issues on this repository.
+
+(The eventual goal is for MMCore to be removed from mmCoreAndDevices and for
+the `mmcore` repository to become the official source. Until then,
+mmCoreAndDevices remains the official source.)
+
+## Building MMCore
+
+The "supported" ways to use MMCore are via MMCoreJ (built as part of
+Micro-Manager) or via pymmcore(-plus). This directory contains files for the
+traditional build systems used by Micro-Manager (MSVC on Windows, GNU Autotools
+on macOS/Linux), but those are not designed to allow building just MMCore in
+isolation.
+
+We are in the process of modularizing the build systems of Micro-Manager's
+components, and MMCore now also has cross-platform build scripts using Meson.
+
+This can be used to build just MMCore using the `mmcore` repository:
+
+```sh
+git clone https://github.com/micro-manager/mmcore.git
+cd mmcore
+meson setup --vsenv builddir  # --vsenv recommended on Windows
+meson compile -C builddir
+meson test -C builddir
+```
+
+Note that the above way of building will use the latest `mmdevice` as a
+dependency. To control the exact version of `mmdevice` to use, you will need to
+copy it into `subprojects/` before running Meson (as is done in
+mmCoreAndDevices's CI).
+
+If using MMCore as a C++ library, it should be noted that it needs to be built
+as a static library. Building as a DLL or shared library would require defining
+which symbols are public, and this is not currently available.

--- a/MMCore/meson.build
+++ b/MMCore/meson.build
@@ -17,8 +17,6 @@ if cxx.get_id() in ['msvc', 'clang-cl']
     add_project_arguments('-DNOMINMAX', language: 'cpp')
 endif
 
-# MMDevice must be copied into subprojects/ for this experimental build to work
-# (unless MMCore is itself being used as a subproject).
 if get_option('tests').enabled()
     tests_option = 'enabled'
 elif get_option('tests').disabled()
@@ -26,8 +24,11 @@ elif get_option('tests').disabled()
 else
     tests_option = 'auto'
 endif
+
+# mmdevice is provided via a .wrap, but it should be manually copied into
+# subprojects in order to control the version that gets fetched.
 mmdevice_proj = subproject(
-    'MMDevice',
+    'mmdevice',
     default_options: {
         'client_interface': true,
         # Propagate value of 'tests' option ('yield: true' in MMDeivce's

--- a/MMCore/subprojects/.gitignore
+++ b/MMCore/subprojects/.gitignore
@@ -1,6 +1,7 @@
 /packagecache/
 
 /MMDevice/
+/mmdevice/
 
 # Subprojects installed by meson wrap
 /*-*/
@@ -10,3 +11,4 @@
 
 # Do not ignore wraps we provide
 !/catch2.wrap
+!/mmdevice.wrap

--- a/MMCore/subprojects/mmdevice.wrap
+++ b/MMCore/subprojects/mmdevice.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/micro-manager/mmdevice.git
+revision = HEAD
+depth = 1
+
+[provide]
+dependency_names = mmdevice

--- a/MMDevice/README.md
+++ b/MMDevice/README.md
@@ -1,0 +1,39 @@
+# MMDevice
+
+MMDevice defines the interface between Micro-Manager device adapters and
+MMCore. It also contains default implementations (in `DeviceBase.h`) for device
+adapter functionality.
+
+The device interface is a C++ interface designed to use limited features so
+that binary compatibility can be maintained between compiler versions and
+settings (such as MSVC Debug vs Release runtimes). This relies on the fact that
+platforms maintain a stable ABI (application binary interface) for C constructs
+and C++ class and vtable layout.
+
+## Repositories
+
+This code is available in two Git repositories:
+
+- https://github.com/micro-manager/mmCoreAndDevices, in subdirectory
+  `MMDevice`. This is the official source for MMDevice.
+
+- https://github.com/micro-manager/mmdevice, which is a mirror of the above; we
+  do not currently accept pull requests or issues on this repository.
+
+## Building MMDevice
+
+MMDevice is usually built as part of Micro-Manager, using its build system
+(MSVC on Windows, GNU Autotools on macOS/Linux); files for that are included in
+this directory (but are not intended for use in isolation).
+
+We are in the process of modularizing the build systems of Micro-Manager's
+components, and MMDevice also has cross-platform build scripts using Meson;
+these can be used to build just MMDevice and run its unit tests:
+
+```sh
+git clone https://github.com/micro-manager/mmdevice.git
+cd mmdevice
+meson setup --vsenv builddir  # --vsenv recommended on Windows
+meson compile -C builddir
+meson test -C builddir
+```

--- a/justfile
+++ b/justfile
@@ -28,7 +28,10 @@ build-mmdevice:
 
 # Build MMCore (depends on build-mmdevice)
 build-mmcore: build-mmdevice
-    cp -R MMDevice MMCore/subprojects
+    # Supply MMDevice from this repo instead of relying on wrap which may fetch
+    # another version
+    rm -rf MMCore/subprojects/mmdevice
+    cp -R MMDevice MMCore/subprojects/mmdevice
     meson setup MMCore/builddir MMCore \
         --reconfigure \
         --vsenv \
@@ -53,4 +56,4 @@ test: test-mmdevice test-mmcore
 clean:
     rm -rf MMDevice/builddir
     rm -rf MMCore/builddir
-    rm -rf MMCore/subprojects/MMDevice
+    rm -rf MMCore/subprojects/mmdevice


### PR DESCRIPTION
This allows mmcore (from the mirror repo) to build automatically.
    
But keep the manual copy for CI and justfile (to use correct version of MMDevice).
    
The mmdevice.wrap just fetches the latest HEAD. Once MMCore is no longer in mmCoreAndDevices it can point to a specific mmdevice commit, but that would only be confusing if done now when official MMDevice is a cohabitant of mmCoreAndDevices. (The mmdevice commit would never be up to date!)

Also adds READMEs for MMCore and MMDevice.