### PR TITLE
ASIStage: precompute protocol for oldstage_, less branching in SendCommand and QueryCommand

### DIFF
--- a/DeviceAdapters/ASIStage/ASIBase.cpp
+++ b/DeviceAdapters/ASIStage/ASIBase.cpp
@@ -13,10 +13,10 @@ ASIBase::ASIBase(MM::Device* device, const char* prefix) :
 	port_("Undefined"),
 	initialized_(false),
 	oldstage_(false),
-	versionData_(VersionData()),
-	version_("Undefined"),
-	buildName_("Undefined"),
-	compileDate_("Undefined"),
+	version_(Version()),
+	firmwareVersion_("Undefined"),
+	firmwareBuild_("Undefined"),
+	firmwareDate_("Undefined"),
 	oldstagePrefix_(prefix),
 	commandPrefix_(""),
 	serialTerm_("\r\n")
@@ -104,37 +104,6 @@ int ASIBase::CheckDeviceStatus() {
 	return ret;
 }
 
-VersionData ASIBase::ParseVersionString(const std::string& version) const
-{	
-	// Version command response examples:
-	// Example A) ":A Version: USB-9.2p \r\n"
-	// Example B) ":A Version: USB-9.50 \r\n"
-	const size_t startIndex = version.find("-");
-	if (startIndex == std::string::npos)
-	{
-		return VersionData(); // error => default data
-	}
-
-	// shortVersion => "9.2m \r\n"
-	const std::string shortVersion = version.substr(startIndex + 1);
-
-	// find the index of the dot that separates major and minor version
-	const size_t dotIndex = shortVersion.find(".");
-	if (dotIndex == std::string::npos)
-	{
-		return VersionData(); // error => default data
-	}
-	
-	// use substr for major versions with more than 1 digit, ##.## for example
-	const int major = std::stoi(shortVersion.substr(0, dotIndex));
-
-	// minor version and revision will only ever be 1 character,
-	// at these specific locations after the dot in the response
-	const int minor = std::stoi(shortVersion.substr(dotIndex + 1, 1));
-	const char revision = shortVersion.at(dotIndex + 2);
-	return VersionData(major, minor, revision);
-}
-
 int ASIBase::GetVersion(std::string& version) const
 {
    std::string answer;
@@ -156,7 +125,7 @@ int ASIBase::OnVersion(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-      pProp->Set(version_.c_str());
+      pProp->Set(firmwareVersion_.c_str());
 	}
 	return DEVICE_OK;
 }
@@ -178,7 +147,7 @@ int ASIBase::OnBuildName(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		pProp->Set(buildName_.c_str());
+		pProp->Set(firmwareBuild_.c_str());
 	}
 	return DEVICE_OK;
 }
@@ -200,7 +169,7 @@ int ASIBase::OnCompileDate(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		pProp->Set(compileDate_.c_str());
+		pProp->Set(firmwareDate_.c_str());
 	}
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/ASIStage/ASIBase.cpp
+++ b/DeviceAdapters/ASIStage/ASIBase.cpp
@@ -183,7 +183,7 @@ int ASIBase::OnBuildName(MM::PropertyBase* pProp, MM::ActionType eAct)
 	return DEVICE_OK;
 }
 
-int ASIBase::GetCompileDate(std::string& buildName) const
+int ASIBase::GetCompileDate(std::string& compileDate) const
 {
 	std::string answer;
 	int ret = QueryCommand("CD", answer);
@@ -191,7 +191,7 @@ int ASIBase::GetCompileDate(std::string& buildName) const
 	{
 		return ret;
 	}
-	buildName = answer;
+	compileDate = answer;
 	return DEVICE_OK;
 }
 

--- a/DeviceAdapters/ASIStage/ASIBase.h
+++ b/DeviceAdapters/ASIStage/ASIBase.h
@@ -87,16 +87,23 @@ protected:
 	int GetBuildName(std::string& buildName) const;
 	int GetCompileDate(std::string& compileDate) const;
 
-	bool oldstage_;
-	bool initialized_;
+	static const size_t SERIAL_RXBUFFER_SIZE = 2048;
+
 	MM::Core* core_;
 	MM::Device* device_;
 	std::string port_;
+
+	bool initialized_;
+	bool oldstage_;
+
+	VersionData versionData_;
 	std::string version_;
 	std::string buildName_;
 	std::string compileDate_;
+
+	// Stage-specific configuration
 	std::string oldstagePrefix_; // "1H" or "2H" for LX-4000 stages
-	VersionData versionData_;
+	std::string serialTerm_; // changes if oldstage_ is true
 };
 
 #endif // ASIBASE_H

--- a/DeviceAdapters/ASIStage/ASIBase.h
+++ b/DeviceAdapters/ASIStage/ASIBase.h
@@ -8,10 +8,9 @@
 #ifndef ASIBASE_H
 #define ASIBASE_H
 
+#include "ASIStage.h"
 #include "MMDevice.h"
 #include "DeviceBase.h"
-#include "ASIStage.h"
-#include <regex>
 #include <string>
 
 
@@ -51,9 +50,9 @@ public:
 
 	// Return the version data parsed from a std::string.
 	static Version ParseString(const std::string& version) {
-		// Version response examples:
-		// Example A: ":A Version: USB-9.2p \r\n"
-		// Example B: ":A Version: USB-9.50 \r\n"
+		// Example response: ":A Version: USB-9.2m \r\n"
+
+		// find the index of the dash
 		const size_t dashIndex = version.find("-");
 		if (dashIndex == std::string::npos) {
 			return Version(); // error => default data
@@ -62,19 +61,23 @@ public:
 		// short version => "9.2m \r\n"
 		const std::string ver = version.substr(dashIndex + 1);
 
-		// find the index of the dot that separates major and minor version
+		// find the index of the dot
 		const size_t dotIndex = ver.find(".");
 		if (dotIndex == std::string::npos) {
 			return Version(); // error => default data
 		}
 
-		// use substr for major versions with more than 1 digit, ##.## for example
+		// major version can have more than 1 digit (##.## for example)
 		// minor version and revision will only ever be 1 character,
 		// at these specific locations after the dot in the response
-		const unsigned int major = std::stoi(ver.substr(0, dotIndex));
-		const unsigned int minor = std::stoi(ver.substr(dotIndex + 1, 1));
-		const unsigned int revision = static_cast<unsigned int>(ver.at(dotIndex + 2));
-		return Version(major, minor, revision);
+		try {
+			const unsigned int major = std::stoul(ver.substr(0, dotIndex));
+			const unsigned int minor = std::stoul(ver.substr(dotIndex + 1, 1));
+			const unsigned int revision = static_cast<unsigned int>(ver.at(dotIndex + 2));
+			return Version(major, minor, revision);
+		} catch (...) {
+			return Version(); // parsing error => default data
+		}
 	}
 
 	bool operator>=(const Version& other) const {

--- a/DeviceAdapters/ASIStage/ASIBase.h
+++ b/DeviceAdapters/ASIStage/ASIBase.h
@@ -11,6 +11,7 @@
 #include "MMDevice.h"
 #include "DeviceBase.h"
 #include "ASIStage.h"
+#include <regex>
 #include <string>
 
 
@@ -18,51 +19,76 @@
 // that's why the build name, compile date, and version are queried for each device.
 
 
-// This data structure is used to store MS2000 version data.
-// The format for firmware versions changed match the Tiger controller after 9.2p
+// This data structure is used to store MS-2000 version data.
+// The format for firmware versions changed to match the Tiger controller after 9.2p
 // Old version format: ":A Version: USB-9.2p \r\n" (revision is a character: 'a'-'z')
 // New version format: ":A Version: USB-9.50 \r\n" (revision is a digit character: '0'-'9')
-class VersionData
-{
+class Version {
 public:
-	VersionData() : major_(0), minor_(0), rev_('-') { }
-	explicit VersionData(int major, int minor, char rev)
+	Version() : major_(0), minor_(0), rev_(0) { }
+	explicit Version(unsigned int major, unsigned int minor, unsigned int rev)
 		: major_(major), minor_(minor), rev_(rev) { }
 
 	// Return true if the controller firmware version is at least the specified version.
-	bool IsVersionAtLeast(int major, int minor, char rev) const
-	{
+	bool IsVersionAtLeast(unsigned int major, unsigned int minor, unsigned int rev) const {
 		// Avoid comparing 'rev' across pre-9.50 (char) and 9.50+ (digit) formats.
 		// Comparing 'rev' relies on ASCII, which doesn't reflect logical version order.
 		// This scenario should never be encountered under the current versioning scheme.
-		if (major_ > major)
-		{
+		if (major_ > major) {
 			return true;
 		}
-		if (major_ < major)
-		{
+		if (major_ < major) {
 			return false;
 		}
-		if (minor_ > minor)
-		{
+		if (minor_ > minor) {
 			return true;
 		}
-		if (minor_ < minor)
-		{
+		if (minor_ < minor) {
 			return false;
 		}
 		return rev_ >= rev;
 	}
 
+	// Return the version data parsed from a std::string.
+	static Version ParseString(const std::string& version) {
+		// Version response examples:
+		// Example A: ":A Version: USB-9.2p \r\n"
+		// Example B: ":A Version: USB-9.50 \r\n"
+		const size_t dashIndex = version.find("-");
+		if (dashIndex == std::string::npos) {
+			return Version(); // error => default data
+		}
+
+		// short version => "9.2m \r\n"
+		const std::string ver = version.substr(dashIndex + 1);
+
+		// find the index of the dot that separates major and minor version
+		const size_t dotIndex = ver.find(".");
+		if (dotIndex == std::string::npos) {
+			return Version(); // error => default data
+		}
+
+		// use substr for major versions with more than 1 digit, ##.## for example
+		// minor version and revision will only ever be 1 character,
+		// at these specific locations after the dot in the response
+		const unsigned int major = std::stoi(ver.substr(0, dotIndex));
+		const unsigned int minor = std::stoi(ver.substr(dotIndex + 1, 1));
+		const unsigned int revision = static_cast<unsigned int>(ver.at(dotIndex + 2));
+		return Version(major, minor, revision);
+	}
+
+	bool operator>=(const Version& other) const {
+		return IsVersionAtLeast(other.major_, other.minor_, other.rev_);
+	}
+
 private:
-	int major_;
-	int minor_;
-	char rev_;
+	unsigned int major_;
+	unsigned int minor_;
+	unsigned int rev_;
 };
 
 // Note: concrete device classes deriving ASIBase must set core_ in Initialize()
-class ASIBase
-{
+class ASIBase {
 public:
 	ASIBase(MM::Device* device, const char* prefix);
 	virtual ~ASIBase();
@@ -77,7 +103,6 @@ public:
 	int ParseResponseAfterPosition(const std::string& answer, unsigned int position, double& value) const;
 	int ParseResponseAfterPosition(const std::string& answer, unsigned int position, unsigned int count, double& value) const;
 	int ResponseStartsWithColonA(const std::string& answer) const;
-	VersionData ParseVersionString(const std::string& version) const;
 
 protected:
 	int OnVersion(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -96,10 +121,10 @@ protected:
 	bool initialized_;
 	bool oldstage_;
 
-	VersionData versionData_;
-	std::string version_;
-	std::string buildName_;
-	std::string compileDate_;
+	Version version_;
+	std::string firmwareVersion_;
+	std::string firmwareBuild_;
+	std::string firmwareDate_;
 
 	// Stage-specific configuration
 	std::string oldstagePrefix_; // "1H" or "2H" for LX-4000 stages, empty string for MS-2000 stages

--- a/DeviceAdapters/ASIStage/ASIBase.h
+++ b/DeviceAdapters/ASIStage/ASIBase.h
@@ -87,7 +87,7 @@ protected:
 	int GetBuildName(std::string& buildName) const;
 	int GetCompileDate(std::string& compileDate) const;
 
-	static const size_t SERIAL_RXBUFFER_SIZE = 2048;
+	static constexpr size_t SERIAL_RXBUFFER_SIZE = 2048;
 
 	MM::Core* core_;
 	MM::Device* device_;
@@ -102,7 +102,8 @@ protected:
 	std::string compileDate_;
 
 	// Stage-specific configuration
-	std::string oldstagePrefix_; // "1H" or "2H" for LX-4000 stages
+	std::string oldstagePrefix_; // "1H" or "2H" for LX-4000 stages, empty string for MS-2000 stages
+	std::string commandPrefix_; // set to oldstagePrefix_ if oldstage_ is true, otherwise empty string
 	std::string serialTerm_; // changes if oldstage_ is true
 };
 

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -1108,34 +1108,37 @@ void CRISP::CreateSumProperty() {
 	if (versionData_.IsVersionAtLeast(9, 2, 'o')) {
 		// The LOCK command can query the value directly
 		// The command responds with => ":A 0 \r\n"
-		this->LogMessage("CRISP: firmware >= 9.2o; use LK T? for the "
+		LogMessage("CRISP: firmware >= 9.2o; use LK T? for the "
 			+ propertyName + " property.", true);
 
-		this->CreateIntegerProperty(
+		CreateIntegerProperty(
 			propertyName.c_str(), 0, true,
 			new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
 				if (eAct == MM::BeforeGet) {
 					float sum{};
-					int result = this->GetValue("LK T?", sum);
+					int result = GetValue("LK T?", sum);
 					if (result != DEVICE_OK) {
 						return result;
 					}
 					pProp->Set(sum);
 				}
 				return DEVICE_OK;
-			}));
-	} else {
+			}
+		));
+
+	} else { // Firmware < 9.2o
+
 		// The old version uses the EXTRA command and requires extra parsing
 		// The command responds with => "I    0    0 \r\n"
-		this->LogMessage("CRISP: firmware < 9.2o; use EXTRA X? for the "
+		LogMessage("CRISP: firmware < 9.2o; use EXTRA X? for the "
 			+ propertyName + " property.", true);
 
-		this->CreateIntegerProperty(
+		CreateIntegerProperty(
 			propertyName.c_str(), 0, true,
 			new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
 				if (eAct == MM::BeforeGet) {
 					std::string answer;
-					int result = this->QueryCommand("EXTRA X?", answer);
+					int result = QueryCommand("EXTRA X?", answer);
 					if (result != DEVICE_OK) {
 						return result;
 					}
@@ -1150,7 +1153,8 @@ void CRISP::CreateSumProperty() {
 					}
 				}
 				return DEVICE_OK;
-			}));
+			}
+		));
 	}
 }
 
@@ -1177,8 +1181,11 @@ void CRISP::CreateDitherErrorProperty() {
 					pProp->Set(sum);
 				}
 				return DEVICE_OK;
-			}));
-	} else {
+			}
+		));
+
+	} else { // Firmware < 9.2o
+
 		// The old version uses the EXTRA command and requires extra parsing
 		// The command responds with => "I    0    0 \r\n"
 		this->LogMessage("CRISP: firmware < 9.2o; use EXTRA X? for the "
@@ -1204,7 +1211,8 @@ void CRISP::CreateDitherErrorProperty() {
 					}
 				}
 				return DEVICE_OK;
-			}));
+			}
+		));
 	}
 }
 

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -111,8 +111,7 @@ int CRISP::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (version_.IsVersionAtLeast(8, 8, 'a'))
-	{
+	if (version_ >= Version(8, 8, 'a')) {
 		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{
@@ -206,8 +205,7 @@ int CRISP::Initialize()
 	CreateProperty(g_CRISPStatePropertyName, "", MM::String, true, pAct);
 
 	// previously compared against compile date (2015, 1, 1)
-	if (version_.IsVersionAtLeast(9, 2, 'h'))
-	{
+	if (version_ >= Version(9, 2, 'h')) {
 		ret = GetNumSkips(numSkips_);
 		if (ret != DEVICE_OK)
 		{
@@ -254,8 +252,7 @@ int CRISP::Initialize()
 
 	// LK M requires firmware version 9.2n or higher.
 	// Enable these properties as a group to modify calibration settings.
-	if (version_.IsVersionAtLeast(9, 2, 'n'))
-	{
+	if (version_ >= Version(9, 2, 'n')) {
 		pAct = new CPropertyAction(this, &CRISP::OnSetLogAmpAGC);
 		CreateProperty("Set LogAmpAGC (Advanced Users Only)", "0", MM::Integer, false, pAct);
 
@@ -1105,7 +1102,7 @@ void CRISP::CreateSumProperty() {
 	const std::string propertyName = "Sum";
 
 	// Check if we can use the faster serial command
-	if (version_.IsVersionAtLeast(9, 2, 'o')) {
+	if (version_ >= Version(9, 2, 'o')) {
 		// The LOCK command can query the value directly
 		// The command responds with => ":A 0 \r\n"
 		LogMessage("CRISP: firmware >= 9.2o; use LK T? for the "
@@ -1163,7 +1160,7 @@ void CRISP::CreateDitherErrorProperty() {
 	const std::string propertyName = "Dither Error";
 
 	// Check if we can use the faster serial command
-	if (version_.IsVersionAtLeast(9, 2, 'o')) {
+	if (version_ >= Version(9, 2, 'o')) {
 		// The LOCK command can query the value directly
 		// The command responds with => ":A 0 \r\n"
 		LogMessage("CRISP: firmware >= 9.2o; use LK Y? for the "

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -89,16 +89,16 @@ int CRISP::Initialize()
 	// Read-only "AxisLetter" property, axis_ is set using a pre-init property named "Axis".
 	CreateProperty("AxisLetter", axis_.c_str(), MM::String, true);
 	
-	ret = GetVersion(version_);
+	ret = GetVersion(firmwareVersion_);
 	if (ret != DEVICE_OK)
 		return ret;
 	CPropertyAction* pAct = new CPropertyAction(this, &CRISP::OnVersion);
-	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
+	CreateProperty("Version", firmwareVersion_.c_str(), MM::String, true, pAct);
 
 	// get the firmware version data from cached value
-	versionData_ = ParseVersionString(version_);
+	version_ = Version::ParseString(firmwareVersion_);
 
-	ret = GetCompileDate(compileDate_);
+	ret = GetCompileDate(firmwareDate_);
 	if (ret != DEVICE_OK)
 	{
 		return ret;
@@ -111,9 +111,9 @@ int CRISP::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (versionData_.IsVersionAtLeast(8, 8, 'a'))
+	if (version_.IsVersionAtLeast(8, 8, 'a'))
 	{
-		ret = GetBuildName(buildName_);
+		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{
 			return ret;
@@ -206,7 +206,7 @@ int CRISP::Initialize()
 	CreateProperty(g_CRISPStatePropertyName, "", MM::String, true, pAct);
 
 	// previously compared against compile date (2015, 1, 1)
-	if (versionData_.IsVersionAtLeast(9, 2, 'h'))
+	if (version_.IsVersionAtLeast(9, 2, 'h'))
 	{
 		ret = GetNumSkips(numSkips_);
 		if (ret != DEVICE_OK)
@@ -254,7 +254,7 @@ int CRISP::Initialize()
 
 	// LK M requires firmware version 9.2n or higher.
 	// Enable these properties as a group to modify calibration settings.
-	if (versionData_.IsVersionAtLeast(9, 2, 'n'))
+	if (version_.IsVersionAtLeast(9, 2, 'n'))
 	{
 		pAct = new CPropertyAction(this, &CRISP::OnSetLogAmpAGC);
 		CreateProperty("Set LogAmpAGC (Advanced Users Only)", "0", MM::Integer, false, pAct);
@@ -1105,7 +1105,7 @@ void CRISP::CreateSumProperty() {
 	const std::string propertyName = "Sum";
 
 	// Check if we can use the faster serial command
-	if (versionData_.IsVersionAtLeast(9, 2, 'o')) {
+	if (version_.IsVersionAtLeast(9, 2, 'o')) {
 		// The LOCK command can query the value directly
 		// The command responds with => ":A 0 \r\n"
 		LogMessage("CRISP: firmware >= 9.2o; use LK T? for the "
@@ -1163,7 +1163,7 @@ void CRISP::CreateDitherErrorProperty() {
 	const std::string propertyName = "Dither Error";
 
 	// Check if we can use the faster serial command
-	if (versionData_.IsVersionAtLeast(9, 2, 'o')) {
+	if (version_.IsVersionAtLeast(9, 2, 'o')) {
 		// The LOCK command can query the value directly
 		// The command responds with => ":A 0 \r\n"
 		this->LogMessage("CRISP: firmware >= 9.2o; use LK Y? for the "

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -1116,7 +1116,7 @@ void CRISP::CreateSumProperty() {
 			new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
 				if (eAct == MM::BeforeGet) {
 					float sum{};
-					int result = GetValue("LK T?", sum);
+					const int result = GetValue("LK T?", sum);
 					if (result != DEVICE_OK) {
 						return result;
 					}
@@ -1138,7 +1138,7 @@ void CRISP::CreateSumProperty() {
 			new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
 				if (eAct == MM::BeforeGet) {
 					std::string answer;
-					int result = QueryCommand("EXTRA X?", answer);
+					const int result = QueryCommand("EXTRA X?", answer);
 					if (result != DEVICE_OK) {
 						return result;
 					}
@@ -1166,15 +1166,15 @@ void CRISP::CreateDitherErrorProperty() {
 	if (version_.IsVersionAtLeast(9, 2, 'o')) {
 		// The LOCK command can query the value directly
 		// The command responds with => ":A 0 \r\n"
-		this->LogMessage("CRISP: firmware >= 9.2o; use LK Y? for the "
+		LogMessage("CRISP: firmware >= 9.2o; use LK Y? for the "
 			+ propertyName + " property.", true);
 
-		this->CreateIntegerProperty(
+		CreateIntegerProperty(
 			propertyName.c_str(), 0, true,
 			new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
 				if (eAct == MM::BeforeGet) {
 					float sum{};
-					int result = this->GetValue("LK Y?", sum);
+					const int result = GetValue("LK Y?", sum);
 					if (result != DEVICE_OK) {
 						return result;
 					}
@@ -1188,15 +1188,15 @@ void CRISP::CreateDitherErrorProperty() {
 
 		// The old version uses the EXTRA command and requires extra parsing
 		// The command responds with => "I    0    0 \r\n"
-		this->LogMessage("CRISP: firmware < 9.2o; use EXTRA X? for the "
+		LogMessage("CRISP: firmware < 9.2o; use EXTRA X? for the "
 			+ propertyName + " property.", true);
 
-		this->CreateIntegerProperty(
+		CreateIntegerProperty(
 			propertyName.c_str(), 0, true,
 			new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
 				if (eAct == MM::BeforeGet) {
 					std::string answer;
-					int result = this->QueryCommand("EXTRA X?", answer);
+					const int result = QueryCommand("EXTRA X?", answer);
 					if (result != DEVICE_OK) {
 						return result;
 					}

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -280,7 +280,7 @@ bool CRISP::Busy()
  */
 int CRISP::GetOffset(double& offset)
 {
-	float val;
+	double val{};
 	int ret = GetValue("LK Z?", val);
 	if (ret != DEVICE_OK)
 	{
@@ -557,55 +557,43 @@ int CRISP::GetCurrentFocusScore(double& score)
 	return GetLastFocusScore(score);
 }
 
-int CRISP::GetValue(const std::string& cmd, float& val)
-{
+int CRISP::GetValue(const std::string& command, double& value) {
 	std::string answer;
-	int ret = QueryCommand(cmd.c_str(), answer);
-	if (ret != DEVICE_OK)
-	{
-		return ret;
+	const int result = QueryCommand(command.c_str(), answer);
+	if (result != DEVICE_OK) {
+		return result;
 	}
 
-	if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
-	{
-		int errNo = atoi(answer.substr(2).c_str());
-		return ERR_OFFSET + errNo;
-	}
-	else if (answer.length() > 0)
-	{
+	if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0) {
+		const int errorNum = atoi(answer.substr(2).c_str());
+		return ERR_OFFSET + errorNum;
+	} else if (answer.length() > 0) {
 		size_t index = 0;
-		while (!isdigit(answer[index]) && (index < answer.length()))
-		{
+		while (!isdigit(answer[index]) && index < answer.length()) {
 			index++;
 		}
 
-		if (index >= answer.length())
-		{
+		if (index >= answer.length()) {
 			return ERR_UNRECOGNIZED_ANSWER;
 		}
 
-		val = (float)atof((answer.substr(index)).c_str());
-
+		value = atof((answer.substr(index)).c_str());
 		return DEVICE_OK;
 	}
 
 	return ERR_UNRECOGNIZED_ANSWER;
 }
 
-int CRISP::SetCommand(const std::string& cmd)
-{
+int CRISP::SetCommand(const std::string& command) {
 	std::string answer;
-	int ret = QueryCommand(cmd.c_str(), answer);
-	if (ret != DEVICE_OK)
-	{
-		return ret;
+	const int result = QueryCommand(command.c_str(), answer);
+	if (result != DEVICE_OK) {
+		return result;
 	}
-	if (answer.compare(0, 2, ":A") == 0)
-	{
+	if (answer.compare(0, 2, ":A") == 0) {
 		return DEVICE_OK;
 	}
-	if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0)
-	{
+	if (answer.length() > 2 && answer.compare(0, 2, ":N") == 0) {
 		int errNo = atoi(answer.substr(2).c_str());
 		return ERR_OFFSET + errNo;
 	}
@@ -671,7 +659,7 @@ int CRISP::OnWaitAfterLock(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CRISP::GetObjectiveNA(double& objNA)
 {
-	float na;
+	double na{};
 	int ret = GetValue("LR Y?", na);
 	if (ret != DEVICE_OK)
 	{
@@ -719,7 +707,7 @@ int CRISP::OnCalGain(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		float calGain;
+		double calGain{};
 		int ret = GetValue("LR X?", calGain);
 		if (ret != DEVICE_OK)
 		{
@@ -740,7 +728,7 @@ int CRISP::OnCalGain(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CRISP::GetCalRange(double& calRange)
 {
-	float calibRange;
+	double calibRange{};
 	int ret = GetValue("LR F?", calibRange);
 	if (ret != DEVICE_OK)
 	{
@@ -770,7 +758,7 @@ int CRISP::OnCalRange(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CRISP::GetLockRange(double& lockRange)
 {
-	float lr;
+	double lr{};
 	int ret = GetValue("LR Z?", lr);
 	if (ret != DEVICE_OK)
 	{
@@ -800,7 +788,7 @@ int CRISP::OnLockRange(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CRISP::GetNumAverages(long& numAverages)
 {
-	float numAvg;
+	double numAvg{};
 	int ret = GetValue("RT F?", numAvg);
 	if (ret != DEVICE_OK)
 	{
@@ -830,7 +818,7 @@ int CRISP::OnNumAvg(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CRISP::GetGainMultiplier(long& gainMult)
 {
-	float gain;
+	double gain{};
 	int ret = GetValue("LR T?", gain);
 	if (ret != DEVICE_OK)
 	{
@@ -860,7 +848,7 @@ int CRISP::OnGainMultiplier(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CRISP::GetLEDIntensity(long& ledIntensity)
 {
-	float ledInt;
+	double ledInt{};
 	int ret = GetValue("UL X?", ledInt);
 	if (ret != DEVICE_OK)
 	{
@@ -970,7 +958,7 @@ int CRISP::OnSNR(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		float snr;
+		double snr{};
 		int ret = GetValue("EXTRA Y?", snr);
 		if (ret != DEVICE_OK)
 		{
@@ -985,7 +973,7 @@ int CRISP::OnLogAmpAGC(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet)
 	{
-		float val;
+		double val{};
 		int ret = GetValue("AL X?", val);
 		if (ret != DEVICE_OK)
 		{
@@ -998,7 +986,7 @@ int CRISP::OnLogAmpAGC(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CRISP::GetNumSkips(long& updateRate)
 {
-	float numSkips;
+	double numSkips{};
 	int ret = GetValue("UL Y?", numSkips);
 	if (ret != DEVICE_OK)
 	{
@@ -1028,7 +1016,7 @@ int CRISP::OnNumSkips(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int CRISP::GetInFocusRange(double& inFocusRange)
 {
-	float focusRange;
+	double focusRange{};
 	int ret = GetValue("AL Z?", focusRange);
 	if (ret != DEVICE_OK)
 	{
@@ -1112,7 +1100,7 @@ void CRISP::CreateSumProperty() {
 			propertyName.c_str(), 0, true,
 			new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
 				if (eAct == MM::BeforeGet) {
-					float sum{};
+					double sum{};
 					const int result = GetValue("LK T?", sum);
 					if (result != DEVICE_OK) {
 						return result;
@@ -1170,12 +1158,12 @@ void CRISP::CreateDitherErrorProperty() {
 			propertyName.c_str(), 0, true,
 			new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
 				if (eAct == MM::BeforeGet) {
-					float sum{};
-					const int result = GetValue("LK Y?", sum);
+					double ditherError{};
+					const int result = GetValue("LK Y?", ditherError);
 					if (result != DEVICE_OK) {
 						return result;
 					}
-					pProp->Set(sum);
+					pProp->Set(ditherError);
 				}
 				return DEVICE_OK;
 			}

--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -389,50 +389,41 @@ int CRISP::ForceSetFocusState(const std::string& focusState)
 	if (focusState == g_CRISP_I)
 	{
 		// Idle (switch off LED)
-		const char* command = "LK F=79";
-		return SetCommand(command);
+		return SetCommand("LK F=79");
 	}
 	else if (focusState == g_CRISP_R)
 	{
 		// Unlock
-		const char* command = "LK F=85";
-		return SetCommand(command);
+		return SetCommand("LK F=85");
 	}
 	else if (focusState == g_CRISP_K)
 	{
 		// Lock
-		const char* command = "LK F=83";
-		return SetCommand(command);
+		return SetCommand("LK F=83");
 	}
 	else if (focusState == g_CRISP_G)
 	{
-		// Log-Amp Calibration
-		const char* command = "LK F=72";
-		return SetCommand(command);
+		// Log-Amp Calibration;
+		return SetCommand("LK F=72");
 	}
 	else if (focusState == g_CRISP_SG)
 	{
 		// gain_Cal Calibration
-		const char* command = "LK F=67";
-		return SetCommand(command);
+		return SetCommand("LK F=67");
 	}
 	else if (focusState == g_CRISP_f)
 	{
 		// Dither
-		const char* command = "LK F=102";
-		return SetCommand(command);
+		return SetCommand("LK F=102");
 	}
 	else if (focusState == g_CRISP_RFO)
 	{
 		// Reset focus offset
-		const char* command = "LK F=111";
-		return SetCommand(command);
+		return SetCommand("LK F=111");
 	}
 	else if (focusState == g_CRISP_SSZ)
 	{
-		// Reset focus offset
-		const char* command = "SS Z";
-		return SetCommand(command);
+		return SetCommand("SS Z");
 	}
 
 	return DEVICE_OK;

--- a/DeviceAdapters/ASIStage/ASICRISP.h
+++ b/DeviceAdapters/ASIStage/ASICRISP.h
@@ -73,8 +73,8 @@ private:
 	int GetFocusState(std::string& focusState);
 	int SetFocusState(const std::string& focusState);
 	int ForceSetFocusState(const std::string& focusState);
-	int GetValue(const std::string& cmd, float& val);
-	int SetCommand(const std::string& cmd);
+	int GetValue(const std::string& command, double& value);
+	int SetCommand(const std::string& command);
 
 	// Properties
 	void CreateSumProperty();

--- a/DeviceAdapters/ASIStage/ASILED.cpp
+++ b/DeviceAdapters/ASIStage/ASILED.cpp
@@ -96,8 +96,7 @@ int LED::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (version_.IsVersionAtLeast(8, 8, 'a'))
-	{
+	if (version_ >= Version(8, 8, 'a')) {
 		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{

--- a/DeviceAdapters/ASIStage/ASILED.cpp
+++ b/DeviceAdapters/ASIStage/ASILED.cpp
@@ -74,16 +74,16 @@ int LED::Initialize()
 	if (ret != DEVICE_OK)
 		return ret;
 
-	ret = GetVersion(version_);
+	ret = GetVersion(firmwareVersion_);
 	if (ret != DEVICE_OK)
 		return ret;
 	CPropertyAction* pAct = new CPropertyAction(this, &LED::OnVersion);
-	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
+	CreateProperty("Version", firmwareVersion_.c_str(), MM::String, true, pAct);
 
 	// get the firmware version data from cached value
-	versionData_ = ParseVersionString(version_);
+	version_ = Version::ParseString(firmwareVersion_);
 
-	ret = GetCompileDate(compileDate_);
+	ret = GetCompileDate(firmwareDate_);
 	if (ret != DEVICE_OK)
 	{
 		return ret;
@@ -96,9 +96,9 @@ int LED::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (versionData_.IsVersionAtLeast(8, 8, 'a'))
+	if (version_.IsVersionAtLeast(8, 8, 'a'))
 	{
-		ret = GetBuildName(buildName_);
+		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{
 			return ret;

--- a/DeviceAdapters/ASIStage/ASIMagnifier.cpp
+++ b/DeviceAdapters/ASIStage/ASIMagnifier.cpp
@@ -67,16 +67,16 @@ int Magnifier::Initialize()
         return ret;
     }
 
-	 ret = GetVersion(version_);
+	 ret = GetVersion(firmwareVersion_);
 	 if (ret != DEVICE_OK)
        return ret;
     CPropertyAction* pAct = new CPropertyAction(this, &Magnifier::OnVersion);
-    CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
+    CreateProperty("Version", firmwareVersion_.c_str(), MM::String, true, pAct);
 
     // get the firmware version data from cached value
-    versionData_ = ParseVersionString(version_);
+    version_ = Version::ParseString(firmwareVersion_);
 
-    ret = GetCompileDate(compileDate_);
+    ret = GetCompileDate(firmwareDate_);
     if (ret != DEVICE_OK)
     {
         return ret;
@@ -89,9 +89,9 @@ int Magnifier::Initialize()
     // I think it was present before 2010 but this is easy way
 
     // previously compared against compile date (2010, 1, 1)
-    if (versionData_.IsVersionAtLeast(8, 8, 'a'))
+    if (version_.IsVersionAtLeast(8, 8, 'a'))
     {
-        ret = GetBuildName(buildName_);
+        ret = GetBuildName(firmwareBuild_);
         if (ret != DEVICE_OK)
         {
             return ret;

--- a/DeviceAdapters/ASIStage/ASIMagnifier.cpp
+++ b/DeviceAdapters/ASIStage/ASIMagnifier.cpp
@@ -89,8 +89,7 @@ int Magnifier::Initialize()
     // I think it was present before 2010 but this is easy way
 
     // previously compared against compile date (2010, 1, 1)
-    if (version_.IsVersionAtLeast(8, 8, 'a'))
-    {
+    if (version_ >= Version(8, 8, 'a')) {
         ret = GetBuildName(firmwareBuild_);
         if (ret != DEVICE_OK)
         {

--- a/DeviceAdapters/ASIStage/ASIStateDevice.cpp
+++ b/DeviceAdapters/ASIStage/ASIStateDevice.cpp
@@ -87,8 +87,7 @@ int StateDevice::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (version_.IsVersionAtLeast(8, 8, 'a'))
-	{
+	if (version_ >= Version(8, 8, 'a')) {
 		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{

--- a/DeviceAdapters/ASIStage/ASIStateDevice.cpp
+++ b/DeviceAdapters/ASIStage/ASIStateDevice.cpp
@@ -65,16 +65,16 @@ int StateDevice::Initialize()
 {
 	core_ = GetCoreCallback();
 
-   int ret = GetVersion(version_);
+   int ret = GetVersion(firmwareVersion_);
 	if (ret != DEVICE_OK)
        return ret;
 	CPropertyAction* pAct = new CPropertyAction(this, &StateDevice::OnVersion);
-	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
+	CreateProperty("Version", firmwareVersion_.c_str(), MM::String, true, pAct);
 
 	// get the firmware version data from cached value
-	versionData_ = ParseVersionString(version_);
+	version_ = Version::ParseString(firmwareVersion_);
 
-	ret = GetCompileDate(compileDate_);
+	ret = GetCompileDate(firmwareDate_);
 	if (ret != DEVICE_OK)
 	{
 		return ret;
@@ -87,9 +87,9 @@ int StateDevice::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (versionData_.IsVersionAtLeast(8, 8, 'a'))
+	if (version_.IsVersionAtLeast(8, 8, 'a'))
 	{
-		ret = GetBuildName(buildName_);
+		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{
 			return ret;

--- a/DeviceAdapters/ASIStage/ASITIRF.cpp
+++ b/DeviceAdapters/ASIStage/ASITIRF.cpp
@@ -75,16 +75,16 @@ int TIRF::Initialize()
         return ret;
     }
 
-    ret = GetVersion(version_);
+    ret = GetVersion(firmwareVersion_);
     if (ret != DEVICE_OK)
        return ret;
     CPropertyAction* pAct = new CPropertyAction(this, &TIRF::OnVersion);
-    CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
+    CreateProperty("Version", firmwareVersion_.c_str(), MM::String, true, pAct);
 
     // get the firmware version data from cached value
-    versionData_ = ParseVersionString(version_);
+    version_ = Version::ParseString(firmwareVersion_);
 
-    ret = GetCompileDate(compileDate_);
+    ret = GetCompileDate(firmwareDate_);
     if (ret != DEVICE_OK)
     {
         return ret;
@@ -97,9 +97,9 @@ int TIRF::Initialize()
     // I think it was present before 2010 but this is easy way
 
     // previously compared against compile date (2010, 1, 1)
-    if (versionData_.IsVersionAtLeast(8, 8, 'a'))
+    if (version_.IsVersionAtLeast(8, 8, 'a'))
     {
-        ret = GetBuildName(buildName_);
+        ret = GetBuildName(firmwareBuild_);
         if (ret != DEVICE_OK)
         {
             return ret;

--- a/DeviceAdapters/ASIStage/ASITIRF.cpp
+++ b/DeviceAdapters/ASIStage/ASITIRF.cpp
@@ -97,8 +97,7 @@ int TIRF::Initialize()
     // I think it was present before 2010 but this is easy way
 
     // previously compared against compile date (2010, 1, 1)
-    if (version_.IsVersionAtLeast(8, 8, 'a'))
-    {
+    if (version_ >= Version(8, 8, 'a')) {
         ret = GetBuildName(firmwareBuild_);
         if (ret != DEVICE_OK)
         {

--- a/DeviceAdapters/ASIStage/ASITurret.cpp
+++ b/DeviceAdapters/ASIStage/ASITurret.cpp
@@ -73,16 +73,16 @@ int AZ100Turret::Initialize()
 		return ret;
 	}
 
-   ret = GetVersion(version_);
+   ret = GetVersion(firmwareVersion_);
    if (ret != DEVICE_OK)
        return ret;
 	pAct = new CPropertyAction(this, &AZ100Turret::OnVersion);
-	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
+	CreateProperty("Version", firmwareVersion_.c_str(), MM::String, true, pAct);
 
 	// get the firmware version data from cached value
-	versionData_ = ParseVersionString(version_);
+	version_ = Version::ParseString(firmwareVersion_);
 
-	ret = GetCompileDate(compileDate_);
+	ret = GetCompileDate(firmwareDate_);
 	if (ret != DEVICE_OK)
 	{
 		return ret;
@@ -95,9 +95,9 @@ int AZ100Turret::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (versionData_.IsVersionAtLeast(8, 8, 'a'))
+	if (version_.IsVersionAtLeast(8, 8, 'a'))
 	{
-		ret = GetBuildName(buildName_);
+		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{
 			return ret;

--- a/DeviceAdapters/ASIStage/ASITurret.cpp
+++ b/DeviceAdapters/ASIStage/ASITurret.cpp
@@ -95,8 +95,7 @@ int AZ100Turret::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (version_.IsVersionAtLeast(8, 8, 'a'))
-	{
+	if (version_ >= Version(8, 8, 'a')) {
 		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{

--- a/DeviceAdapters/ASIStage/ASIXYStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIXYStage.cpp
@@ -85,16 +85,16 @@ int XYStage::Initialize()
 	if (ret != DEVICE_OK)
 		return ret;
 
-   ret = GetVersion(version_);
+   ret = GetVersion(firmwareVersion_);
    if (ret != DEVICE_OK)
        return ret;
 	CPropertyAction* pAct = new CPropertyAction(this, &XYStage::OnVersion);
-	CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
+	CreateProperty("Version", firmwareVersion_.c_str(), MM::String, true, pAct);
 
 	// get the firmware version data from cached value
-	versionData_ = ParseVersionString(version_);
+	version_ = Version::ParseString(firmwareVersion_);
 
-	ret = GetCompileDate(compileDate_);
+	ret = GetCompileDate(firmwareDate_);
 	if (ret != DEVICE_OK)
 	{
 		return ret;
@@ -107,9 +107,9 @@ int XYStage::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (versionData_.IsVersionAtLeast(8, 8, 'a'))
+	if (version_.IsVersionAtLeast(8, 8, 'a'))
 	{
-		ret = GetBuildName(buildName_);
+		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{
 			return ret;
@@ -776,7 +776,7 @@ int XYStage::OnWait(MM::PropertyBase* pProp, MM::ActionType eAct)
 		// and that transition occurred ~2008 but not sure exactly when
 
 		// previously compared against compile date (2009, 1, 1)
-		if (versionData_.IsVersionAtLeast(8, 6, 'd'))
+		if (version_.IsVersionAtLeast(8, 6, 'd'))
 		{
 			// don't enforce upper limit
 		}

--- a/DeviceAdapters/ASIStage/ASIXYStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIXYStage.cpp
@@ -107,8 +107,7 @@ int XYStage::Initialize()
 	// I think it was present before 2010 but this is easy way
 
 	// previously compared against compile date (2010, 1, 1)
-	if (version_.IsVersionAtLeast(8, 8, 'a'))
-	{
+	if (version_ >= Version(8, 8, 'a')) {
 		ret = GetBuildName(firmwareBuild_);
 		if (ret != DEVICE_OK)
 		{
@@ -776,12 +775,11 @@ int XYStage::OnWait(MM::PropertyBase* pProp, MM::ActionType eAct)
 		// and that transition occurred ~2008 but not sure exactly when
 
 		// previously compared against compile date (2009, 1, 1)
-		if (version_.IsVersionAtLeast(8, 6, 'd'))
-		{
+		if (version_ >= Version(8, 6, 'd')) {
 			// don't enforce upper limit
-		}
-		else  // enforce limit for 2008 and earlier firmware or
-		{     // if getting compile date wasn't successful
+		} else {
+			// enforce limit for 2008 and earlier firmware or
+			// if getting compile date wasn't successful
 			if (waitCycles > 255)
 			{
 				waitCycles = 255;

--- a/DeviceAdapters/ASIStage/ASIXYStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIXYStage.cpp
@@ -1199,14 +1199,7 @@ int XYStage::OnMotorCtrl(MM::PropertyBase* pProp, MM::ActionType eAct)
 	if (eAct == MM::BeforeGet)
 	{
 		// The controller can not report whether or not the motors are on.  Cache the value
-		if (motorOn_)
-		{
-			pProp->Set("On");
-		}
-		else
-		{
-			pProp->Set("Off");
-		}
+		pProp->Set(motorOn_ ? "On" : "Off");
 		return DEVICE_OK;
 	}
 	else if (eAct == MM::AfterSet)
@@ -1244,14 +1237,7 @@ int XYStage::OnJSMirror(MM::PropertyBase* pProp, MM::ActionType eAct)
 	if (eAct == MM::BeforeGet)
 	{
 		// TODO: read from device, at least on initialization
-		if (joyStickMirror_)
-		{
-			pProp->Set("On");
-		}
-		else
-		{
-			pProp->Set("Off");
-		}
+		pProp->Set(joyStickMirror_ ? "On" : "Off");
 		return DEVICE_OK;
 	}
 	else if (eAct == MM::AfterSet) {
@@ -1466,17 +1452,10 @@ int XYStage::OnSerialResponse(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int XYStage::OnSerialCommandOnlySendChanged(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::string tmpstr;
 	if (eAct == MM::AfterSet) {
+		std::string tmpstr;
 		pProp->Get(tmpstr);
-		if (tmpstr.compare("Yes") == 0)
-		{
-			serialOnlySendChanged_ = true;
-		}
-		else
-		{
-			serialOnlySendChanged_ = false;
-		}
+		serialOnlySendChanged_ = (tmpstr == "Yes") ? true : false;
 	}
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/ASIStage/ASIZStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIZStage.cpp
@@ -103,16 +103,16 @@ int ZStage::Initialize()
         ret = GetPositionSteps(curSteps_);
     }
 
-    ret = GetVersion(version_);
+    ret = GetVersion(firmwareVersion_);
     if (ret != DEVICE_OK)
        return ret;
     CPropertyAction* pAct = new CPropertyAction(this, &ZStage::OnVersion);
-    CreateProperty("Version", version_.c_str(), MM::String, true, pAct);
+    CreateProperty("Version", firmwareVersion_.c_str(), MM::String, true, pAct);
 
     // get the firmware version data from cached value
-    versionData_ = ParseVersionString(version_);
+    version_ = Version::ParseString(firmwareVersion_);
 
-    ret = GetCompileDate(compileDate_);
+    ret = GetCompileDate(firmwareDate_);
     if (ret != DEVICE_OK)
     {
         return ret;
@@ -125,9 +125,9 @@ int ZStage::Initialize()
     // I think it was present before 2010 but this is easy way
 
     // previously compared against compile date (2010, 1, 1)
-    if (versionData_.IsVersionAtLeast(8, 8, 'a'))
+    if (version_.IsVersionAtLeast(8, 8, 'a'))
     {
-        ret = GetBuildName(buildName_);
+        ret = GetBuildName(firmwareBuild_);
         if (ret != DEVICE_OK)
         {
             return ret;
@@ -630,7 +630,7 @@ int ZStage::SendStageSequence()
             std::ostringstream os;
             os.precision(0);
             // previously compared against compile date (2015, 10, 23)
-            if (versionData_.IsVersionAtLeast(9, 2, 'i'))
+            if (version_.IsVersionAtLeast(9, 2, 'i'))
             {
                 os << std::fixed << "LD " << axis_ << "=" << sequence_[i] * 10;  // 10 here is for unit multiplier/1000
                 ret = QueryCommand(os.str().c_str(), answer);
@@ -1012,7 +1012,7 @@ int ZStage::OnWait(MM::PropertyBase* pProp, MM::ActionType eAct)
         // parse version strings
 
         // previously compared against compile date (2009, 1, 1)
-        if (versionData_.IsVersionAtLeast(8, 6, 'd'))
+        if (version_.IsVersionAtLeast(8, 6, 'd'))
         {
             // don't enforce upper limit
         }

--- a/DeviceAdapters/ASIStage/ASIZStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIZStage.cpp
@@ -125,8 +125,7 @@ int ZStage::Initialize()
     // I think it was present before 2010 but this is easy way
 
     // previously compared against compile date (2010, 1, 1)
-    if (version_.IsVersionAtLeast(8, 8, 'a'))
-    {
+    if (version_ >= Version(8, 8, 'a')) {
         ret = GetBuildName(firmwareBuild_);
         if (ret != DEVICE_OK)
         {
@@ -630,8 +629,7 @@ int ZStage::SendStageSequence()
             std::ostringstream os;
             os.precision(0);
             // previously compared against compile date (2015, 10, 23)
-            if (version_.IsVersionAtLeast(9, 2, 'i'))
-            {
+            if (version_ >= Version(9, 2, 'i')) {
                 os << std::fixed << "LD " << axis_ << "=" << sequence_[i] * 10;  // 10 here is for unit multiplier/1000
                 ret = QueryCommand(os.str().c_str(), answer);
                 if (ret != DEVICE_OK)
@@ -1012,14 +1010,12 @@ int ZStage::OnWait(MM::PropertyBase* pProp, MM::ActionType eAct)
         // parse version strings
 
         // previously compared against compile date (2009, 1, 1)
-        if (version_.IsVersionAtLeast(8, 6, 'd'))
-        {
+        if (version_ >= Version(8, 6, 'd')) {
             // don't enforce upper limit
-        }
-        else  // enforce limit for 2008 and earlier firmware or
-        {     // if getting compile date wasn't successful
-            if (waitCycles > 255)
-            {
+        } else {
+            // enforce limit for 2008 and earlier firmware or
+            // if getting compile date wasn't successful
+            if (waitCycles > 255) {
                 waitCycles = 255;
             }
         }

--- a/DeviceAdapters/ASIStage/ASIZStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIZStage.cpp
@@ -1410,14 +1410,7 @@ int ZStage::OnMotorCtrl(MM::PropertyBase* pProp, MM::ActionType eAct)
     if (eAct == MM::BeforeGet)
     {
         // The controller can not report whether or not the motors are on.  Cache the value
-        if (motorOn_)
-        {
-            pProp->Set("On");
-        }
-        else
-        {
-            pProp->Set("Off");
-        }
+        pProp->Set(motorOn_ ? "On" : "Off");
         return DEVICE_OK;
     }
     else if (eAct == MM::AfterSet)


### PR DESCRIPTION
Precompute the serial terminator and command prefix for less branching in `SendCommand` and `QueryCommand`.

Improve `Version` class and add `>=` overload. `ParseVersionString` moved to `Version` class and is now `Version::ParseString`.