### PR TITLE
Remove camera "clear on buffer overflow" behavior

### DIFF
--- a/DeviceAdapters/ABS/ABSCamera.cpp
+++ b/DeviceAdapters/ABS/ABSCamera.cpp
@@ -1277,14 +1277,6 @@ int CABSCamera::InsertImage()
 
   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str() );
 
-  if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-  {  
-    // do not stop on overflow - just reset the buffer
-    GetCoreCallback()->ClearImageBuffer(this);
-    // don't process this same image again...
-    ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-  }
-
   if (ret == DEVICE_OK)
     imageCounter_++;
 

--- a/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.cpp
+++ b/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.cpp
@@ -1392,13 +1392,6 @@ void AlliedVisionCamera::insertFrame(VmbFrame_t *frame)
         err = GetCoreCallback()->InsertImage(this, buffer, GetImageWidth(), GetImageHeight(), m_currentPixelFormat.getBytesPerPixel(),
                                              m_currentPixelFormat.getNumberOfComponents(), md.Serialize().c_str());
 
-        if (err == DEVICE_BUFFER_OVERFLOW)
-        {
-            GetCoreCallback()->ClearImageBuffer(this);
-            err = GetCoreCallback()->InsertImage(this, buffer, GetImageWidth(), GetImageHeight(), m_currentPixelFormat.getBytesPerPixel(),
-                                                 m_currentPixelFormat.getNumberOfComponents(), md.Serialize().c_str(), false);
-        }
-
         if (IsCapturing())
         {
             m_sdk->VmbCaptureFrameQueue_t(m_handle, frame,

--- a/DeviceAdapters/AmScope/AmScope.cpp
+++ b/DeviceAdapters/AmScope/AmScope.cpp
@@ -752,7 +752,6 @@ int AmScope::StartSequenceAcquisition(long numImages, double interval_ms, bool s
    sequenceStartTime_ = GetCurrentMMTime();
    imageCounter_ = 0;
    thd_->Start(numImages,interval_ms);
-   stopOnOverflow_ = stopOnOverflow;
 
    return DEVICE_OK;
 }
@@ -781,14 +780,6 @@ int AmScope::InsertImage()
   unsigned int b = GetImageBytesPerPixel();  
 
   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str() );
-
-  if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-  {  
-    // do not stop on overflow - just reset the buffer
-    GetCoreCallback()->ClearImageBuffer(this);
-    // don't process this same image again...
-    ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-  }
   
   if (ret == DEVICE_OK)
   {

--- a/DeviceAdapters/AmScope/AmScope.h
+++ b/DeviceAdapters/AmScope/AmScope.h
@@ -134,7 +134,6 @@ private:
    bool isSequenceable_;
    long sequenceMaxLength_;
    bool sequenceRunning_;
-   bool stopOnOverflow_;
    long imageCounter_;
    MMThreadLock imgPixelsLock_;
    std::string triggerDevice_;

--- a/DeviceAdapters/Andor/Andor.cpp
+++ b/DeviceAdapters/Andor/Andor.cpp
@@ -5229,31 +5229,17 @@ int AndorCamera::GetCameraAcquisitionProgress(at_32* series)
    {
      MMThreadGuard g(imgPixelsLock_);
 
-     int retCode;
      Metadata md;
      AddMetadataInfo(md);
 
      imageCounter_++;
 
      // This method inserts new image in the circular buffer (residing in MMCore)
-     retCode = GetCoreCallback()->InsertImage(this, imagePtr,
+     return GetCoreCallback()->InsertImage(this, imagePtr,
        width,
        height,
        bytesPerPixel,
        md.Serialize().c_str());
-
-     if (!stopOnOverflow_ && DEVICE_BUFFER_OVERFLOW == retCode)
-     {
-       // do not stop on overflow - just reset the buffer
-       GetCoreCallback()->ClearImageBuffer(this);
-       GetCoreCallback()->InsertImage(this, (unsigned char*)imagePtr,
-         width,
-         height,
-         bytesPerPixel,
-         md.Serialize().c_str(),
-         false);
-     }
-     return retCode;
    }
 
 
@@ -5332,21 +5318,6 @@ int AndorCamera::GetCameraAcquisitionProgress(at_32* series)
             if (DEVICE_OK != corecallbackInsertImageReturn)
             {
                return corecallbackInsertImageReturn;
-            }
-
-            if (!stopOnOverflow_ && DEVICE_BUFFER_OVERFLOW == corecallbackInsertImageReturn)
-            {
-               // do not stop on overflow - just reset the buffer
-               //Log("[PushImageWithSRRF] Circular Buffer overflowed. Clearing and sending up image again...");
-               GetCoreCallback()->ClearImageBuffer(this);
-               GetCoreCallback()->InsertImage(
-                  this,
-                  SRRFImage_->GetPixels(),
-                  SRRFImage_->Width(),
-                  SRRFImage_->Height(),
-                  SRRFImage_->Depth(),
-                  md.Serialize().c_str(),
-                  false);
             }
          }
 

--- a/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
+++ b/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
@@ -1339,16 +1339,7 @@ int CAndorSDK3Camera::InsertMMImage(const ImgBuffer& image, const Metadata& md)
    unsigned int h = image.Height();
    unsigned int b = image.Depth();
 
-   int ret = GetCoreCallback()->InsertImage(this, pData, w, h, b, md.Serialize().c_str());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // don't process this same image again...
-      ret = GetCoreCallback()->InsertImage(this, pData, w, h, b, md.Serialize().c_str(), false);
-   }
-
-   return ret;
+   return GetCoreCallback()->InsertImage(this, pData, w, h, b, md.Serialize().c_str());
 }
 
 std::wstring CAndorSDK3Camera::GetPreferredFeature(std::wstring Name, std::wstring FallbackName) const

--- a/DeviceAdapters/AndorSDK3/CallBackManager.cpp
+++ b/DeviceAdapters/AndorSDK3/CallBackManager.cpp
@@ -93,7 +93,6 @@ void CCallBackManager::CPCRestartLiveAcquisition()
 void CCallBackManager::CPCStopLiveAcquisition()
 {
    parentClass_->StopSequenceAcquisition();
-   parentClass_->GetCoreCallback()->ClearImageBuffer(parentClass_);
 }
 
 void CCallBackManager::CPCStartLiveAcquisition()

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -184,10 +184,7 @@ void AravisCamera::AcquisitionCallback(ArvStreamCallbackType type, ArvBuffer *cb
 					     1,
 					     md.Serialize().c_str(),
 					     FALSE);
-    if (ret == DEVICE_BUFFER_OVERFLOW) {
-      GetCoreCallback()->ClearImageBuffer(this);
-    }
-    
+
     arv_stream_push_buffer(arv_stream, cb_arv_buffer);
     counter += 1;
     break;

--- a/DeviceAdapters/Atik/Atik.cpp
+++ b/DeviceAdapters/Atik/Atik.cpp
@@ -889,17 +889,7 @@ int Atik::InsertImage()
 	auto h = GetImageHeight();
 	auto bpp = GetImageBytesPerPixel();
 
-	int ret = GetCoreCallback()->InsertImage(this, imgBuf, w, h, bpp, serialised.c_str());
-
-	if (!isStopOnOverflow() && ret == DEVICE_BUFFER_OVERFLOW)
-	{
-		GetCoreCallback()->ClearImageBuffer(this);
-		return GetCoreCallback()->InsertImage(this, imgBuf, w, h, bpp, serialised.c_str(), false);
-	}
-	else
-	{
-		return ret;
-	}
+	return GetCoreCallback()->InsertImage(this, imgBuf, w, h, bpp, serialised.c_str());
 }
 
 

--- a/DeviceAdapters/Basler/BaslerPylonCamera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylonCamera.cpp
@@ -2152,10 +2152,6 @@ void CircularBufferInserter::OnImageGrabbed(CInstantCamera& /* camera */, const 
 			int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)ptrGrabResult->GetBuffer(),
 				(unsigned)ptrGrabResult->GetWidth(), (unsigned)ptrGrabResult->GetHeight(),
 				(unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize().c_str(), FALSE);
-			if (ret == DEVICE_BUFFER_OVERFLOW) {
-				//if circular buffer overflows, just clear it and keep putting stuff in so live mode can continue
-				dev_->GetCoreCallback()->ClearImageBuffer(dev_);
-			}
 		}
 		else if (IsByerFormat || ptrGrabResult->GetPixelType() == PixelType_RGB8packed)
 		{
@@ -2166,10 +2162,6 @@ void CircularBufferInserter::OnImageGrabbed(CInstantCamera& /* camera */, const 
 			int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)image.GetBuffer(),
 				(unsigned)dev_->GetImageWidth(), (unsigned)dev_->GetImageHeight(),
 				(unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize().c_str(), FALSE);
-			if (ret == DEVICE_BUFFER_OVERFLOW) {
-				//if circular buffer overflows, just clear it and keep putting stuff in so live mode can continue
-				dev_->GetCoreCallback()->ClearImageBuffer(dev_);
-			}
 		}
 		else if (ptrGrabResult->GetPixelType() == PixelType_BGR8packed)
 		{
@@ -2178,11 +2170,6 @@ void CircularBufferInserter::OnImageGrabbed(CInstantCamera& /* camera */, const 
 			int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)dev_->Buffer4ContinuesShot,
 				(unsigned)dev_->GetImageWidth(), (unsigned)dev_->GetImageHeight(),
 				(unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize().c_str(), FALSE);
-			if (ret == DEVICE_BUFFER_OVERFLOW)
-			{
-				//if circular buffer overflows, just clear it and keep putting stuff in so live mode can continue
-				dev_->GetCoreCallback()->ClearImageBuffer(dev_);
-			}
 		}
 	}
 	else

--- a/DeviceAdapters/BaumerOptronic/BaumerOptronic.cpp
+++ b/DeviceAdapters/BaumerOptronic/BaumerOptronic.cpp
@@ -2286,18 +2286,7 @@ int CBaumerOptronic::SendImageToCore()
    unsigned h = GetImageHeight();
    unsigned b = GetImageBytesPerPixel();
 
-   int ret = GetCoreCallback()->InsertImage(this, p, w, h, b, md.Serialize().c_str());
-
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      return GetCoreCallback()->InsertImage(this, p, w, h, b, md.Serialize().c_str());
-   }
-   else
-   {
-      return ret;
-   }
+   return GetCoreCallback()->InsertImage(this, p, w, h, b, md.Serialize().c_str());
 }
 
 

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
@@ -2061,18 +2061,6 @@ void CircularBufferInserter::DoOnImageCaptured(CImageDataPointer& objImageDataPo
             int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)objImageDataPointer->GetBuffer(),
                 (unsigned)objImageDataPointer->GetWidth(), (unsigned)objImageDataPointer->GetHeight(),
                 (unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize().c_str(), FALSE);
-            if (ret == DEVICE_BUFFER_OVERFLOW) {
-                //if circular buffer overflows, just clear it and keep putting stuff in so live mode can continue
-               if (stopOnOverflow_)
-               {
-                  dev_->StopSequenceAcquisition();
-                  dev_->LogMessage("Error inserting image into sequence buffer", false);
-               }
-               else
-               {
-                  dev_->GetCoreCallback()->ClearImageBuffer(dev_);
-               }
-            }
         }
         else if (dev_->colorCamera_)
         {
@@ -2088,10 +2076,6 @@ void CircularBufferInserter::DoOnImageCaptured(CImageDataPointer& objImageDataPo
             int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)dev_->imgBuffer_,
                 (unsigned)dev_->GetImageWidth(), (unsigned)dev_->GetImageHeight(),
                 (unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize().c_str(), FALSE);
-            if (ret == DEVICE_BUFFER_OVERFLOW) {
-                //if circular buffer overflows, just clear it and keep putting stuff in so live mode can continue
-                dev_->GetCoreCallback()->ClearImageBuffer(dev_);
-            }
         }
         imgCounter_++;
         if (imgCounter_ == numImages_)

--- a/DeviceAdapters/Fli/FirstLightImagingCameras.cpp
+++ b/DeviceAdapters/Fli/FirstLightImagingCameras.cpp
@@ -224,12 +224,6 @@ void FirstLightImagingCameras::imageReceived(const uint8_t* image)
 	MM::Core* core = GetCoreCallback();
 
 	int ret = core->InsertImage(this, image, w, h, b, 1, md.Serialize().c_str(), false);
-	if (ret == DEVICE_BUFFER_OVERFLOW)
-	{
-		// do not stop on overflow - just reset the buffer
-		core->ClearImageBuffer(this);
-		core->InsertImage(this, image, w, h, b, 1, md.Serialize().c_str(), false);
-	}
 }
 
 //---------------------------------------------------------------

--- a/DeviceAdapters/GigECamera/GigECameraAcq.cpp
+++ b/DeviceAdapters/GigECamera/GigECameraAcq.cpp
@@ -54,14 +54,6 @@ void CGigECamera::SnapImageCallback( J_tIMAGE_INFO* imageInfo )
 
 		nRet = GetCoreCallback()->InsertImage(this, buffer_,
 				GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel(), md.Serialize().c_str());
-
-		if( !stopOnOverflow_ && nRet == DEVICE_BUFFER_OVERFLOW )
-		{
-			// do not stop on overflow - just reset the buffer
-			GetCoreCallback()->ClearImageBuffer( this );
-			nRet = GetCoreCallback()->InsertImage(this, buffer_,
-				GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel(), md.Serialize().c_str());
-		}
 	} // end if doContinuousAcquisition
 	else if( this->snapOneImageOnly )
 	{

--- a/DeviceAdapters/Hikrobot/HikrobotCamera.cpp
+++ b/DeviceAdapters/Hikrobot/HikrobotCamera.cpp
@@ -1546,14 +1546,6 @@ void HikrobotCamera::ImageRecvThreadProc()
 			nRet = GetCoreCallback()->InsertImage(this, (const unsigned char*)stConvertParam.pDstBuffer,
 				stOutFrame.stFrameInfo.nWidth,
 				stOutFrame.stFrameInfo.nHeight, GetImageBytesPerPixel(), 1, md.Serialize().c_str(), FALSE);
-			if (nRet == DEVICE_BUFFER_OVERFLOW)
-			{
-				//if circular buffer overflows, just clear it and keep putting stuff in so live mode can continue
-				GetCoreCallback()->ClearImageBuffer(this);
-				MvWriteLog(__FILE__, __LINE__, m_chDevID, "InsertImage clear!");
-
-
-			}
 			if (nRet == DEVICE_OK)
 			{
 				MvWriteLog(__FILE__, __LINE__, m_chDevID, "Success InsertImage Width[%d], Height[%d], FrameNum[%d] FrameLen[%d] enPixelType[%lld]",
@@ -1574,11 +1566,6 @@ void HikrobotCamera::ImageRecvThreadProc()
 		}
 
 	}
-
-
-	GetCoreCallback()->ClearImageBuffer(this);
-
-
 
 	MvWriteLog(__FILE__, __LINE__, m_chDevID, "ImageRecvThreadProc End!");
 	return;

--- a/DeviceAdapters/IDSPeak/IDSPeak.cpp
+++ b/DeviceAdapters/IDSPeak/IDSPeak.cpp
@@ -1403,23 +1403,11 @@ int CIDSPeak::InsertImage()
     imageCounter_++;
 
     MMThreadGuard g(imgPixelsLock_);
-    int nRet = GetCoreCallback()->InsertImage(this, img_.GetPixels(),
+    return GetCoreCallback()->InsertImage(this, img_.GetPixels(),
         img_.Width(),
         img_.Height(),
         img_.Depth(),
         md.Serialize().c_str());
-
-    if (!stopOnOverflow_ && nRet == DEVICE_BUFFER_OVERFLOW)
-    {
-        // do not stop on overflow - just reset the buffer
-        GetCoreCallback()->ClearImageBuffer(this);
-        return GetCoreCallback()->InsertImage(this, img_.GetPixels(),
-            img_.Width(),
-            img_.Height(),
-            img_.Depth(),
-            md.Serialize().c_str());
-    }
-    else { return nRet; }
 }
 
 /*

--- a/DeviceAdapters/IDS_uEye/IDS_uEye.cpp
+++ b/DeviceAdapters/IDS_uEye/IDS_uEye.cpp
@@ -1350,15 +1350,7 @@ int CIDS_uEye::InsertImage()
    unsigned int h = GetImageHeight();
    unsigned int b = GetImageBytesPerPixel();
 
-   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // don't process this same image again...
-      return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-   } else
-      return ret;
+   return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
 }
 
 /*

--- a/DeviceAdapters/IIDC/MMIIDCCamera.cpp
+++ b/DeviceAdapters/IIDC/MMIIDCCamera.cpp
@@ -2101,19 +2101,6 @@ MMIIDCCamera::ProcessedSequenceCallback(const void* pixels,
    int err;
    err = GetCoreCallback()->InsertImage(this, bytes, uWidth, uHeight, uBytesPerPixel,
          serializedMD.c_str());
-   if (err == DEVICE_BUFFER_OVERFLOW)
-   {
-      if (!stopOnOverflow_)
-      {
-         GetCoreCallback()->ClearImageBuffer(this);
-         err = GetCoreCallback()->InsertImage(this, bytes, uWidth, uHeight, uBytesPerPixel,
-               serializedMD.c_str(), false);
-      }
-      else
-      {
-         BOOST_THROW_EXCEPTION(Error("Sequence buffer overflow"));
-      }
-   }
    if (err != DEVICE_OK)
       BOOST_THROW_EXCEPTION(Error("Unknown error (" +
                boost::lexical_cast<std::string>(err) +

--- a/DeviceAdapters/JAI/JAI.cpp
+++ b/DeviceAdapters/JAI/JAI.cpp
@@ -826,18 +826,6 @@ int JAICamera::PushImage(unsigned char* imgBuf)
 		img.Width(),
 		img.Height(),
 		img.Depth());
-
-	if (!stopOnOverflow && retCode == DEVICE_BUFFER_OVERFLOW)
-	{
-		// do not stop on overflow - just reset the buffer
-		GetCoreCallback()->ClearImageBuffer(this);
-		retCode = GetCoreCallback()->InsertImage(this,
-			imgBuf,
-			img.Width(),
-			img.Height(),
-			img.Depth());
-	}
-
 	return DEVICE_OK;
 }
 
@@ -978,30 +966,11 @@ void JAICamera::ClearPvBuffers()
 
 int JAICamera::InsertImage()
 {
-   int retCode = GetCoreCallback()->InsertImage(this,
+   return GetCoreCallback()->InsertImage(this,
          img.GetPixels(),
          img.Width(),
          img.Height(),
          img.Depth());
-
-   if (!stopOnOverflow)
-   {
-      if (retCode == DEVICE_BUFFER_OVERFLOW)
-      {
-         // do not stop on overflow - just reset the buffer
-         GetCoreCallback()->ClearImageBuffer(this);
-         retCode = GetCoreCallback()->InsertImage(this,
-            img.GetPixels(),
-            img.Width(),
-            img.Height(),
-            img.Depth());
-         return DEVICE_OK;
-      }
-      else
-         return retCode;
-   }
-
-   return retCode;
 }
 
 /**

--- a/DeviceAdapters/MatrixVision/mvIMPACT_Acquire_Device.cpp
+++ b/DeviceAdapters/MatrixVision/mvIMPACT_Acquire_Device.cpp
@@ -977,15 +977,7 @@ int mvIMPACT_Acquire_Device::InsertImage( void )
    const unsigned int w = GetImageWidth();
    const unsigned int h = GetImageHeight();
    const unsigned int b = GetImageBytesPerPixel();
-   int result = GetCoreCallback()->InsertImage( this, pI, w, h, b, md.Serialize().c_str(), false );
-   if( !stopOnOverflow_ && ( result == DEVICE_BUFFER_OVERFLOW ) )
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer( this );
-      // don't process this same image again...
-      result = GetCoreCallback()->InsertImage( this, pI, w, h, b, md.Serialize().c_str(), false );
-   }
-   return result;
+   return GetCoreCallback()->InsertImage( this, pI, w, h, b, md.Serialize().c_str(), false );
 }
 
 //-----------------------------------------------------------------------------

--- a/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.cpp
+++ b/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.cpp
@@ -1573,15 +1573,7 @@ int CMightex_BUF_USBCCDCamera::InsertImage()
    unsigned int h = GetImageHeight();
    unsigned int b = GetImageBytesPerPixel();
 
-   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // don't process this same image again...
-      return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-   } else
-      return ret;
+   return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
 }
 
 /*

--- a/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.cpp
+++ b/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.cpp
@@ -1191,15 +1191,7 @@ int CMightex_SB_Camera::InsertImage()
    unsigned int h = GetImageHeight();
    unsigned int b = GetImageBytesPerPixel();
 
-   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // don't process this same image again...
-      return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-   } else
-      return ret;
+   return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
 }
 
 /*

--- a/DeviceAdapters/Motic/MoticCamera.cpp
+++ b/DeviceAdapters/Motic/MoticCamera.cpp
@@ -843,24 +843,8 @@ int CMoticCamera::InsertImage()
      return DEVICE_ERR;
    }
 
-   int ret = GetCoreCallback()->InsertImage(this, img, GetImageWidth(), 
+   return GetCoreCallback()->InsertImage(this, img, GetImageWidth(), 
      GetImageHeight(), GetImageBytesPerPixel());
-
-   if (!stopOnOverflow && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-     // do not stop on overflow - just reset the buffer
-     GetCoreCallback()->ClearImageBuffer(this);
-     return(GetCoreCallback()->InsertImage(this, img, 
-       GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel()));
-   } 
-   else
-   {
-     return ret;
-   }
-#ifdef _LOG_OUT_
-   OutputDebugString("InsertImage OK");
-#endif
-   return DEVICE_OK;
 }
 
 

--- a/DeviceAdapters/NikonKs/NikonKsCam.cpp
+++ b/DeviceAdapters/NikonKs/NikonKsCam.cpp
@@ -1203,25 +1203,11 @@ int NikonKsCam::InsertImage()
 
     MMThreadGuard g(imgPixelsLock_);
 
-    int ret = GetCoreCallback()->InsertImage(this, img_.GetPixels(),
+    return GetCoreCallback()->InsertImage(this, img_.GetPixels(),
               img_.Width(),
               img_.Height(),
               img_.Depth(),
               md.Serialize().c_str());
-
-    if (!stopOnOverFlow_ && ret == DEVICE_BUFFER_OVERFLOW)
-    {
-        // do not stop on overflow, reset the buffer and insert the same image again
-        GetCoreCallback()->ClearImageBuffer(this);
-        return GetCoreCallback()->InsertImage(this, img_.GetPixels(),
-                                              img_.Width(),
-                                              img_.Height(),
-                                              img_.Depth(),
-                                              md.Serialize().c_str());
-    } else
-        return ret;
-
-    return DEVICE_OK;
 }
 
 /*

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
@@ -835,16 +835,7 @@ int COpenCVgrabber::InsertImage()
    unsigned int h = GetImageHeight();
    unsigned int b = GetImageBytesPerPixel();
 
-   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-   if (!stopOnOverFlow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // don't process this same image again...
-	  return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-	  //return GetCoreCallback()->InsertImage(this, pI, w, h, b);
-   } else
-      return ret;
+   return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
 }
 
 /*

--- a/DeviceAdapters/PCO_Generic/MicroManager.cpp
+++ b/DeviceAdapters/PCO_Generic/MicroManager.cpp
@@ -2489,12 +2489,6 @@ int CPCOCam::InsertImage()
 
       m_iNumImagesInserted++;
       ret = pcore->InsertImage(this, img, m_iWidth, m_iHeight, m_iBytesPerPixel);
-      if(!m_bStopOnOverflow && ret == DEVICE_BUFFER_OVERFLOW)
-      {
-        // do not stop on overflow - just reset the buffer
-        pcore->ClearImageBuffer(this);
-        return pcore->InsertImage(this, img, m_iWidth, m_iHeight, m_iBytesPerPixel);
-      }
     }
   }
   else                                 // Else path for Unit-Tester

--- a/DeviceAdapters/PICAM/PICAMUniversal.cpp
+++ b/DeviceAdapters/PICAM/PICAMUniversal.cpp
@@ -2553,28 +2553,14 @@ int Universal::PushImage(const unsigned char* pixBuffer, Metadata* pMd )
 {
    START_METHOD("Universal::PushImage");
 
-   int nRet = DEVICE_ERR;
    MM::Core* pCore = GetCoreCallback();
    // This method inserts a new image into the circular buffer (residing in MMCore)
-   nRet = pCore->InsertImage(this,
+   return pCore->InsertImage(this,
          pixBuffer,
          GetImageWidth(),
          GetImageHeight(),
          GetImageBytesPerPixel(),
          pMd->Serialize().c_str());
-   if (!stopOnOverflow_ && nRet == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      pCore->ClearImageBuffer(this);
-      nRet = pCore->InsertImage(this,
-            pixBuffer,
-            GetImageWidth(),
-            GetImageHeight(),
-            GetImageBytesPerPixel(),
-            pMd->Serialize().c_str());
-   }
-
-   return nRet;
 }
 
 

--- a/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
@@ -4156,21 +4156,10 @@ int Universal::PushImageToMmCore(const unsigned char* pPixBuffer, Metadata* pMd 
 {
     START_METHOD("Universal::PushImageToMmCore");
 
-    int nRet = DEVICE_ERR;
     MM::Core* pCore = GetCoreCallback();
     // This method inserts a new image into the circular buffer (residing in MMCore)
-    nRet = pCore->InsertImage(this, pPixBuffer, GetImageWidth(), GetImageHeight(),
+    return pCore->InsertImage(this, pPixBuffer, GetImageWidth(), GetImageHeight(),
         GetImageBytesPerPixel(), pMd->Serialize().c_str());
-
-    if (!stopOnOverflow_ && nRet == DEVICE_BUFFER_OVERFLOW)
-    {
-        // do not stop on overflow - just reset the buffer
-        pCore->ClearImageBuffer(this);
-        nRet = pCore->InsertImage(this, pPixBuffer, GetImageWidth(), GetImageHeight(),
-            GetImageBytesPerPixel(), pMd->Serialize().c_str(), false);
-    }
-
-    return nRet;
 }
 
 int Universal::ProcessNotification( const NotificationEntry& entry )

--- a/DeviceAdapters/Piper/CameraAdapter.cpp
+++ b/DeviceAdapters/Piper/CameraAdapter.cpp
@@ -2123,25 +2123,7 @@ void CCameraAdapter::Capture()
          );
       if (ret != DEVICE_OK)
       {
-         // Micro-Manager can't keep up
-         if (!m_bStopOnOverflow && ret == DEVICE_BUFFER_OVERFLOW)
-         {
-            // do not stop on overflow - just reset the buffer
-            GetCoreCallback()->ClearImageBuffer(this);
-            piulLogMessage( m_sMyName.c_str(), s_unLogMethodCallTrace, "MM can't keep up, clearing its buffer" );
-            ret = GetCoreCallback()->InsertImage
-                  (
-                     this,
-                     punBuffer,
-                     m_nStreamWidth,
-                     m_nStreamHeight,
-                     m_nStreamPixelBytes
-                  );
-            if (ret != DEVICE_OK)
-            {
-               m_bStream = FALSE;
-            }
-         }
+         m_bStream = FALSE;
       }
       //oCS.Unlock();
 

--- a/DeviceAdapters/Pixelink/Pixelink.cpp
+++ b/DeviceAdapters/Pixelink/Pixelink.cpp
@@ -908,26 +908,7 @@ int Pixelink::InsertImage()
 	md.put(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(imageCounter_));
 	md.put("FrameCounter", frameCounter);
 
-
-
-
-	//GetCoreCallback()->ClearImageBuffer(this);
-	ret = GetCoreCallback()->InsertImage(this, pPixel, w, h, b, md.Serialize().c_str(), false);
-
-	if (ret == DEVICE_BUFFER_OVERFLOW)
-	{
-		// do not stop on overflow - just reset the buffer
-		GetCoreCallback()->ClearImageBuffer(this);
-		GetCoreCallback()->InsertImage(this, pPixel, w, h, b, md.Serialize().c_str(), false);
-		return DEVICE_OK;
-	}
-
-
-	
-	//frameBuffer.clear();
-
-
-	return ret;
+	return GetCoreCallback()->InsertImage(this, pPixel, w, h, b, md.Serialize().c_str(), false);
 }
 
 

--- a/DeviceAdapters/PlayerOne/POACamera.cpp
+++ b/DeviceAdapters/PlayerOne/POACamera.cpp
@@ -1397,17 +1397,7 @@ int POACamera::InsertImage()
     unsigned int h = GetImageHeight();
     unsigned int b = GetImageBytesPerPixel();
 
-    int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-
-    if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-    {
-        // do not stop on overflow - just reset the buffer
-        GetCoreCallback()->ClearImageBuffer(this);
-        // don't process this same image again...
-        return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-    }
-    else
-        return ret;
+    return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
 }
 
 /*

--- a/DeviceAdapters/PointGrey/PointGrey.cpp
+++ b/DeviceAdapters/PointGrey/PointGrey.cpp
@@ -1349,16 +1349,7 @@ int PointGrey::InsertImage(Image* pImg)
    {
       pData = RGBToBGRA(pImg->GetData());
    }
-   ret = GetCoreCallback()->InsertImage(this, pData, w, h, b, md.Serialize().c_str(), false);
-	if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-	{
-		// do not stop on overflow - just reset the buffer
-		GetCoreCallback()->ClearImageBuffer(this);
-		GetCoreCallback()->InsertImage(this, pData, w, h, b, md.Serialize().c_str(), false);
-      return DEVICE_OK;
-	} 
-
-   return ret;
+   return GetCoreCallback()->InsertImage(this, pData, w, h, b, md.Serialize().c_str(), false);
 }
 
 

--- a/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
@@ -2140,19 +2140,6 @@ int Universal::PushImage()
       GetImageBytesPerPixel(),
       &md);
 
-   if (!stopOnOverflow_ && nRet == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      nRet = GetCoreCallback()->InsertMultiChannel(this,
-         (unsigned char*) pixBuffer,
-         1,
-         GetImageWidth(),
-         GetImageHeight(),
-         GetImageBytesPerPixel(),
-         &md);
-   }
-
    ostringstream txtEnd;
    txtEnd << name_ << " exited PushImage()";
    LogMessage(txtEnd.str(), true);

--- a/DeviceAdapters/PyDevice/PyCamera.cpp
+++ b/DeviceAdapters/PyDevice/PyCamera.cpp
@@ -237,16 +237,7 @@ int CPyCamera::InsertImage()
     if (!buffer)
         return DEVICE_ERR;
 
-    int ret = GetCoreCallback()->InsertImage(this, buffer, GetImageWidth(),
+    return GetCoreCallback()->InsertImage(this, buffer, GetImageWidth(),
                                              GetImageHeight(), GetImageBytesPerPixel(),
                                              md.Serialize().c_str());
-    if (!isStopOnOverflow() && ret == DEVICE_BUFFER_OVERFLOW)
-    {
-        // do not stop on overflow - just reset the buffer
-        GetCoreCallback()->ClearImageBuffer(this);
-        return GetCoreCallback()->InsertImage(this, buffer, GetImageWidth(),
-                                              GetImageHeight(), GetImageBytesPerPixel(),
-                                              md.Serialize().c_str());
-    }
-    return ret;
 }

--- a/DeviceAdapters/QCam/QICamera.cpp
+++ b/DeviceAdapters/QCam/QICamera.cpp
@@ -4507,25 +4507,10 @@ int QICamera::InsertImage(int iFrameBuff)
 
       ret = GetCoreCallback()->InsertImage(this, (unsigned char*) m_colorBuffer.GetPixelsRW(), 
          m_colorBuffer.Width(), m_colorBuffer.Height(), m_colorBuffer.Depth());
-
-      if (!isStopOnOverflow() && ret == DEVICE_BUFFER_OVERFLOW) {
-         // do not stop on overflow - just reset the buffer
-         GetCoreCallback()->ClearImageBuffer(this);
-         ret = GetCoreCallback()->InsertImage(this, (unsigned char*) m_colorBuffer.GetPixelsRW(), 
-            m_colorBuffer.Width(), m_colorBuffer.Height(), m_colorBuffer.Depth());
-      }
-
    } else {
       int bytes = (pFrame->bits > 8) ? 2 : 1;
       ret = GetCoreCallback()->InsertImage(this, (unsigned char*) pFrame->pBuffer, 
          pFrame->width, pFrame->height, bytes);
-
-      if (!isStopOnOverflow() && ret == DEVICE_BUFFER_OVERFLOW) {
-         // do not stop on overflow - just reset the buffer
-         GetCoreCallback()->ClearImageBuffer(this);
-         ret = GetCoreCallback()->InsertImage(this, (unsigned char*) pFrame->pBuffer, 
-            pFrame->width, pFrame->height, bytes);
-      }
    }
    return ret;
 }

--- a/DeviceAdapters/QSI/QSICameraAdapter.cpp
+++ b/DeviceAdapters/QSI/QSICameraAdapter.cpp
@@ -474,7 +474,6 @@ int QSICameraAdapter::InsertImage()
   char label[MM::MaxStrLength];
   Metadata metadata;
   const unsigned char * pImageBuffer;
-  int response;
   const char * pSerializedMetadata;
 
   // Assemble metadata
@@ -488,15 +487,7 @@ int QSICameraAdapter::InsertImage()
   pImageBuffer = GetImageBuffer();
 
   // Insert received image into MMCore's circular buffer
-  response = GetCoreCallback()->InsertImage( this, pImageBuffer, m_imageNumX, m_imageNumY, QSI_IMAGE_BYTES_PER_PIXEL, pSerializedMetadata );
-
-  if( !isStopOnOverflow() && response == DEVICE_BUFFER_OVERFLOW )
-  {
-    GetCoreCallback()->ClearImageBuffer( this );
-    return GetCoreCallback()->InsertImage( this, pImageBuffer, m_imageNumX, m_imageNumY, QSI_IMAGE_BYTES_PER_PIXEL, pSerializedMetadata, false );
-  }
-  else
-    return response;
+  return GetCoreCallback()->InsertImage( this, pImageBuffer, m_imageNumX, m_imageNumY, QSI_IMAGE_BYTES_PER_PIXEL, pSerializedMetadata );
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
@@ -5955,20 +5955,7 @@ int CRaptorEPIX::InsertImage()
    //int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b) ;//, &md);
    //int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
 
-   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-   	  if(fidSerial[UNITSOPENMAP] && gUseSerialLog[UNITSOPENMAP])
-			fprintf(fidSerial[UNITSOPENMAP],"*** Insert Image Buffer Overflow - Resetting ***\n");
-
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // don't process this same image again...
-      return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-   } else
-      return ret;
-
-
+   return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
 }
 
 /*

--- a/DeviceAdapters/Revealer/MMSCCam.cpp
+++ b/DeviceAdapters/Revealer/MMSCCam.cpp
@@ -668,15 +668,7 @@ int SCCamera::InsertImage()
 	const unsigned char* data = GetImageBuffer();
 
     auto coreCallback = GetCoreCallback();
-    auto rslt = GetCoreCallback()->InsertImage(this, data, width, height, bytePerPixel,1, md.Serialize().c_str());
-    if (!stopOnOverflow_ && rslt == DEVICE_BUFFER_OVERFLOW)
-    {  
-		// do not stop on overflow - just reset the buffer
-		GetCoreCallback()->ClearImageBuffer(this);
-		// don't process this same image again...
-		rslt = GetCoreCallback()->InsertImage(this, data, width, height, bytePerPixel, 1, md.Serialize().c_str(), false);
-	}
-    return rslt;
+    return GetCoreCallback()->InsertImage(this, data, width, height, bytePerPixel,1, md.Serialize().c_str());
 }
 
 int SCCamera::getNextFrame() {

--- a/DeviceAdapters/ScionCam/capture.cpp
+++ b/DeviceAdapters/ScionCam/capture.cpp
@@ -342,20 +342,8 @@ if (img == 0)
 	return DEVICE_ERR;
 	}
 
-int ret = GetCoreCallback()->InsertImage(this, img, GetImageWidth(), 
+return GetCoreCallback()->InsertImage(this, img, GetImageWidth(), 
 								GetImageHeight(), GetImageBytesPerPixel());
-
-if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-	{
-	// do not stop on overflow - just reset the buffer
-	GetCoreCallback()->ClearImageBuffer(this);
-	return(GetCoreCallback()->InsertImage(this, img, 
-				GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel()));
-	} 
-else
-	{
-	return ret;
-	}
 }
 
 

--- a/DeviceAdapters/Sensicam/Sensicam.cpp
+++ b/DeviceAdapters/Sensicam/Sensicam.cpp
@@ -849,17 +849,7 @@ int CSensicam::InsertImage()
    if (img == 0) 
       return ERR_TIMEOUT;
 
-   int ret = GetCoreCallback()->InsertImage(this, img, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
-
-
-
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      return GetCoreCallback()->InsertImage(this, img, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
-   } else
-      return ret;
+   return GetCoreCallback()->InsertImage(this, img, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
 }
 
 

--- a/DeviceAdapters/SequenceTester/SequenceTester.cpp
+++ b/DeviceAdapters/SequenceTester/SequenceTester.cpp
@@ -558,17 +558,8 @@ TesterCamera::SendSequence(bool finite, long count, bool stopOnOverflow)
 
       try
       {
-         int err;
-         err = core->InsertImage(this, bytes, width, height,
+         int err = core->InsertImage(this, bytes, width, height,
                bytesPerPixel, serializedMD.c_str());
-
-         if (!stopOnOverflow && err == DEVICE_BUFFER_OVERFLOW)
-         {
-            core->ClearImageBuffer(this);
-            err = core->InsertImage(this, bytes, width, height,
-                  bytesPerPixel, serializedMD.c_str(), false);
-         }
-
          if (err != DEVICE_OK)
          {
             bool stopped;

--- a/DeviceAdapters/SigmaKoki/Camera.cpp
+++ b/DeviceAdapters/SigmaKoki/Camera.cpp
@@ -968,20 +968,7 @@ int Camera::InsertImage()
 	unsigned int h = GetImageHeight();
 	unsigned int b = GetImageBytesPerPixel();
 	cout << "bytes per pixel    = " << b << endl;
-	int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-
-	if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-	{
-		// do not stop on overflow - just reset the buffer
-		GetCoreCallback()->ClearImageBuffer(this);
-		// don't process this same image again...
-		cout << "Stop On overflow   = " << stopOnOverflow_ << endl;
-		return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-	}
-	else
-	{
-		return ret;
-	}
+	return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
 }
 
 /*

--- a/DeviceAdapters/Spinnaker/SpinnakerCamera.cpp
+++ b/DeviceAdapters/Spinnaker/SpinnakerCamera.cpp
@@ -1654,20 +1654,10 @@ int SpinnakerCamera::MoveImageToCircularBuffer()
          unsigned int b = GetImageBytesPerPixel();
 
          int ret = GetCoreCallback()->InsertImage(this, imageData, w, h, b, md.Serialize().c_str());
-         if (!m_stopOnOverflow && ret == DEVICE_BUFFER_OVERFLOW)
-         {
-            // do not stop on overflow - just reset the buffer
-            GetCoreCallback()->ClearImageBuffer(this);
-            // don't process this same image again...
-            return GetCoreCallback()->InsertImage(this, imageData, w, h, b, md.Serialize().c_str(), false);
-         }
-         else
-         {
-            if (ip != nullptr)
-               ip->Release();
+         if (ip != nullptr)
+            ip->Release();
 
-            return ret;
-         }
+         return ret;
       }
       else
       {

--- a/DeviceAdapters/TISCam/TIScamera.cpp
+++ b/DeviceAdapters/TISCam/TIScamera.cpp
@@ -2206,21 +2206,7 @@ int CTIScamera::PushImage()
    unsigned int h = GetImageHeight();
    unsigned int b = GetImageBytesPerPixel();
 
-   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // don't process this same image again...
-      return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-   } else
-      return ret;
-
-
-
-
-
-
+   return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
 }
 
 

--- a/DeviceAdapters/TSI/TSI3Cam.cpp
+++ b/DeviceAdapters/TSI/TSI3Cam.cpp
@@ -841,32 +841,12 @@ int Tsi3Cam::InsertImage()
 	this->GetLabel(label);
 	Metadata md;
 
-   int retCode = GetCoreCallback()->InsertImage(this,
+   return GetCoreCallback()->InsertImage(this,
          img.GetPixels(),
          img.Width(),
          img.Height(),
          img.Depth(),
 	   md.Serialize().c_str());
-
-   if (!stopOnOverflow)
-   {
-      if (retCode == DEVICE_BUFFER_OVERFLOW)
-      {
-         // do not stop on overflow - just reset the buffer
-         GetCoreCallback()->ClearImageBuffer(this);
-         retCode = GetCoreCallback()->InsertImage(this,
-            img.GetPixels(),
-            img.Width(),
-            img.Height(),
-            img.Depth(),
-			 md.Serialize().c_str());
-         return DEVICE_OK;
-      }
-      else
-         return retCode;
-   }
-
-   return retCode;
 }
 
 bool Tsi3Cam::StopCamera()

--- a/DeviceAdapters/TSI/TSICam.cpp
+++ b/DeviceAdapters/TSI/TSICam.cpp
@@ -854,17 +854,6 @@ int TsiCam::PushImage(unsigned char* imgBuf)
          colorImg.Width(),
          colorImg.Height(),
          colorImg.Depth());
-
-      if (!stopOnOverflow && retCode == DEVICE_BUFFER_OVERFLOW)
-      {
-         // do not stop on overflow - just reset the buffer
-         GetCoreCallback()->ClearImageBuffer(this);
-         retCode = GetCoreCallback()->InsertImage(this,
-            imgBuf,
-            colorImg.Width(),
-            colorImg.Height(),
-            colorImg.Depth());
-      }
    }
    else
    {
@@ -873,17 +862,6 @@ int TsiCam::PushImage(unsigned char* imgBuf)
          img.Width(),
          img.Height(),
          img.Depth());
-
-      if (!stopOnOverflow && retCode == DEVICE_BUFFER_OVERFLOW)
-      {
-         // do not stop on overflow - just reset the buffer
-         GetCoreCallback()->ClearImageBuffer(this);
-         retCode = GetCoreCallback()->InsertImage(this,
-            imgBuf,
-            img.Width(),
-            img.Height(),
-            img.Depth());
-      }
    }
 
    return DEVICE_OK;
@@ -891,30 +869,11 @@ int TsiCam::PushImage(unsigned char* imgBuf)
 
 int TsiCam::InsertImage()
 {
-   int retCode = GetCoreCallback()->InsertImage(this,
+   return GetCoreCallback()->InsertImage(this,
          img.GetPixels(),
          img.Width(),
          img.Height(),
          img.Depth());
-
-   if (!stopOnOverflow)
-   {
-      if (retCode == DEVICE_BUFFER_OVERFLOW)
-      {
-         // do not stop on overflow - just reset the buffer
-         GetCoreCallback()->ClearImageBuffer(this);
-         retCode = GetCoreCallback()->InsertImage(this,
-            img.GetPixels(),
-            img.Width(),
-            img.Height(),
-            img.Depth());
-         return DEVICE_OK;
-      }
-      else
-         return retCode;
-   }
-
-   return retCode;
 }
 
 bool TsiCam::GetAttrValue(TSI_PARAM_ID ParamID, TSI_ATTR_ID AttrID, void *Data, uint32_t DataLength) 

--- a/DeviceAdapters/TUCam/MMTUCam.cpp
+++ b/DeviceAdapters/TUCam/MMTUCam.cpp
@@ -2883,16 +2883,7 @@ int CMMTUCam::InsertImage()
     unsigned int h = GetImageHeight();
     unsigned int b = GetImageBytesPerPixel();
 
-    int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
-    
-    if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-    {
-        // do not stop on overflow - just reset the buffer
-        GetCoreCallback()->ClearImageBuffer(this);
-        // don't process this same image again...
-        return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-    } else
-        return ret;
+    return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str());
 }
 
 /*

--- a/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.cpp
+++ b/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.cpp
@@ -620,23 +620,11 @@ int ThorlabsUSBCam::InsertImage()
 
    MMThreadGuard g(imgPixelsLock_);
 
-   int ret = GetCoreCallback()->InsertImage(this, img_.GetPixels(),
+   return GetCoreCallback()->InsertImage(this, img_.GetPixels(),
                                                   img_.Width(),
                                                   img_.Height(), 
                                                   img_.Depth(), 
                                                   md.Serialize().c_str());
-
-   if (!stopOnOverFlow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow, reset the buffer and insert the same image again
-      GetCoreCallback()->ClearImageBuffer(this);
-      return GetCoreCallback()->InsertImage(this, img_.GetPixels(),
-                                                  img_.Width(),
-                                                  img_.Height(), 
-                                                  img_.Depth(), 
-                                                  md.Serialize().c_str());
-   } else
-      return ret;
 }
 
 /*

--- a/DeviceAdapters/TwainCamera/TwainCamera.cpp
+++ b/DeviceAdapters/TwainCamera/TwainCamera.cpp
@@ -1268,15 +1268,7 @@ int TwainCamera::PushImage()
    GetImageBuffer(); // this effectively copies images to rawBuffer_
 
    // insert all three channels at once
-   int ret = GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // repeat the insert
-      return GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
-   } else
-      return ret;
+   return GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
 }
 int TwainCamera::StopSequenceAcquisition()
 {
@@ -1302,16 +1294,5 @@ int TwainCamera::ThreadRun()
 		return DEVICE_ERR;
 
 	// insert all three channels at once
-   ret = GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // repeat the insert
-      return GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
-   } else
-      return ret;
-
-
-
+   return GetCoreCallback()->InsertImage(this, rawBuffer_, GetImageWidth(), GetImageHeight(), GetImageBytesPerPixel());
 }

--- a/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
+++ b/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
@@ -1050,15 +1050,7 @@ int BitFlowCamera::LiveThread::svc()
 			  cam_->GetImageHeight(),
 			  cam_->GetImageBytesPerPixel(),
 			  md.Serialize().c_str());
-		  if (ret == DEVICE_BUFFER_OVERFLOW) {
-			  cam_->GetCoreCallback()->ClearImageBuffer(cam_);
-			  cam_->GetCoreCallback()->InsertImage(cam_, cam_->GetImageBuffer(i),
-				  cam_->GetImageWidth(),
-				  cam_->GetImageHeight(),
-				  cam_->GetImageBytesPerPixel(),
-				  md.Serialize().c_str());
-		  }
-		  else if (ret != DEVICE_OK) {
+		  if (ret != DEVICE_OK) {
 			  cam_->GetCoreCallback()->LogMessage(cam_, "BitFlow thread: error inserting image", false);
 			  break;
 		  }

--- a/DeviceAdapters/UniversalMMHubUsb/ummhUsb.cpp
+++ b/DeviceAdapters/UniversalMMHubUsb/ummhUsb.cpp
@@ -3764,18 +3764,7 @@ int UmmhCamera::InsertImage()
    unsigned int h = GetImageHeight();
    unsigned int b = GetImageBytesPerPixel();
 
-   int ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, nComponents_, md.Serialize().c_str());
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-   {
-      // do not stop on overflow - just reset the buffer
-      GetCoreCallback()->ClearImageBuffer(this);
-      // don't process this same image again...
-      return GetCoreCallback()->InsertImage(this, pI, w, h, b, nComponents_, md.Serialize().c_str(), false);
-   }
-   else
-   {
-      return ret;
-   }
+   return GetCoreCallback()->InsertImage(this, pI, w, h, b, nComponents_, md.Serialize().c_str());
 }
 
 /*

--- a/DeviceAdapters/Ximea/XIMEACamera.cpp
+++ b/DeviceAdapters/Ximea/XIMEACamera.cpp
@@ -789,8 +789,6 @@ int XimeaCamera::StartSequenceAcquisition(long numImages, double interval_ms, bo
 */
 int XimeaCamera::InsertImage()
 {
-	int ret = DEVICE_OK;
-
 	MM::MMTime timeStamp = readoutStartTime_;
 	char label[MM::MaxStrLength];
 	this->GetLabel(label);
@@ -816,19 +814,7 @@ int XimeaCamera::InsertImage()
 	unsigned int h = GetImageHeight();
 	unsigned int b = GetImageBytesPerPixel();
 
-	ret = GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-	if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW)
-	{
-		// do not stop on overflow - just reset the buffer
-		GetCoreCallback()->ClearImageBuffer(this);
-		// don't process this same image again...
-		// return GetCoreCallback()->InsertImage(this, pI, w, h, b, &md, false);
-		return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
-	}
-	else
-	{
-		return ret;
-	}
+	return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize().c_str(), false);
 }
 
 /***********************************************************************

--- a/DeviceAdapters/ZWO/MyASICam2.cpp
+++ b/DeviceAdapters/ZWO/MyASICam2.cpp
@@ -1157,16 +1157,7 @@ int CMyASICam::InsertImage()
 
 	const unsigned char* pI;
 	pI = GetImageBuffer();
-	int ret = 0;
-	ret  = GetCoreCallback()->InsertImage(this, pI, iROIWidth, iROIHeight, iPixBytes, md.Serialize().c_str());
-	if (ret == DEVICE_BUFFER_OVERFLOW)//缓冲区满了要清空, 否则不能继续插入图像而卡住
-	{
-		// do not stop on overflow - just reset the buffer
-		GetCoreCallback()->ClearImageBuffer(this);
-		// don't process this same image again...
-		return GetCoreCallback()->InsertImage(this, pI, iROIWidth, iROIHeight, iPixBytes, md.Serialize().c_str(), false);
-	} else
-		return ret;
+	return GetCoreCallback()->InsertImage(this, pI, iROIWidth, iROIHeight, iPixBytes, md.Serialize().c_str());
 }
 
 

--- a/DeviceAdapters/dc1394/dc1394.cpp
+++ b/DeviceAdapters/dc1394/dc1394.cpp
@@ -2145,13 +2145,6 @@ int Cdc1394::PushImage(dc1394video_frame_t *myframe)
 
    // insert image into the circular MMCore buffer
    int ret =  GetCoreCallback()->InsertImage(this, buf, width_, height_, GetBytesPerPixel());
-
-   if (!stopOnOverflow_ && ret == DEVICE_BUFFER_OVERFLOW) {
-      // do not stop on overflow - just reset the buffer                     
-      GetCoreCallback()->ClearImageBuffer(this);                             
-      ret =  GetCoreCallback()->InsertImage(this, buf, width_, height_, GetBytesPerPixel());
-   }
-
    free(buf);
    return ret;
 }

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -271,11 +271,6 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
    }
 }
 
-void CoreCallback::ClearImageBuffer(const MM::Device* /*caller*/)
-{
-   core_->cbuf_->Clear();
-}
-
 bool CoreCallback::InitializeImageBuffer(unsigned channels, unsigned slices,
       unsigned int w, unsigned int h, unsigned int pixDepth)
 {

--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -86,7 +86,6 @@ public:
    // continuous acquisition support
    int InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess = true);
    int InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const char* serializedMetadata, const bool doProcess = true);
-   /*Deprecated*/ void ClearImageBuffer(const MM::Device* caller);
    bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth);
 
    int AcqFinished(const MM::Device* caller, int statusCode);

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1532,18 +1532,9 @@ protected:
       this->GetLabel(label);
       Metadata md;
       md.put(MM::g_Keyword_Metadata_CameraLabel, label);
-      int ret = GetCoreCallback()->InsertImage(this, GetImageBuffer(), GetImageWidth(),
+      return GetCoreCallback()->InsertImage(this, GetImageBuffer(), GetImageWidth(),
          GetImageHeight(), GetImageBytesPerPixel(),
          md.Serialize().c_str());
-      if (!stopWhenCBOverflows_ && ret == DEVICE_BUFFER_OVERFLOW)
-      {
-         // do not stop on overflow - just reset the buffer
-         GetCoreCallback()->ClearImageBuffer(this);
-         return GetCoreCallback()->InsertImage(this, GetImageBuffer(), GetImageWidth(),
-            GetImageHeight(), GetImageBytesPerPixel(),
-            md.Serialize().c_str());
-      } else
-         return ret;
    }
 
    virtual double GetIntervalMs() {return thd_->GetIntervalMs();}

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1588,19 +1588,12 @@ namespace MM {
        *
        * doProcess: must be true, except for the case mentioned below
        *
-       * Legacy note: previously, cameras were required to perform the
-       * following special handling when InsertImage() returns
-       * DEVICE_BUFFER_OVERFLOW. However, InsertImage() no longer ever
-       * returns that particular error when stopOnOverflow = false. So
+       * Legacy note: Previously, cameras were required to perform special
+       * handling when InsertImage() returns DEVICE_BUFFER_OVERFLOW and
+       * stopOnOverflow == false. However, InsertImage() no longer ever
+       * returns that particular error when stopOnOverflow == false. So
        * cameras should always just stop the acquisition if InsertImage()
        * returns any error.
-       *
-       * If the sequence acquisition was started with stopOnOverflow = false
-       * _and_ the return value of InsertImage() is DEVICE_BUFFER_OVERFLOW,
-       * ClearImageBuffer() should be called and the call to InsertImage()
-       * should then be repeated with doProcess set to false. Otherwise, if the
-       * return value is not DEVICE_OK, or the second call failed (with any
-       * code), acquisition should stop.
        */
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const char* serializedMetadata, const bool doProcess = true) = 0;
 
@@ -1611,7 +1604,6 @@ namespace MM {
        */
       virtual int InsertImage(const Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata = nullptr, const bool doProcess = true) = 0;
 
-      MM_DEPRECATED(virtual void ClearImageBuffer(const Device* caller)) = 0;
       virtual bool InitializeImageBuffer(unsigned channels, unsigned slices, unsigned int w, unsigned int h, unsigned int pixDepth) = 0;
 
       // These functions violate the separation between device adapters and


### PR DESCRIPTION
Closes #640.

- **Remove "live" acquisition clear-on-overflow**

The special handling of `DEVICE_BUFFER_OVERFLOW` that is no longer necessary because of #588 is removed from all cameras.

- **Remove ClearImageBuffer() from Core callback**

And `ClearImageBuffer()` (deprecated in #588) is completely removed.