### PR TITLE
Reduce Boost usage in SequenceTester

### DIFF
--- a/DeviceAdapters/SequenceTester/InterDevice.cpp
+++ b/DeviceAdapters/SequenceTester/InterDevice.cpp
@@ -35,7 +35,7 @@ InterDevice::GetLogger()
 EdgeTriggerSignal*
 InterDevice::GetEdgeTriggerSource(const std::string& port)
 {
-   boost::unordered_map<std::string, EdgeTriggerSignal*>::const_iterator
+   std::unordered_map<std::string, EdgeTriggerSignal*>::const_iterator
       found = edgeTriggersSources_.find(port);
    if (found == edgeTriggersSources_.end())
       return 0;

--- a/DeviceAdapters/SequenceTester/InterDevice.h
+++ b/DeviceAdapters/SequenceTester/InterDevice.h
@@ -25,9 +25,9 @@
 
 #include "LoggedSetting.h"
 
-#include <boost/enable_shared_from_this.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
+
+#include <memory>
 #include <string>
 
 class SettingLogger;
@@ -37,19 +37,19 @@ class TesterHub;
 // Common mixin interface for inter-device communication. Provides an interface
 // for communication among devices belonging to the same hub, orthogonal to the
 // Micro-Manager device interface. This way, we can use
-// boost::shared_ptr<InterDevice> to reference any peer device.
-class InterDevice : public boost::enable_shared_from_this<InterDevice>
+// std::shared_ptr<InterDevice> to reference any peer device.
+class InterDevice : public std::enable_shared_from_this<InterDevice>
 {
 public:
-   typedef boost::shared_ptr<InterDevice> Ptr;
+   typedef std::shared_ptr<InterDevice> Ptr;
 
    InterDevice(const std::string& name) : name_(name) {}
    virtual ~InterDevice() {}
-   virtual void SetHub(boost::shared_ptr<TesterHub> hub) { hub_ = hub; }
+   virtual void SetHub(std::shared_ptr<TesterHub> hub) { hub_ = hub; }
 
    virtual std::string GetDeviceName() const { return name_; }
-   virtual boost::shared_ptr<TesterHub> GetHub() { return hub_; }
-   virtual boost::shared_ptr<const TesterHub> GetHub() const { return hub_; }
+   virtual std::shared_ptr<TesterHub> GetHub() { return hub_; }
+   virtual std::shared_ptr<const TesterHub> GetHub() const { return hub_; }
    virtual SettingLogger* GetLogger();
    virtual CountDownSetting::Ptr GetBusySetting() = 0;
 
@@ -61,6 +61,6 @@ protected:
 
 private:
    const std::string name_;
-   boost::shared_ptr<TesterHub> hub_;
+   std::shared_ptr<TesterHub> hub_;
    boost::unordered_map<std::string, EdgeTriggerSignal*> edgeTriggersSources_;
 };

--- a/DeviceAdapters/SequenceTester/InterDevice.h
+++ b/DeviceAdapters/SequenceTester/InterDevice.h
@@ -25,10 +25,9 @@
 
 #include "LoggedSetting.h"
 
-#include <boost/unordered_map.hpp>
-
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 class SettingLogger;
 class TesterHub;
@@ -62,5 +61,5 @@ protected:
 private:
    const std::string name_;
    std::shared_ptr<TesterHub> hub_;
-   boost::unordered_map<std::string, EdgeTriggerSignal*> edgeTriggersSources_;
+   std::unordered_map<std::string, EdgeTriggerSignal*> edgeTriggersSources_;
 };

--- a/DeviceAdapters/SequenceTester/LoggedSetting.cpp
+++ b/DeviceAdapters/SequenceTester/LoggedSetting.cpp
@@ -81,7 +81,7 @@ LoggedSetting::ConnectToEdgeTriggerSource(EdgeTriggerSignal& source)
 {
    edgeTriggerConnection_ = source.connect(
          EdgeTriggerSignal::slot_type(&Self::ReceiveEdgeTrigger, this).
-         track(shared_from_this()));
+         track_foreign(shared_from_this()));
 }
 
 

--- a/DeviceAdapters/SequenceTester/LoggedSetting.h
+++ b/DeviceAdapters/SequenceTester/LoggedSetting.h
@@ -25,10 +25,9 @@
 
 #include "DeviceBase.h"
 
-#include <boost/enable_shared_from_this.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/signals2.hpp>
+
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -52,7 +51,7 @@ typedef boost::signals2::signal<void ()> EdgeTriggerSignal;
 
 // A "setting" in this device adapter is a property or a property-like entity
 // (e.g. camera exposure, stage position).
-class LoggedSetting : public boost::enable_shared_from_this<LoggedSetting>
+class LoggedSetting : public std::enable_shared_from_this<LoggedSetting>
 {
    typedef LoggedSetting Self;
 
@@ -60,12 +59,12 @@ class LoggedSetting : public boost::enable_shared_from_this<LoggedSetting>
    InterDevice* device_;
    const std::string name_;
 
-   boost::shared_ptr<CountDownSetting> busySetting_;
+   std::shared_ptr<CountDownSetting> busySetting_;
 
    boost::signals2::signal<void ()> postSetSignal_;
 
    // Zero is interpreted as triggering disabled
-   boost::shared_ptr<IntegerSetting> sequenceMaxLengthSetting_;
+   std::shared_ptr<IntegerSetting> sequenceMaxLengthSetting_;
 
    boost::signals2::connection edgeTriggerConnection_;
 
@@ -81,21 +80,21 @@ protected:
    void FirePostSetSignal() { postSetSignal_(); }
 
 public:
-   typedef boost::shared_ptr<Self> Ptr;
-   typedef boost::shared_ptr<const Self> ConstPtr;
+   typedef std::shared_ptr<Self> Ptr;
+   typedef std::shared_ptr<const Self> ConstPtr;
 
    LoggedSetting(SettingLogger* logger, InterDevice* device,
          const std::string& name);
    virtual ~LoggedSetting() {}
 
-   void SetBusySetting(boost::shared_ptr<CountDownSetting> setting)
+   void SetBusySetting(std::shared_ptr<CountDownSetting> setting)
    { busySetting_ = setting; }
    void MarkBusy();
 
    typedef boost::signals2::signal<void ()> PostSetSignal;
    PostSetSignal& GetPostSetSignal() { return postSetSignal_; }
 
-   void SetSequenceMaxLengthSetting(boost::shared_ptr<IntegerSetting> setting)
+   void SetSequenceMaxLengthSetting(std::shared_ptr<IntegerSetting> setting)
    { sequenceMaxLengthSetting_ = setting; }
    int GetSequenceMaxLength(long& len) const;
    long GetSequenceMaxLength() const;
@@ -123,15 +122,15 @@ class BoolSetting : public LoggedSetting
    size_t nextTriggerIndex_;
 
 public:
-   typedef boost::shared_ptr<Self> Ptr;
-   typedef boost::shared_ptr<const Self> ConstPtr;
+   typedef std::shared_ptr<Self> Ptr;
+   typedef std::shared_ptr<const Self> ConstPtr;
 
    BoolSetting(SettingLogger* logger, InterDevice* device,
          const std::string& name, bool initialValue);
 
    static Ptr New(SettingLogger* logger, InterDevice* device,
          const std::string& name, bool initialValue)
-   { return boost::make_shared<Self>(logger, device, name, initialValue); }
+   { return std::make_shared<Self>(logger, device, name, initialValue); }
 
    int Set(bool newValue);
    int Get(bool& value) const;
@@ -165,8 +164,8 @@ class IntegerSetting : public LoggedSetting
    typedef IntegerSetting Self;
 
 public:
-   typedef boost::shared_ptr<Self> Ptr;
-   typedef boost::shared_ptr<const Self> ConstPtr;
+   typedef std::shared_ptr<Self> Ptr;
+   typedef std::shared_ptr<const Self> ConstPtr;
 
    IntegerSetting(SettingLogger* logger, InterDevice* device,
          const std::string& name, long initialValue,
@@ -176,7 +175,7 @@ public:
          const std::string& name, long initialValue,
          bool hasMinMax, long minimum = 0, long maximum = 0)
    {
-      return boost::make_shared<Self>(logger, device, name, initialValue,
+      return std::make_shared<Self>(logger, device, name, initialValue,
          hasMinMax, minimum, maximum);
    }
 
@@ -210,8 +209,8 @@ class FloatSetting : public LoggedSetting
    typedef FloatSetting Self;
 
 public:
-   typedef boost::shared_ptr<Self> Ptr;
-   typedef boost::shared_ptr<const Self> ConstPtr;
+   typedef std::shared_ptr<Self> Ptr;
+   typedef std::shared_ptr<const Self> ConstPtr;
 
    FloatSetting(SettingLogger* logger, InterDevice* device,
          const std::string& name, double initialValue,
@@ -221,7 +220,7 @@ public:
          const std::string& name, double initialValue,
          bool hasMinMax, double minimum = 0.0, double maximum = 0.0)
    {
-      return boost::make_shared<Self>(logger, device, name, initialValue,
+      return std::make_shared<Self>(logger, device, name, initialValue,
             hasMinMax, minimum, maximum);
    }
 
@@ -250,15 +249,15 @@ class StringSetting : public LoggedSetting
    typedef StringSetting Self;
 
 public:
-   typedef boost::shared_ptr<Self> Ptr;
-   typedef boost::shared_ptr<const Self> ConstPtr;
+   typedef std::shared_ptr<Self> Ptr;
+   typedef std::shared_ptr<const Self> ConstPtr;
 
    StringSetting(SettingLogger* logger, InterDevice* device,
          const std::string& name, const std::string& initialValue);
 
    static Ptr New(SettingLogger* logger, InterDevice* device,
          const std::string& name, const std::string& initialValue = "")
-   { return boost::make_shared<Self>(logger, device, name, initialValue); }
+   { return std::make_shared<Self>(logger, device, name, initialValue); }
 
    int Set(const std::string& newValue);
    int Get(std::string& value) const;
@@ -273,15 +272,15 @@ class OneShotSetting : public LoggedSetting
    typedef OneShotSetting Self;
 
 public:
-   typedef boost::shared_ptr<Self> Ptr;
-   typedef boost::shared_ptr<const Self> ConstPtr;
+   typedef std::shared_ptr<Self> Ptr;
+   typedef std::shared_ptr<const Self> ConstPtr;
 
    OneShotSetting(SettingLogger* logger, InterDevice* device,
          const std::string& name);
 
    static Ptr New(SettingLogger* logger, InterDevice* device,
          const std::string& name)
-   { return boost::make_shared<Self>(logger, device, name); }
+   { return std::make_shared<Self>(logger, device, name); }
 
 
    int Set();
@@ -297,8 +296,8 @@ class CountDownSetting : public LoggedSetting
    long defaultIncrement_;
 
 public:
-   typedef boost::shared_ptr<Self> Ptr;
-   typedef boost::shared_ptr<const Self> ConstPtr;
+   typedef std::shared_ptr<Self> Ptr;
+   typedef std::shared_ptr<const Self> ConstPtr;
 
    CountDownSetting(SettingLogger* logger, InterDevice* device,
          const std::string& name, long initialCount,
@@ -308,7 +307,7 @@ public:
          const std::string& name, long initialCount,
          long defaultIncrement = 1)
    {
-      return boost::make_shared<Self>(logger, device, name,
+      return std::make_shared<Self>(logger, device, name,
             initialCount, defaultIncrement);
    }
 

--- a/DeviceAdapters/SequenceTester/Makefile.am
+++ b/DeviceAdapters/SequenceTester/Makefile.am
@@ -1,8 +1,4 @@
-# To allow building with outdated versions of Boost (present by default on many
-# Linux distributions), use the older Boost.Thread interface, even though it
-# differs more from C++11. Another way around this might be to use G++'s C++11
-# libraries where possible.
-AM_CPPFLAGS = $(BOOST_CPPFLAGS) -DBOOST_THREAD_VERSION=2 $(MSGPACK_CPPFLAGS)
+AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(MSGPACK_CPPFLAGS)
 
 AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS) $(MSGPACK_CXXFLAGS)
 
@@ -24,9 +20,6 @@ libmmgr_dal_SequenceTester_la_SOURCES = \
 					TriggerInput.h
 
 libmmgr_dal_SequenceTester_la_LIBADD = $(MMDEVAPI_LIBADD) \
-				       $(BOOST_THREAD_LIB) \
-				       $(BOOST_SYSTEM_LIB) \
 				       $(MSGPACK_LIBS)
 libmmgr_dal_SequenceTester_la_LDFLAGS = $(MMDEVAPI_LDFLAGS) \
-					$(BOOST_LDFLAGS) \
 					$(MSGPACK_LDFLAGS)

--- a/DeviceAdapters/SequenceTester/SequenceTester.cpp
+++ b/DeviceAdapters/SequenceTester/SequenceTester.cpp
@@ -26,11 +26,11 @@
 
 #include "ModuleInterface.h"
 
-#include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
 
 #include <exception>
 #include <future>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -74,7 +74,7 @@ namespace
       static std::mutex mutex_;
       static boost::unordered_map<
          MM::Device*,
-         boost::shared_ptr<InterDevice>
+         std::shared_ptr<InterDevice>
       > devices_;
 
    public:
@@ -83,8 +83,8 @@ namespace
       {
          std::lock_guard<std::mutex> g(mutex_);
 
-         boost::shared_ptr<InterDevice> interdev =
-            boost::make_shared<TDevice>(name);
+         std::shared_ptr<InterDevice> interdev =
+            std::make_shared<TDevice>(name);
 
          MM::Device* pDevice = static_cast<TDevice*>(interdev.get());
          devices_.insert(std::make_pair(pDevice, interdev));
@@ -102,7 +102,7 @@ namespace
    std::mutex DeviceRetainer::mutex_;
    boost::unordered_map<
       MM::Device*,
-      boost::shared_ptr<InterDevice>
+      std::shared_ptr<InterDevice>
    > DeviceRetainer::devices_;
 }
 
@@ -178,7 +178,7 @@ TesterHub::Shutdown()
 
    // For hub only, do _not_ call Super::Shutdown(). Release the self-reference
    // created in Initialize().
-   InterDevice::SetHub(boost::shared_ptr<TesterHub>());
+   InterDevice::SetHub(std::shared_ptr<TesterHub>());
    return DEVICE_OK;
 }
 
@@ -210,7 +210,7 @@ TesterHub::DetectInstalledDevices()
 int
 TesterHub::RegisterDevice(const std::string& name, InterDevice::Ptr device)
 {
-   boost::weak_ptr<InterDevice>& ptr = devices_[name];
+   std::weak_ptr<InterDevice>& ptr = devices_[name];
    if (!ptr.lock())
    {
       ptr = device;
@@ -232,7 +232,7 @@ TesterHub::UnregisterDevice(const std::string& name)
 InterDevice::Ptr
 TesterHub::FindPeerDevice(const std::string& name)
 {
-   boost::unordered_map< std::string, boost::weak_ptr<InterDevice> >::iterator
+   boost::unordered_map< std::string, std::weak_ptr<InterDevice> >::iterator
       found = devices_.find(name);
    if (found == devices_.end())
       return InterDevice::Ptr();
@@ -1002,8 +1002,8 @@ TesterAutofocus::UpdateZStageLink()
       return;
 
    InterDevice::Ptr device = GetHub()->FindPeerDevice(zStageName);
-   boost::shared_ptr<TesterZStage> zStage =
-      boost::dynamic_pointer_cast<TesterZStage>(device);
+   std::shared_ptr<TesterZStage> zStage =
+      std::dynamic_pointer_cast<TesterZStage>(device);
    if (!zStage)
       return;
 

--- a/DeviceAdapters/SequenceTester/SequenceTester.cpp
+++ b/DeviceAdapters/SequenceTester/SequenceTester.cpp
@@ -26,7 +26,6 @@
 
 #include "ModuleInterface.h"
 
-#include <boost/unordered_map.hpp>
 
 #include <exception>
 #include <future>
@@ -34,6 +33,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 
 
@@ -72,7 +72,7 @@ namespace
    class DeviceRetainer
    {
       static std::mutex mutex_;
-      static boost::unordered_map<
+      static std::unordered_map<
          MM::Device*,
          std::shared_ptr<InterDevice>
       > devices_;
@@ -100,7 +100,7 @@ namespace
    };
 
    std::mutex DeviceRetainer::mutex_;
-   boost::unordered_map<
+   std::unordered_map<
       MM::Device*,
       std::shared_ptr<InterDevice>
    > DeviceRetainer::devices_;
@@ -232,7 +232,7 @@ TesterHub::UnregisterDevice(const std::string& name)
 InterDevice::Ptr
 TesterHub::FindPeerDevice(const std::string& name)
 {
-   boost::unordered_map< std::string, std::weak_ptr<InterDevice> >::iterator
+   std::unordered_map< std::string, std::weak_ptr<InterDevice> >::iterator
       found = devices_.find(name);
    if (found == devices_.end())
       return InterDevice::Ptr();

--- a/DeviceAdapters/SequenceTester/SequenceTester.h
+++ b/DeviceAdapters/SequenceTester/SequenceTester.h
@@ -32,13 +32,13 @@
 #include "DeviceBase.h"
 
 #include <boost/signals2.hpp>
-#include <boost/unordered_map.hpp>
 
 #include <future>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 
@@ -103,7 +103,7 @@ class TesterHub : public TesterBase<HubBase, TesterHub>
 
    SettingLogger logger_;
 
-   boost::unordered_map< std::string, std::weak_ptr<InterDevice> > devices_;
+   std::unordered_map< std::string, std::weak_ptr<InterDevice> > devices_;
 
 public:
    typedef TesterHub Self;

--- a/DeviceAdapters/SequenceTester/SequenceTester.h
+++ b/DeviceAdapters/SequenceTester/SequenceTester.h
@@ -33,10 +33,13 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/signals2.hpp>
-#include <boost/thread.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/weak_ptr.hpp>
+
+#include <future>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 
@@ -97,7 +100,7 @@ class TesterHub : public TesterBase<HubBase, TesterHub>
    // finer-grained locking because the Core already synchronizes access to the
    // device adapter. However, we do need this lock to be per-hub so that
    // access from different Core instances can run concurrently.)
-   mutable boost::recursive_mutex hubGlobalMutex_;
+   mutable std::recursive_mutex hubGlobalMutex_;
 
    SettingLogger logger_;
 
@@ -114,7 +117,7 @@ public:
 
    virtual int DetectInstalledDevices();
 
-   typedef boost::unique_lock<boost::recursive_mutex> Guard;
+   typedef std::unique_lock<std::recursive_mutex> Guard;
    Guard LockGlobalMutex() const { return Guard(hubGlobalMutex_); }
 
    boost::shared_ptr<TesterHub> GetSharedPtr()
@@ -188,13 +191,12 @@ private:
 
    // Guards stopSequence_. Always acquire after acquiring the hub global mutex
    // (if acquiring both).
-   boost::mutex sequenceMutex_;
+   std::mutex sequenceMutex_;
 
    bool stopSequence_; // Guarded by sequenceMutex_
 
-   // Note: boost::future in more recent versions
-   boost::unique_future<void> sequenceFuture_;
-   boost::thread sequenceThread_;
+   std::future<void> sequenceFuture_;
+   std::thread sequenceThread_;
 
    FloatSetting::Ptr exposureSetting_;
    IntegerSetting::Ptr binningSetting_;

--- a/DeviceAdapters/SequenceTester/SequenceTester.h
+++ b/DeviceAdapters/SequenceTester/SequenceTester.h
@@ -31,12 +31,11 @@
 
 #include "DeviceBase.h"
 
-#include <boost/shared_ptr.hpp>
 #include <boost/signals2.hpp>
 #include <boost/unordered_map.hpp>
-#include <boost/weak_ptr.hpp>
 
 #include <future>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -104,7 +103,7 @@ class TesterHub : public TesterBase<HubBase, TesterHub>
 
    SettingLogger logger_;
 
-   boost::unordered_map< std::string, boost::weak_ptr<InterDevice> > devices_;
+   boost::unordered_map< std::string, std::weak_ptr<InterDevice> > devices_;
 
 public:
    typedef TesterHub Self;
@@ -120,8 +119,8 @@ public:
    typedef std::unique_lock<std::recursive_mutex> Guard;
    Guard LockGlobalMutex() const { return Guard(hubGlobalMutex_); }
 
-   boost::shared_ptr<TesterHub> GetSharedPtr()
-   { return boost::static_pointer_cast<TesterHub>(shared_from_this()); }
+   std::shared_ptr<TesterHub> GetSharedPtr()
+   { return std::static_pointer_cast<TesterHub>(shared_from_this()); }
    virtual SettingLogger* GetLogger() { return &logger_; }
 
    int RegisterDevice(const std::string& name, InterDevice::Ptr device);

--- a/DeviceAdapters/SequenceTester/SequenceTesterImpl.h
+++ b/DeviceAdapters/SequenceTester/SequenceTesterImpl.h
@@ -89,7 +89,7 @@ TesterBase<TDeviceBase, UConcreteDevice>::Shutdown()
    TesterHub::Guard g(GetHub()->LockGlobalMutex());
 
    CommonHubPeripheralShutdown();
-   InterDevice::SetHub(boost::shared_ptr<TesterHub>());
+   InterDevice::SetHub(std::shared_ptr<TesterHub>());
    return DEVICE_OK;
 }
 

--- a/DeviceAdapters/SequenceTester/SettingLogger.cpp
+++ b/DeviceAdapters/SequenceTester/SettingLogger.cpp
@@ -26,8 +26,7 @@
 
 #include <msgpack.hpp>
 
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -186,8 +185,8 @@ SettingLogger::SetBool(const std::string& device, const std::string& key,
       bool value, bool logEvent)
 {
    SettingKey keyRecord = SettingKey(device, key);
-   boost::shared_ptr<SettingValue> valueRecord =
-      boost::make_shared<BoolSettingValue>(value);
+   std::shared_ptr<SettingValue> valueRecord =
+      std::make_shared<BoolSettingValue>(value);
    settingValues_[keyRecord] = valueRecord;
 
    if (logEvent)
@@ -216,8 +215,8 @@ SettingLogger::SetInteger(const std::string& device, const std::string& key,
       long value, bool logEvent)
 {
    SettingKey keyRecord = SettingKey(device, key);
-   boost::shared_ptr<SettingValue> valueRecord =
-      boost::make_shared<IntegerSettingValue>(value);
+   std::shared_ptr<SettingValue> valueRecord =
+      std::make_shared<IntegerSettingValue>(value);
    settingValues_[keyRecord] = valueRecord;
 
    if (logEvent)
@@ -246,8 +245,8 @@ SettingLogger::SetFloat(const std::string& device, const std::string& key,
       double value, bool logEvent)
 {
    SettingKey keyRecord = SettingKey(device, key);
-   boost::shared_ptr<SettingValue> valueRecord =
-      boost::make_shared<FloatSettingValue>(value);
+   std::shared_ptr<SettingValue> valueRecord =
+      std::make_shared<FloatSettingValue>(value);
    settingValues_[keyRecord] = valueRecord;
 
    if (logEvent)
@@ -276,8 +275,8 @@ SettingLogger::SetString(const std::string& device, const std::string& key,
       const std::string& value, bool logEvent)
 {
    SettingKey keyRecord = SettingKey(device, key);
-   boost::shared_ptr<SettingValue> valueRecord =
-      boost::make_shared<StringSettingValue>(value);
+   std::shared_ptr<SettingValue> valueRecord =
+      std::make_shared<StringSettingValue>(value);
    settingValues_[keyRecord] = valueRecord;
 
    if (logEvent)
@@ -306,8 +305,8 @@ SettingLogger::FireOneShot(const std::string& device, const std::string& key,
       bool logEvent)
 {
    SettingKey keyRecord = SettingKey(device, key);
-   boost::shared_ptr<SettingValue> valueRecord =
-      boost::make_shared<OneShotSettingValue>();
+   std::shared_ptr<SettingValue> valueRecord =
+      std::make_shared<OneShotSettingValue>();
    settingValues_[keyRecord] = valueRecord;
 
    if (logEvent)
@@ -415,7 +414,7 @@ SettingLogger::SettingMapAsText(const SettingMap& values) const
    for (SettingConstIterator it = values.begin(), end = values.end();
          it != end; ++it)
    {
-      if (boost::dynamic_pointer_cast<OneShotSettingValue>(it->second))
+      if (std::dynamic_pointer_cast<OneShotSettingValue>(it->second))
          continue; // Skip one-shot settings
 
       if (first)

--- a/DeviceAdapters/SequenceTester/SettingLogger.h
+++ b/DeviceAdapters/SequenceTester/SettingLogger.h
@@ -28,9 +28,8 @@
 
 #include <msgpack.hpp>
 
-#include <boost/shared_ptr.hpp>
-
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -132,10 +131,10 @@ public:
 class SettingEvent : public Serializable
 {
    SettingKey key_;
-   boost::shared_ptr<SettingValue> value_;
+   std::shared_ptr<SettingValue> value_;
    size_t count_;
 public:
-   SettingEvent(SettingKey key, boost::shared_ptr<SettingValue> value,
+   SettingEvent(SettingKey key, std::shared_ptr<SettingValue> value,
          uint64_t counterValue) :
       key_(key), value_(value), count_(counterValue)
    {}
@@ -213,7 +212,7 @@ private:
    uint64_t counterAtLastReset_;
    uint64_t nextGlobalImageNr_;
 
-   typedef std::map< SettingKey, boost::shared_ptr<SettingValue> > SettingMap;
+   typedef std::map< SettingKey, std::shared_ptr<SettingValue> > SettingMap;
    typedef SettingMap::const_iterator SettingConstIterator;
    SettingMap settingValues_;
    SettingMap startingValues_;


### PR DESCRIPTION
It still uses Boost.Signals2 and a few little things. But this removes the dependency on Boost.Thread, which requires a library; the remaining usage is header-only.