### PR TITLE
MMDevice/MMCore: add Meson dependency override

### DIFF
--- a/MMCore/meson.build
+++ b/MMCore/meson.build
@@ -36,7 +36,7 @@ mmdevice_proj = subproject(
         'tests': tests_option,
     },
 )
-mmdevice_dep = mmdevice_proj.get_variable('mmdevice')
+mmdevice_dep = mmdevice_proj.get_variable('mmdevice_dep')
 
 mmcore_sources = files(
     'CircularBuffer.cpp',
@@ -117,11 +117,12 @@ mmcore_lib = static_library(
 
 subdir('unittest')
 
-mmcore = declare_dependency(
+mmcore_dep = declare_dependency(
     include_directories: mmcore_include_dir,
     link_with: mmcore_lib,
     dependencies: mmdevice_dep,
 )
+meson.override_dependency('mmcore', mmcore_dep)
 
 # For providing include dir to SWIG when using this project as a subproject
 swig_include_dirs = mmdevice_proj.get_variable('swig_include_dirs') + [

--- a/MMDevice/meson.build
+++ b/MMDevice/meson.build
@@ -60,11 +60,12 @@ mmdevice_lib = static_library(
 
 subdir('unittest')
 
-mmdevice = declare_dependency(
+mmdevice_dep = declare_dependency(
     compile_args: build_mode_args,
     include_directories: mmdevice_include_dir,
     link_with: mmdevice_lib,
 )
+meson.override_dependency('mmdevice', mmdevice_dep)
 
 # For providing include dir to SWIG when using this project as a subproject
 swig_include_dirs = [meson.current_source_dir()]


### PR DESCRIPTION
This helps with using these as dependencies (in particular, mmdevice as a dependency for a device adapter).