### PR TITLE
On shutterOpenChanged callback

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -3914,7 +3914,7 @@ int DemoShutter::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 
       // apply the value
       state_ = pos == 0 ? false : true;
-      //GetCoreCallback()->OnShutterOpenChanged(this, pos == 0);
+      GetCoreCallback()->OnShutterOpenChanged(this, pos == 0);
    }
 
    return DEVICE_OK;

--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -236,6 +236,9 @@ CDemoCamera::CDemoCamera() :
 	fractionOfPixelsToDropOrSaturate_(0.002),
    shouldRotateImages_(false),
    shouldDisplayImageNumber_(false),
+   busy_(false),
+   imageCounter_(0),
+   stopOnOverFlow_(true),
    stripeWidth_(1.0),
    supportsMultiROI_(false),
    multiROIFillValue_(0),
@@ -3061,9 +3064,10 @@ int CDemoStateDevice::OnNumberOfStates(MM::PropertyBase* pProp, MM::ActionType e
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 CDemoLightPath::CDemoLightPath() : 
-numPos_(3), 
-busy_(false), 
-initialized_(false)
+   position_(0),
+   numPos_(3), 
+   busy_(false), 
+   initialized_(false)
 {
    InitializeDefaultErrorMessages();
    // parent ID display
@@ -3180,10 +3184,12 @@ int CDemoLightPath::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 CDemoObjectiveTurret::CDemoObjectiveTurret() : 
+   position_(0),
    numPos_(6), 
    busy_(false), 
    initialized_(false),
    sequenceRunning_(false),
+   sequenceIndex_(0),
    sequenceMaxSize_(10)
 {
    SetErrorText(ERR_IN_SEQUENCE, "Error occurred while executing sequence");
@@ -3594,6 +3600,11 @@ posX_um_(0.0),
 posY_um_(0.0),
 timeOutTimer_(0),
 velocity_(10.0), // in mm per second (= um/ms)
+moveDuration_ms_(100),
+startPosX_um_(0.0),
+startPosY_um_(0.),
+targetPosX_um_(0.0),
+targetPosY_um_(0.),
 initialized_(false),
 lowerLimit_(0.0),
 upperLimit_(20000.0)
@@ -3903,6 +3914,7 @@ int DemoShutter::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 
       // apply the value
       state_ = pos == 0 ? false : true;
+      //GetCoreCallback()->OnShutterOpenChanged(this, pos == 0);
    }
 
    return DEVICE_OK;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -631,6 +631,7 @@ public:
    {
       state_ = open;
       changedTime_ = GetCurrentMMTime();
+      GetCoreCallback()->OnShutterOpenChanged(this, open);
       return DEVICE_OK;
    }
    int GetOpen(bool& open)

--- a/DeviceAdapters/Utilities/DAShutter.cpp
+++ b/DeviceAdapters/Utilities/DAShutter.cpp
@@ -118,9 +118,12 @@ bool DAShutter::Busy()
 int DAShutter::SetOpen(bool open)
 {
    MM::SignalIO* da = (MM::SignalIO*)GetDevice(DADeviceName_.c_str());
+   int ret = DEVICE_OK;
    if (da != 0)
-      return da->SetGateOpen(open);
-   return DEVICE_OK;
+      ret = da->SetGateOpen(open);
+   if (ret == DEVICE_OK)
+      GetCoreCallback()->OnShutterOpenChanged(this, open);
+   return ret;;
 }
 
 int DAShutter::GetOpen(bool& open)

--- a/DeviceAdapters/Utilities/MultiShutter.cpp
+++ b/DeviceAdapters/Utilities/MultiShutter.cpp
@@ -155,6 +155,7 @@ int MultiShutter::SetOpen(bool open)
       }
    }
    open_ = open;
+   GetCoreCallback()->OnShutterOpenChanged(this, open);
    return DEVICE_OK;
 }
 

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -674,6 +674,19 @@ int CoreCallback::OnMagnifierChanged(const MM::Device* /* device */)
    return DEVICE_OK;
 }
 
+/**
+ * Handler for Shutter State changes.
+ * 
+ */
+int CoreCallback::OnShutterOpenChanged(const MM::Device* device, bool state)
+{
+   if (core_->externalCallback_) {
+      char label[MM::MaxStrLength];
+      device->GetLabel(label);
+      core_->externalCallback_->onShutterOpenChanged(label, state);
+   }
+   return DEVICE_OK;
+}
 
 
 int CoreCallback::SetSerialProperties(const char* portName,

--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -120,6 +120,7 @@ public:
    int OnExposureChanged(const MM::Device* device, double newExposure);
    int OnSLMExposureChanged(const MM::Device* device, double newExposure);
    int OnMagnifierChanged(const MM::Device* device);
+   int OnShutterOpenChanged(const MM::Device* device, bool open);
 
 
    void NextPostedError(int& errorCode, char* pMessage, int maxlen, int& messageLength);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -103,7 +103,7 @@
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 11, MMCore_versionMinor = 9, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 11, MMCore_versionMinor = 10, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/MMEventCallback.h
+++ b/MMCore/MMEventCallback.h
@@ -87,6 +87,11 @@ public:
       std::cout << "onExposureChanged()" << name << " " << newExposure << '\n';
    }
 
+   virtual void onShutterOpenChanged(const char* name, bool open)
+   {
+      std::cout << "onShutterOpenChanges()" << name << " " << open << '\n';
+   }
+
    virtual void onSLMExposureChanged(const char* name, double newExposure)
    {
       std::cout << "onSLMExposureChanged()" << name << " " << newExposure << '\n';

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1571,6 +1571,10 @@ namespace MM {
        * Magnifiers can use this to signal changes in magnification
        */
       virtual int OnMagnifierChanged(const Device* caller) = 0;
+      /**
+       * Signals that the shutter opened or clased
+       */
+      virtual int OnShutterOpenChanged(const Device* caller, bool open) = 0;
 
       // Deprecated: Return value overflows in ~72 minutes on Windows.
       // Prefer std::chrono::steady_clock for time delta measurements.

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -28,7 +28,7 @@
 // Header version
 // If any of the class definitions changes, the interface version
 // must be incremented
-#define DEVICE_INTERFACE_VERSION 73
+#define DEVICE_INTERFACE_VERSION 74
 ///////////////////////////////////////////////////////////////////////////////
 
 // N.B.


### PR DESCRIPTION
This PR lets Device Adapters inform the Core that the state of the shutter they control has changed.  It should be called from code that monitors the state of the shutter.  It would also be possible to call from code opening the shutter, but then you should make sure the shutter is really in the state reported (many shutters need some time to open / close).  

This PR updated the Device interface version as well as the minor version of the Core.  I am fine waiting to merge this PR until there are other reasons to increase the Device Interface version (as there are still a number of 3dparty device adpa\\apters that we can not automatically update).  @tlambert03 