### PR TITLE
TSI cameras: Adds capability to work with multiple cameras simultanuously

### DIFF
--- a/DeviceAdapters/TSI/TSI3Cam.cpp
+++ b/DeviceAdapters/TSI/TSI3Cam.cpp
@@ -173,15 +173,17 @@ int Tsi3Cam::Initialize()
 	// Get desired ID.  For backwards compatability, zero indicates take the first camera
 	char camera_id[maxSdkStringLength];
 	this->GetProperty(MM::g_Keyword_CameraID, camera_id);
+   char camera_ids[maxSdkStringLength];
 
-	if (std::strcmp(camera_id, "0") != 0) 
+	// Even though it does not seem to be needed if we already know the camera ID,
+   // not discovering available cameras leads to failure to open the camera sometimes.
+   if (tl_camera_discover_available_cameras(camera_ids, maxSdkStringLength))
+   {
+      return ERR_TSI_CAMERA_NOT_FOUND;
+   }
+
+	if (std::strcmp(camera_id, "0") == 0) 
 	{
-		char camera_ids[maxSdkStringLength];
-
-		if (tl_camera_discover_available_cameras(camera_ids, maxSdkStringLength))
-		{
-			return ERR_TSI_CAMERA_NOT_FOUND;
-		}
 
 		// pull out the first camera in the list
 		string s_camera_ids(camera_ids);

--- a/DeviceAdapters/TSI/TSI3Cam.cpp
+++ b/DeviceAdapters/TSI/TSI3Cam.cpp
@@ -94,6 +94,43 @@ Tsi3Cam::Tsi3Cam() :
 
    // this identifies which camera we want to access
    CreateProperty(MM::g_Keyword_CameraID, "0", MM::Integer, false, 0, true);
+	AddAllowedValue(MM::g_Keyword_CameraID, "0");
+	const int maxSdkStringLength = 1024;
+   char camera_ids[maxSdkStringLength];
+	if (!tl_camera_sdk_dll_initialize())
+	{
+		if (!tl_camera_open_sdk())
+      {
+			if (!tl_camera_discover_available_cameras(camera_ids, maxSdkStringLength))
+			{
+				string s_camera_ids(camera_ids);
+				std::stringstream ss(s_camera_ids);
+				std::string segment;
+
+				while (std::getline(ss, segment, ' ')) {
+					if (!segment.empty()) {
+						try {
+							std::ignore = std::stoi(segment);
+							AddAllowedValue(MM::g_Keyword_CameraID, segment.c_str());
+						}
+						catch (const std::invalid_argument&) {
+							this->GetCoreCallback()->LogMessage(this, "Error parsing CameraIDs", false);
+						}
+						catch (const std::out_of_range&) {
+							this->GetCoreCallback()->LogMessage(this, "Error parsing CameraIDs", false);
+						}
+					}
+				}
+
+				string s_camera_id = s_camera_ids.substr(0, s_camera_ids.find(' '));
+
+				char camera_id[maxSdkStringLength];
+				strcpy_s(camera_id, s_camera_id.c_str());
+			}
+         tl_camera_close_sdk();
+		}
+      tl_camera_sdk_dll_terminate();
+	}
 
 	// obtain path for loading DLLs
 	sdkPath = getSDKPath();
@@ -132,7 +169,34 @@ int Tsi3Cam::Initialize()
       return ERR_TSI_OPEN_FAILED;
    }
 
-   char camera_ids[maxSdkStringLength];
+   // To handle multiple cameras
+	// Get desired ID.  For backwards compatability, zero indicates take the first camera
+	char camera_id[maxSdkStringLength];
+	this->GetProperty(MM::g_Keyword_CameraID, camera_id);
+
+	if (std::strcmp(camera_id, "0") != 0) 
+	{
+		char camera_ids[maxSdkStringLength];
+
+		if (tl_camera_discover_available_cameras(camera_ids, maxSdkStringLength))
+		{
+			return ERR_TSI_CAMERA_NOT_FOUND;
+		}
+
+		// pull out the first camera in the list
+		string s_camera_ids(camera_ids);
+		string s_camera_id = s_camera_ids.substr(0, s_camera_ids.find(' '));
+      strcpy_s(camera_id, s_camera_id.c_str());
+	}
+
+   if (tl_camera_open_camera(camera_id, &camHandle))
+   {
+      return ERR_CAMERA_OPEN_FAILED;
+   }
+
+   // this must be done after connecting to the camera
+   if (tl_camera_disarm(camHandle))
+	   return ERR_INTERNAL_ERROR;
 
    //if (tl_camera_set_camera_connect_callback(camera_connect_callback, nullptr))
    //{
@@ -144,28 +208,6 @@ int Tsi3Cam::Initialize()
    //   return ERR_INTERNAL_ERROR;
    //}
 
-   if (tl_camera_discover_available_cameras(camera_ids, maxSdkStringLength))
-   {
-	   return ERR_TSI_CAMERA_NOT_FOUND;
-   }
-
-   // pull out the first camera in the list
-   string s_camera_ids(camera_ids);
-   string s_camera_id = s_camera_ids.substr(0, s_camera_ids.find(' '));
-
-   char camera_id[maxSdkStringLength];
-   strcpy_s(camera_id, s_camera_id.c_str());
-
-   if (tl_camera_open_camera(camera_id, &camHandle))
-   {
-      return ERR_CAMERA_OPEN_FAILED;
-   }
-
-   // this must be done after connecting to the camera
-   if (tl_camera_disarm(camHandle))
-	   return ERR_INTERNAL_ERROR;
-
-   // TODO: figure out how to handle multiple cameras
 
    // set callback for collecting frames
    if (tl_camera_set_frame_available_callback(camHandle, &Tsi3Cam::frame_available_callback, this))

--- a/DeviceAdapters/TSI/TSI3Cam.h
+++ b/DeviceAdapters/TSI/TSI3Cam.h
@@ -43,6 +43,7 @@
 
 #include <string>
 #include <map>
+#include <mutex>
 
 struct Tsi3RoiBin
 {
@@ -183,6 +184,8 @@ private:
 	int ApplyWhiteBalance(double redScaler, double greenScaler, double blueScaler);
 	void EnableColorOutputLUTs();
 	int GetCameraROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
+   int OpenDLLAndSDK();
+   int CloseDLLAndSDK();
 
    static void frame_available_callback(void* sender, unsigned short* image_buffer, int frame_count, unsigned char* metadata, int metadata_size_in_bytes, void* context);
 
@@ -193,6 +196,9 @@ private:
    bool prepared;
 	static bool globalColorInitialized;
 	static bool globalPolarizationInitialized;
+   static uint16_t Tsi3Cam::dllCount;
+   static uint16_t Tsi3Cam::sdkCount;
+   static std::mutex mtx;
    bool stopOnOverflow;
    void* camHandle;
    void* colorProcessor;

--- a/DeviceAdapters/TSI/TSILibrary.cpp
+++ b/DeviceAdapters/TSI/TSILibrary.cpp
@@ -84,6 +84,10 @@ MODULE_API MM::Device* CreateDevice(const char* deviceName)
  */
 bool isTsiSDK3Available()
 {
+   static bool available = false;
+   if (available)
+      return true;
+
 	//std::string sdkPath = getSDKPath();
 	//std::string kernelPath(sdkPath);
 	//kernelPath += "thorlabs_unified_sdk_kernel.dll";
@@ -101,6 +105,7 @@ bool isTsiSDK3Available()
    tl_camera_close_sdk();
 	tl_camera_sdk_dll_terminate();
 
+   available = true;
    return true;
 }
 


### PR DESCRIPTION
Adds the serial number as a pre-init property (for backwards compatibility, zero selects the first camera) and ads reference counting for opening sdk and dll so that multiple instances can work with sdk and dll.  Only works with TSI3 cameras.