### PR TITLE
PlayerOne: Include S/N in camera selection

### DIFF
--- a/DeviceAdapters/PlayerOne/POACamera.cpp
+++ b/DeviceAdapters/PlayerOne/POACamera.cpp
@@ -235,7 +235,10 @@ POACamera::POACamera() :
             continue;
         }
 
-        connectCamerasName_.push_back(std::string(camProp.cameraModelName));
+        std::string itemName = camProp.cameraModelName;
+        itemName += ' ';
+        itemName += camProp.SN;
+        connectCamerasName_.push_back(itemName);
     }
     
     CPropertyAction* pAct = new CPropertyAction(this, &POACamera::OnSelectCamIndex);


### PR DESCRIPTION
This is needed to distinguish between multiple cameras of the same model name.

This will be a breaking change for existing config files. Will merge after I hear back if it actually works with 2 cameras.