### PR TITLE
Meson: MMCore: default to hidden visibility

### DIFF
--- a/MMCore/meson.build
+++ b/MMCore/meson.build
@@ -110,6 +110,7 @@ mmcore_lib = static_library(
         mmdevice_dep,
         dependency('threads'),
     ],
+    gnu_symbol_visibility: 'inlineshidden',
     cpp_args: [
         '-D_CRT_SECURE_NO_WARNINGS', # TODO Eliminate the need
     ],


### PR DESCRIPTION
This does to MMCore what #735 did to MMDevice (sorry for the churn).

We currently build MMCore only as a static library (never shared library/DLL on its own), but the primary use case is to build it into a shared library (Python or Java extension). It is almost never the case that a shared library wants to expose the MMCore C++ API to its clients. So this is a good default.

If we (in the future) add support for building MMCore as a C++ shared library, this is still a good setting, because then each public API function should be explicitly exported (as it will have to be on Windows anyway).

In particular, this removes the unnecessary exported symbols from pymmcore builds without the pymmcore build script having to jump through hoops.