### PR TITLE
Check for null serialized metadata from camera

### DIFF
--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -218,7 +218,10 @@ CoreCallback::AddCameraMetadata(const MM::Device* caller, const Metadata* pMd)
 int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess)
 {
    Metadata origMd;
-   origMd.Restore(serializedMetadata);
+   if (serializedMetadata)
+   {
+      origMd.Restore(serializedMetadata);
+   }
 
    try 
    {
@@ -246,7 +249,10 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
 int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, unsigned nComponents, const char* serializedMetadata, const bool doProcess)
 {
    Metadata origMd;
-   origMd.Restore(serializedMetadata);
+   if (serializedMetadata)
+   {
+      origMd.Restore(serializedMetadata);
+   }
 
    try 
    {


### PR DESCRIPTION
In #710 (0734eec77f50396a10ecd1a97045f48885edf72b) I changed the signature of one of the two overloads of `InsertImage()` from

```cpp
virtual int InsertImage(
    const Device* caller,
    const unsigned char* buf,
    unsigned width,
    unsigned height,
    unsigned byteDepth,
    const char* serializedMetadata,
    const bool doProcess = true) = 0;
```

to

```cpp
virtual int InsertImage(
    const Device* caller,
    const unsigned char* buf,
    unsigned width,
    unsigned height,
    unsigned byteDepth,
    const char* serializedMetadata = nullptr,
    const bool doProcess = true) = 0;
```

(added nullptr default argument to `serializedMetadata`).

This was to support existing cameras that were calling the deleted overload

```cpp
MM_DEPRECATED(
virtual int InsertImage(
    const Device* caller,
    const unsigned char* buf,
    unsigned width,
    unsigned height,
    unsigned byteDepth,
    const Metadata* md = 0,
    const bool doProcess = true)) = 0;
```

without passing a non-null `md`.

But I forgot to ensure that the called implementations in `CoreCallback` is checking for `nullptr` in this case (actually forgot to include the relevant commit). So here is a fix.