### PR TITLE
Meson: Upgrade Catch2 wrap

### DIFF
--- a/MMCore/subprojects/catch2.wrap
+++ b/MMCore/subprojects/catch2.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = Catch2-3.4.0
-source_url = https://github.com/catchorg/Catch2/archive/v3.4.0.tar.gz
-source_filename = Catch2-3.4.0.tar.gz
-source_hash = 122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.4.0-1/Catch2-3.4.0.tar.gz
-wrapdb_version = 3.4.0-1
+directory = Catch2-3.9.1
+source_url = https://github.com/catchorg/Catch2/archive/v3.9.1.tar.gz
+source_filename = Catch2-3.9.1.tar.gz
+source_hash = a215c2a723bd7483efd236dc86066842a389cb4e344c61119c978acdf24d39be
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.9.1-1/Catch2-3.9.1.tar.gz
+wrapdb_version = 3.9.1-1
 
 [provide]
 catch2 = catch2_dep

--- a/MMDevice/subprojects/catch2.wrap
+++ b/MMDevice/subprojects/catch2.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = Catch2-3.4.0
-source_url = https://github.com/catchorg/Catch2/archive/v3.4.0.tar.gz
-source_filename = Catch2-3.4.0.tar.gz
-source_hash = 122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.4.0-1/Catch2-3.4.0.tar.gz
-wrapdb_version = 3.4.0-1
+directory = Catch2-3.9.1
+source_url = https://github.com/catchorg/Catch2/archive/v3.9.1.tar.gz
+source_filename = Catch2-3.9.1.tar.gz
+source_hash = a215c2a723bd7483efd236dc86066842a389cb4e344c61119c978acdf24d39be
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.9.1-1/Catch2-3.9.1.tar.gz
+wrapdb_version = 3.9.1-1
 
 [provide]
 catch2 = catch2_dep

--- a/justfile
+++ b/justfile
@@ -55,5 +55,7 @@ test: test-mmdevice test-mmcore
 # Clean build artifacts
 clean:
     rm -rf MMDevice/builddir
+    rm -rf MMDevice/subprojects/Catch2-*
     rm -rf MMCore/builddir
     rm -rf MMCore/subprojects/mmdevice
+    rm -rf MMCore/subprojects/Catch2-*


### PR DESCRIPTION
Also make sure `just clean` removes Catch2, since Meson doesn't replace subproject directories once they exist.