### PR TITLE
DemoCamera: improve timing on Windows in Sequence mode. 

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.vcxproj
+++ b/DeviceAdapters/DemoCamera/DemoCamera.vcxproj
@@ -67,6 +67,7 @@
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalDependencies>Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -89,6 +90,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalDependencies>Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Use timeBeginPeriod(1) to improve timing of Sleep call. Links agains Winmm.dll.