### PR TITLE
Match MMCore/MMDevice values for focus direction

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -2115,11 +2115,7 @@ int CMMCore::getFocusDirection(const char* stageLabel) MMCORE_LEGACY_THROW(CMMEr
       deviceManager_->GetDeviceOfType<StageInstance>(stageLabel);
 
    mm::DeviceModuleLockGuard guard(stage);
-   switch (stage->GetFocusDirection()) {
-      case MM::FocusDirectionTowardSample: return +1;
-      case MM::FocusDirectionAwayFromSample: return -1;
-      default: return 0;
-   }
+   return static_cast<int>(stage->GetFocusDirection());
 }
 
 

--- a/MMDevice/MMDeviceConstants.h
+++ b/MMDevice/MMDeviceConstants.h
@@ -282,9 +282,9 @@ namespace MM {
    };
 
    enum FocusDirection {
-      FocusDirectionUnknown,
-      FocusDirectionTowardSample,
-      FocusDirectionAwayFromSample,
+      FocusDirectionUnknown = 0,
+      FocusDirectionTowardSample = +1,
+      FocusDirectionAwayFromSample = -1,
    };
 
    //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This should avoid confusion. No change to MMCore API or behavior.

Technically this requires the Device Interface Version to be bumped,
though none of our devices actually use these constants currently.

Closes #558.
