### PR TITLE
MMCoreJ: Avoid relative include of MMDevice/MMCore

### DIFF
--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -916,12 +916,12 @@
 
 
 %{
-#include "../MMDevice/MMDeviceConstants.h"
-#include "../MMCore/Error.h"
-#include "../MMCore/Configuration.h"
-#include "../MMDevice/ImageMetadata.h"
-#include "../MMCore/MMEventCallback.h"
-#include "../MMCore/MMCore.h"
+#include "MMDeviceConstants.h"
+#include "Error.h"
+#include "Configuration.h"
+#include "ImageMetadata.h"
+#include "MMEventCallback.h"
+#include "MMCore.h"
 %}
 
 
@@ -1235,10 +1235,10 @@ namespace std {
 }
 
 
-%include "../MMDevice/MMDeviceConstants.h"
-%include "../MMCore/Error.h"
-%include "../MMCore/Configuration.h"
-%include "../MMDevice/ImageMetadata.h"
-%include "../MMCore/MMEventCallback.h"
-%include "../MMCore/MMCore.h"
+%include "MMDeviceConstants.h"
+%include "Error.h"
+%include "Configuration.h"
+%include "ImageMetadata.h"
+%include "MMEventCallback.h"
+%include "MMCore.h"
 

--- a/MMCoreJ_wrap/MMCoreJ_wrap.vcxproj
+++ b/MMCoreJ_wrap/MMCoreJ_wrap.vcxproj
@@ -52,7 +52,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\MMDevice;$(JAVA_HOME)\include\win32;$(JAVA_HOME)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\MMCore;..\MMDevice;$(JAVA_HOME)\include\win32;$(JAVA_HOME)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>
@@ -71,7 +71,7 @@
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\MMDevice;$(JAVA_HOME)\include\win32;$(JAVA_HOME)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\MMCore;..\MMDevice;$(JAVA_HOME)\include\win32;$(JAVA_HOME)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>
@@ -99,7 +99,7 @@ del /s/q %swig_out_dir% &gt; NUL
 echo Creating output directory (%swig_out_dir%)...
 mkdir %swig_out_dir% &gt; NUL
 echo Running SWIG on %(FullPath)...
-$(MM_SWIG) -c++ -java -package mmcorej -module MMCoreJ -outdir %swig_out_dir% %(FullPath)
+$(MM_SWIG) -c++ -java -package mmcorej -module MMCoreJ -outdir %swig_out_dir% -I$(ProjectDir)\..\MMCore -I$(ProjectDir)\..\MMDevice %(FullPath)
 rem
 echo Removing old copy of Java sources (%java_src_dir%)...
 del /s/q %java_src_dir% &gt; NUL
@@ -119,7 +119,7 @@ del /s/q %swig_out_dir% &gt; NUL
 echo Creating output directory (%swig_out_dir%)...
 mkdir %swig_out_dir% &gt; NUL
 echo Running SWIG on %(FullPath)...
-$(MM_SWIG) -c++ -java -package mmcorej -module MMCoreJ -outdir %swig_out_dir% %(FullPath)
+$(MM_SWIG) -c++ -java -package mmcorej -module MMCoreJ -outdir %swig_out_dir% -I$(ProjectDir)\..\MMCore -I$(ProjectDir)\..\MMDevice %(FullPath)
 rem
 echo Removing old copy of Java sources (%java_src_dir%)...
 del /s/q %java_src_dir% &gt; NUL

--- a/MMCoreJ_wrap/Makefile.am
+++ b/MMCoreJ_wrap/Makefile.am
@@ -11,7 +11,7 @@ AUTOMAKE_OPTIONS = foreign subdir-objects
 # for the above reason (though the intent was never documented). But there is
 # nothing Linux-specific about this.)
 AM_CXXFLAGS = -fno-strict-aliasing
-AM_CPPFLAGS = $(JNI_CPPFLAGS) -DMMDEVICE_CLIENT_BUILD -I../MMDevice
+AM_CPPFLAGS = $(JNI_CPPFLAGS) -DMMDEVICE_CLIENT_BUILD -I../MMDevice -I../MMCore
 
 
 # This ugly list of headers is necessary to trigger the rebuild of the
@@ -43,6 +43,7 @@ MMCoreJ.stamp: $(swig_sources)
 	$(MKDIR_P) gensrc/mmcorej
 	$(SWIG) -c++ -java -package mmcorej -outdir gensrc/mmcorej -module MMCoreJ \
 		"-DMMCOREJ_LIBRARY_PATH=\"$(MMCOREJ_LIBRARY_PATH)\"" \
+		-I../MMCore -I../MMDevice \
 		-o MMCoreJ_wrap.cxx $(srcdir)/MMCoreJ.i
 	@mv -f MMCoreJ.tmp $@
 MMCoreJ_wrap.h MMCoreJ_wrap.cxx: MMCoreJ.stamp


### PR DESCRIPTION
Instead, require that the build system provide the correct include path.

(Follow-up of #693)