### PR TITLE
Meson: MMDevice: default to hidden visibility

### DIFF
--- a/MMDevice/meson.build
+++ b/MMDevice/meson.build
@@ -56,6 +56,7 @@ mmdevice_lib = static_library(
     dependencies: [
         dependency('threads'),
     ],
+    gnu_symbol_visibility: 'inlineshidden',
 )
 
 subdir('unittest')


### PR DESCRIPTION
MMDevice is either built into device adapters or (usually, via MMCore) into Python or Java extensions, which are all DLLs/shared objects. None of these should expose the MMDevice C++ classes and functions (except for the ones marked MODULE_API, which overrides the default set here). (On Windows, unmarked symbols are already hidden by default.)