### PR TITLE
scope trigger-mm-test-adapters workflow app key to different repo

### DIFF
--- a/.github/workflows/trigger-mm-test-adapters.yml
+++ b/.github/workflows/trigger-mm-test-adapters.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           app-id: ${{ secrets.MM_PR_BOT_APP_ID }}
           private-key: ${{ secrets.MM_PR_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            mm-test-adapters
 
       - name: Send repository_dispatch to mm-test-adapters
         uses: actions/github-script@v7


### PR DESCRIPTION
another fix to #724 and #723 