### PR TITLE
MMDevice: Delete most deprecated functions

### DIFF
--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -84,34 +84,17 @@ public:
    void Sleep(const MM::Device* caller, double intervalMs);
 
    // continuous acquisition support
-   /*Deprecated*/ int InsertImage(const MM::Device* caller, const ImgBuffer& imgBuf); // Note: _not_ mm::ImgBuffer
    int InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess = true);
    int InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const char* serializedMetadata, const bool doProcess = true);
-
-   /*Deprecated*/ int InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const Metadata* pMd = 0, const bool doProcess = true);
-   /*Deprecated*/ int InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const Metadata* pMd = 0, const bool doProcess = true);
-
-   /*Deprecated*/ int InsertMultiChannel(const MM::Device* caller, const unsigned char* buf, unsigned numChannels, unsigned width, unsigned height, unsigned byteDepth, Metadata* pMd = 0);
    void ClearImageBuffer(const MM::Device* caller);
    bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth);
 
    int AcqFinished(const MM::Device* caller, int statusCode);
    int PrepareForAcq(const MM::Device* caller);
 
-   // autofocus support
-   const char* GetImage();
-   int GetImageDimensions(int& width, int& height, int& depth);
+   // Deprecated
    int GetFocusPosition(double& pos);
-   int SetFocusPosition(double pos);
-   int MoveFocus(double v);
-   int SetXYPosition(double x, double y);
    int GetXYPosition(double& x, double& y);
-   int MoveXYStage(double vX, double vY);
-   int SetExposure(double expMs);
-   int GetExposure(double& expMs);
-   int SetConfig(const char* group, const char* name);
-   int GetCurrentConfig(const char* group, int bufLen, char* name);
-   int GetChannelConfig(char* channelConfigName, const unsigned int channelConfigIterator);
 
    // notification handlers
    int OnPropertiesChanged(const MM::Device* caller);
@@ -122,17 +105,10 @@ public:
    int OnSLMExposureChanged(const MM::Device* device, double newExposure);
    int OnMagnifierChanged(const MM::Device* device);
 
-
-   void NextPostedError(int& errorCode, char* pMessage, int maxlen, int& messageLength);
-   void PostError(const int errorCode, const char* pMessage);
-   void ClearPostedErrors();
-
-
-   MM::ImageProcessor* GetImageProcessor(const MM::Device* caller);
-   MM::State* GetStateDevice(const MM::Device* caller, const char* label);
+   // Deprecated
    MM::SignalIO* GetSignalIODevice(const MM::Device* caller,
          const char* label);
-   MM::AutoFocus* GetAutoFocus(const MM::Device* caller);
+
    MM::Hub* GetParentHub(const MM::Device* caller) const;
    void GetLoadedDeviceOfType(const MM::Device* caller, MM::DeviceType devType,
          char* deviceName, const unsigned int deviceIterator);
@@ -142,6 +118,7 @@ private:
    MMThreadLock* pValueChangeLock_;
 
    Metadata AddCameraMetadata(const MM::Device* caller, const Metadata* pMd);
+   MM::ImageProcessor* GetImageProcessor(const MM::Device* caller);
 
    int OnConfigGroupChanged(const char* groupName, const char* newConfigName);
    int OnPixelSizeChanged(double newPixelSizeUm);

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -726,9 +726,6 @@ private:
    mutable MMThreadLock stateCacheLock_;
    mutable Configuration stateCache_; // Synchronized by stateCacheLock_
 
-   MMThreadLock* pPostedErrorsLock_;
-   mutable std::deque<std::pair< int, std::string> > postedErrors_;
-
    // True while interpreting the config file (but not while rolling back on
    // failure):
    bool isLoadingSystemConfiguration_ = false;

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -97,11 +97,6 @@ public:
    typedef MM::ActionEx<U> CPropertyActionEx;
 
    /**
-   * Returns the library handle (for use only by the calling code).
-   */
-   virtual HDEVMODULE GetModuleHandle() const {return module_;}
-
-   /**
    * Assigns a name for the module (for use only by the calling code).
    */
    virtual void SetModuleName(const char* name)
@@ -132,11 +127,6 @@ public:
    {
       CDeviceUtils::CopyLimitedString(name, description_.c_str());
    }
-
-   /**
-   * Sets the library handle (for use only by the calling code).
-   */
-   virtual void SetModuleHandle(HDEVMODULE hModule) {module_ = hModule;}
 
    /**
    * Sets the device label (for use only by the calling code).
@@ -809,7 +799,7 @@ public:
 
 protected:
 
-   CDeviceBase() : module_(0), delayMs_(0), usesDelay_(false), callback_(0)
+   CDeviceBase() : delayMs_(0), usesDelay_(false), callback_(0)
    {
       InitializeDefaultErrorMessages();
    }
@@ -1250,7 +1240,6 @@ private:
 
 
    MM::PropertyCollection properties_;
-   HDEVMODULE module_;
    std::string label_;
    std::string moduleName_;
    std::string description_;

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -28,7 +28,7 @@
 // Header version
 // If any of the class definitions changes, the interface version
 // must be incremented
-#define DEVICE_INTERFACE_VERSION 73
+#define DEVICE_INTERFACE_VERSION 74
 ///////////////////////////////////////////////////////////////////////////////
 
 // N.B.
@@ -52,17 +52,6 @@
 #include <string>
 #include <vector>
 
-// To be removed once the deprecated Get/SetModuleHandle() is removed:
-#ifdef _WIN32
-   #define WIN32_LEAN_AND_MEAN
-   #include <windows.h>
-
-   typedef HMODULE HDEVMODULE;
-#else
-   typedef void* HDEVMODULE;
-#endif
-
-class ImgBuffer;
 
 namespace MM {
 
@@ -265,9 +254,6 @@ namespace MM {
       virtual double GetDelayMs() const = 0;
       virtual void SetDelayMs(double delay) = 0;
       virtual bool UsesDelay() = 0;
-
-      MM_DEPRECATED(virtual HDEVMODULE GetModuleHandle() const) = 0;
-      MM_DEPRECATED(virtual void SetModuleHandle(HDEVMODULE hLibraryHandle)) = 0;
 
       virtual void SetLabel(const char* label) = 0;
       virtual void GetLabel(char* name) const = 0;
@@ -1585,9 +1571,6 @@ namespace MM {
       virtual int AcqFinished(const Device* caller, int statusCode) = 0;
       virtual int PrepareForAcq(const Device* caller) = 0;
 
-      /// \deprecated Use the other overloads instead.
-      MM_DEPRECATED(virtual int InsertImage(const Device* caller, const ImgBuffer& buf)) = 0;
-
       /**
        * Cameras must call this function during sequence acquisition to send
        * each frame to the Core.
@@ -1610,57 +1593,23 @@ namespace MM {
        */
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const char* serializedMetadata, const bool doProcess = true) = 0;
 
-      /// \deprecated Use the other overloads instead.
-      MM_DEPRECATED(virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const Metadata* md = 0, const bool doProcess = true)) = 0;
-      // TODO Upon removing the above deprecated overload, add a default
-      // argument `= nullptr` to `serializedMetadata` in the following
-      // overload. That allows existing device adapters to compile.
-
       /**
        * Same as the overload with the added nComponents parameter.
        *
        * Assumes nComponents == 1 (grayscale).
        */
-      virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess = true) = 0;
+      virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata = nullptr, const bool doProcess = true) = 0;
 
       virtual void ClearImageBuffer(const Device* caller) = 0;
       virtual bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth) = 0;
 
-      /// \deprecated Use InsertImage() instead.
-      MM_DEPRECATED(virtual int InsertMultiChannel(const Device* caller, const unsigned char* buf, unsigned numChannels, unsigned width, unsigned height, unsigned byteDepth, Metadata* md = 0)) = 0;
-
-      // Formerly intended for use by autofocus
-      MM_DEPRECATED(virtual const char* GetImage()) = 0;
-      MM_DEPRECATED(virtual int GetImageDimensions(int& width, int& height, int& depth)) = 0;
+      // These functions violate the separation between device adapters and
+      // will be removed as soon as we remove all uses. Never use in new code.
       MM_DEPRECATED(virtual int GetFocusPosition(double& pos)) = 0;
-      MM_DEPRECATED(virtual int SetFocusPosition(double pos)) = 0;
-      MM_DEPRECATED(virtual int MoveFocus(double velocity)) = 0;
-      MM_DEPRECATED(virtual int SetXYPosition(double x, double y)) = 0;
       MM_DEPRECATED(virtual int GetXYPosition(double& x, double& y)) = 0;
-      MM_DEPRECATED(virtual int MoveXYStage(double vX, double vY)) = 0;
-      MM_DEPRECATED(virtual int SetExposure(double expMs)) = 0;
-      MM_DEPRECATED(virtual int GetExposure(double& expMs)) = 0;
-      MM_DEPRECATED(virtual int SetConfig(const char* group, const char* name)) = 0;
-      MM_DEPRECATED(virtual int GetCurrentConfig(const char* group, int bufLen, char* name)) = 0;
-      MM_DEPRECATED(virtual int GetChannelConfig(char* channelConfigName, const unsigned int channelConfigIterator)) = 0;
-
-      // Direct (and dangerous) access to specific device types
-      MM_DEPRECATED(virtual MM::ImageProcessor* GetImageProcessor(const MM::Device* caller)) = 0;
-      MM_DEPRECATED(virtual MM::AutoFocus* GetAutoFocus(const MM::Device* caller)) = 0;
-
-      virtual MM::Hub* GetParentHub(const MM::Device* caller) const = 0;
-
-      // More direct (and dangerous) access to specific device types
-      MM_DEPRECATED(virtual MM::State* GetStateDevice(const MM::Device* caller, const char* deviceName)) = 0;
       MM_DEPRECATED(virtual MM::SignalIO* GetSignalIODevice(const MM::Device* caller, const char* deviceName)) = 0;
 
-      // Asynchronous error handling (never implemented)
-      /// \deprecated Not sure what this was meant to do.
-      MM_DEPRECATED(virtual void NextPostedError(int& /*errorCode*/, char* /*pMessage*/, int /*maxlen*/, int& /*messageLength*/)) = 0;
-      /// \deprecated Better handling of asynchronous errors to be developed.
-      MM_DEPRECATED(virtual void PostError(const int, const char*)) = 0;
-      /// \deprecated Better handling of asynchronous errors to be developed.
-      MM_DEPRECATED(virtual void ClearPostedErrors(void)) = 0;
+      virtual MM::Hub* GetParentHub(const MM::Device* caller) const = 0;
    };
 
 } // namespace MM


### PR DESCRIPTION
And remove corresponding CoreCallback implementations (and leftover functions from previously deprecated ones).

Closes #295.

This leaves a few deprecated functions in MMDevice because they are still used by a few device adapters:

```cpp
MM_DEPRECATED(virtual int GetFocusPosition(double& pos)) = 0;
MM_DEPRECATED(virtual int GetXYPosition(double& x, double& y)) = 0;
MM_DEPRECATED(virtual MM::SignalIO* GetSignalIODevice(const MM::Device* caller, const char* deviceName)) = 0;
```