### PR TITLE
Remove overrides of GetPixelSizeUm()

### DIFF
--- a/DeviceAdapters/ABS/ABSCamera.cpp
+++ b/DeviceAdapters/ABS/ABSCamera.cpp
@@ -16,7 +16,6 @@ using namespace std;
 
 #include "AutoTimeMeasure.h"
 
-const double CABSCamera::nominalPixelSizeUm_ = 1.0;
 double g_IntensityFactor_ = 1.0;
 // External names used used by the rest of the system
 // to load particular device from the "DemoCamera.dll" library

--- a/DeviceAdapters/ABS/ABSCamera.h
+++ b/DeviceAdapters/ABS/ABSCamera.h
@@ -118,7 +118,6 @@ public:
   int   InsertImage();
   virtual int ThreadRun (void);
 
-  double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
   int   GetBinning() const;
   int   SetBinning(int bS);
 
@@ -282,8 +281,6 @@ private:
   CStringVector             transposePropertyNames_;
 
 private:
-  static const double nominalPixelSizeUm_;
-
   bool  isSupported( unsigned long long qwFunctionID );
   int   SetAllowedBinning();
   void  generateEmptyImage( CAbsImgBuffer& img );

--- a/DeviceAdapters/ABS/ABSCamera.h
+++ b/DeviceAdapters/ABS/ABSCamera.h
@@ -119,7 +119,6 @@ public:
   virtual int ThreadRun (void);
 
   double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-  double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
   int   GetBinning() const;
   int   SetBinning(int bS);
 

--- a/DeviceAdapters/AmScope/AmScope.cpp
+++ b/DeviceAdapters/AmScope/AmScope.cpp
@@ -341,8 +341,7 @@ int AmScope::Initialize()
 
    // Physical pixel size (um)
    Toupcam_get_PixelSize(m_Htoupcam, 0, &orgPixelSizeXUm_, &orgPixelSizeYUm_);
-   nominalPixelSizeUm_ = orgPixelSizeXUm_;
-   pixelSizeXUm_ = (float)nominalPixelSizeUm_;
+   pixelSizeXUm_ = orgPixelSizeXUm_;
    pixelSizeYUm_ = orgPixelSizeYUm_;
    pAct = new CPropertyAction (this, &AmScope::OnPixelSizeXUm);
    CreateFloatProperty("PixelSizeX(um)", pixelSizeXUm_, true, pAct);

--- a/DeviceAdapters/AmScope/AmScope.h
+++ b/DeviceAdapters/AmScope/AmScope.h
@@ -59,7 +59,6 @@ public:
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StopSequenceAcquisition();
    bool IsCapturing();
-   double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
    int GetBinning() const;
    int SetBinning(int binSize);
    int IsExposureSequenceable(bool& seq) const {seq = false; return DEVICE_OK;}
@@ -103,7 +102,6 @@ private:
    long IMAGE_WIDTH;
    long IMAGE_HEIGHT;
    static const int MAX_BIT_DEPTH = 16;
-   double nominalPixelSizeUm_;
 
    SequenceThread* thd_;
    int binning_;

--- a/DeviceAdapters/AmScope/AmScope.h
+++ b/DeviceAdapters/AmScope/AmScope.h
@@ -60,8 +60,6 @@ public:
    int StopSequenceAcquisition();
    bool IsCapturing();
    double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-   //double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
-   double GetPixelSizeUm() const {return pixelSizeXUm_;}
    int GetBinning() const;
    int SetBinning(int binSize);
    int IsExposureSequenceable(bool& seq) const {seq = false; return DEVICE_OK;}

--- a/DeviceAdapters/Andor/Andor.cpp
+++ b/DeviceAdapters/Andor/Andor.cpp
@@ -2199,20 +2199,6 @@ int AndorCamera::GetListOfAvailableCameras()
       return DEVICE_OK;
    }
 
-
-   double AndorCamera::GetPixelSizeUm() const
-   {
-      DriverGuard dg(this);
-      float x, y;
-      unsigned ret = ::GetPixelSize(&x, &y);
-      if (ret == DRV_SUCCESS)
-      {
-         return (double)x;
-      }
-
-      return GetBinning();
-   }
-
    ///////////////////////////////////////////////////////////////////////////////
    // Action handlers
    // ~~~~~~~~~~~~~~~

--- a/DeviceAdapters/Andor/Andor.h
+++ b/DeviceAdapters/Andor/Andor.h
@@ -314,8 +314,6 @@ private:
    ROI roi_, customROI_;
    std::vector<ROI> roiList;
 
-   double GetPixelSizeUm() const;
-
    int binSize_;
    double expMs_; //value used by camera
    std::string driverDir_;

--- a/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
+++ b/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
@@ -54,7 +54,6 @@
 using namespace std;
 using namespace andor;
 
-const double CAndorSDK3Camera::nominalPixelSizeUm_ = 1.0;
 double g_IntensityFactor_ = 1.0;
 
 // External names used used by the rest of the system

--- a/DeviceAdapters/AndorSDK3/AndorSDK3.h
+++ b/DeviceAdapters/AndorSDK3/AndorSDK3.h
@@ -114,7 +114,6 @@ public:
    bool IsCapturing();
    void OnThreadExiting() throw(); 
    //double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-   double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
    int GetBinning() const;
    int SetBinning(int bS);
    int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}

--- a/DeviceAdapters/AndorSDK3/AndorSDK3.h
+++ b/DeviceAdapters/AndorSDK3/AndorSDK3.h
@@ -113,7 +113,6 @@ public:
    int ThreadRun();
    bool IsCapturing();
    void OnThreadExiting() throw(); 
-   //double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
    int GetBinning() const;
    int SetBinning(int bS);
    int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}
@@ -148,7 +147,6 @@ private:
    void AddSimpleFloatProperty(std::wstring Name, std::string DisplayName="");
    std::string ToNarrowString(std::wstring wstr) const;
 
-   static const double nominalPixelSizeUm_;
    static const int CID_FPGA_TICKS = 1;
 
    ImgBuffer img_;

--- a/DeviceAdapters/BaumerOptronic/BaumerOptronic.cpp
+++ b/DeviceAdapters/BaumerOptronic/BaumerOptronic.cpp
@@ -80,9 +80,6 @@ there is too much uncommented magic in this code.
 
 using namespace std;
 
-
-const double CBaumerOptronic::nominalPixelSizeUm_ = 1.0;
-
 // External names used by the rest of the system
 const char* g_CameraDeviceName = "BaumerOptronic";
 

--- a/DeviceAdapters/BaumerOptronic/BaumerOptronic.h
+++ b/DeviceAdapters/BaumerOptronic/BaumerOptronic.h
@@ -90,7 +90,6 @@ public:
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
    int ClearROI();
    double GetNominalPixelSizeUm() const { return nominalPixelSizeUm_; }
-   double GetPixelSizeUm() const { return nominalPixelSizeUm_ * GetBinning(); }
    int GetBinning() const;
    int SetBinning(int binSize);
    int IsExposureSequenceable(bool& isSequenceable) const { isSequenceable = false; return DEVICE_OK; }

--- a/DeviceAdapters/BaumerOptronic/BaumerOptronic.h
+++ b/DeviceAdapters/BaumerOptronic/BaumerOptronic.h
@@ -89,7 +89,6 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
    int ClearROI();
-   double GetNominalPixelSizeUm() const { return nominalPixelSizeUm_; }
    int GetBinning() const;
    int SetBinning(int binSize);
    int IsExposureSequenceable(bool& isSequenceable) const { isSequenceable = false; return DEVICE_OK; }
@@ -115,7 +114,6 @@ private:
    int WaitForImageAndCopyToBuffer();
    int SendImageToCore();
 
-   static const double nominalPixelSizeUm_;
    ImgBuffer img_;
    bool initialized_;
    bool stopOnOverflow_;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -164,7 +164,6 @@ public:
    bool IsCapturing();
    void OnThreadExiting() throw(); 
    double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-   double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
    int GetBinning() const;
    int SetBinning(int bS);
 

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -163,7 +163,6 @@ public:
    int RunSequenceOnThread();
    bool IsCapturing();
    void OnThreadExiting() throw(); 
-   double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
    int GetBinning() const;
    int SetBinning(int bS);
 
@@ -228,8 +227,6 @@ private:
    void GenerateSyntheticImage(ImgBuffer& img, double exp);
    bool GenerateColorTestPattern(ImgBuffer& img);
    int ResizeImageBuffer();
-
-   static constexpr double nominalPixelSizeUm_ = 1.0;
 
    double exposureMaximum_ = 10000.0;
    double dPhase_ = 0.0;

--- a/DeviceAdapters/DirectElectron/src/DECamera/DECamera.cpp
+++ b/DeviceAdapters/DirectElectron/src/DECamera/DECamera.cpp
@@ -965,11 +965,6 @@ int CDECamera::ResizeImageBuffer()
 	return DEVICE_OK;
 }
 
-double CDECamera::GetNominalPixelSizeUm() const
-{
-	return pixelSize_.x;
-}
-
 void CDECamera::SetupProperty(string label, PropertyHelper settings)
 {
 	CPropertyAction* pAct = new CPropertyAction(this, &CDECamera::OnProperty);

--- a/DeviceAdapters/DirectElectron/src/DECamera/DECamera.cpp
+++ b/DeviceAdapters/DirectElectron/src/DECamera/DECamera.cpp
@@ -970,11 +970,6 @@ double CDECamera::GetNominalPixelSizeUm() const
 	return pixelSize_.x;
 }
 
-double CDECamera::GetPixelSizeUm() const
-{
-	return pixelSize_.x  * this->GetBinning();
-}
-
 void CDECamera::SetupProperty(string label, PropertyHelper settings)
 {
 	CPropertyAction* pAct = new CPropertyAction(this, &CDECamera::OnProperty);

--- a/DeviceAdapters/DirectElectron/src/DECamera/DECamera.h
+++ b/DeviceAdapters/DirectElectron/src/DECamera/DECamera.h
@@ -71,7 +71,6 @@ public:
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
    virtual double GetNominalPixelSizeUm() const;
-   virtual double GetPixelSizeUm() const;
    int GetBinning() const;
    int SetBinning(int binSize);
 

--- a/DeviceAdapters/DirectElectron/src/DECamera/DECamera.h
+++ b/DeviceAdapters/DirectElectron/src/DECamera/DECamera.h
@@ -70,7 +70,6 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
-   virtual double GetNominalPixelSizeUm() const;
    int GetBinning() const;
    int SetBinning(int binSize);
 

--- a/DeviceAdapters/FLICamera/FLICamera.cpp
+++ b/DeviceAdapters/FLICamera/FLICamera.cpp
@@ -154,7 +154,6 @@ int CFLICamera::Initialize()
 
 	DOFLIAPIERR(FLIOpen(&dev_, "flipro0", FLIDOMAIN_USB | FLIDEVICE_CAMERA), DEVICE_NOT_CONNECTED);
 	DOFLIAPIERR(FLIControlShutter(dev_, shutter_), DEVICE_NOT_CONNECTED);
-	DOFLIAPIERR(FLIGetPixelSize(dev_, &pixel_x_, &pixel_y_), DEVICE_NOT_CONNECTED);
 	DOFLIAPIERR(FLIGetVisibleArea(dev_, &ul_x, &ul_y, &lr_x, &lr_y), DEVICE_NOT_CONNECTED);
 
 	image_offset_x_ = ul_x;
@@ -718,11 +717,6 @@ int CFLICamera::OnExposure(MM::PropertyBase* pProp, MM::ActionType eAct)
 int CFLICamera::PrepareSequenceAcqusition()
 {
 	return DEVICE_OK;
-}
-
-double CFLICamera::GetNominalPixelSizeUm() const
-{
-	return pixel_x_;
 }
 
 int CFLICamera::ResizeImageBuffer()

--- a/DeviceAdapters/FLICamera/FLICamera.cpp
+++ b/DeviceAdapters/FLICamera/FLICamera.cpp
@@ -725,11 +725,6 @@ double CFLICamera::GetNominalPixelSizeUm() const
 	return pixel_x_;
 }
 
-double CFLICamera::GetPixelSizeUm() const
-{
-	return pixel_x_;
-}
-
 int CFLICamera::ResizeImageBuffer()
 {
 	int byteDepth = 2;

--- a/DeviceAdapters/FLICamera/FLICamera.h
+++ b/DeviceAdapters/FLICamera/FLICamera.h
@@ -59,7 +59,6 @@ class CFLICamera : public CLegacyCameraBase<CFLICamera>
 		int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
 		int ClearROI();
 		int PrepareSequenceAcqusition();
-		double GetNominalPixelSizeUm() const;
 		int GetBinning() const;
 		int SetBinning(int binSize);
 		int IsExposureSequenceable(bool& seq) const {seq = false; return DEVICE_OK;}
@@ -107,9 +106,6 @@ class CFLICamera : public CLegacyCameraBase<CFLICamera>
 		long exposure_;
 		long shutter_;
 		long downloaded_;
-
-		double pixel_x_;
-		double pixel_y_;
 
 public:
 	void Disconnect(void);

--- a/DeviceAdapters/FLICamera/FLICamera.h
+++ b/DeviceAdapters/FLICamera/FLICamera.h
@@ -60,7 +60,6 @@ class CFLICamera : public CLegacyCameraBase<CFLICamera>
 		int ClearROI();
 		int PrepareSequenceAcqusition();
 		double GetNominalPixelSizeUm() const;
-		double GetPixelSizeUm() const;
 		int GetBinning() const;
 		int SetBinning(int binSize);
 		int IsExposureSequenceable(bool& seq) const {seq = false; return DEVICE_OK;}

--- a/DeviceAdapters/GigECamera/GigECamera.h
+++ b/DeviceAdapters/GigECamera/GigECamera.h
@@ -192,7 +192,6 @@ public:
 	// pixel-size-related functions
 	// the GenICam spec and the JAI sdk have no way to query sensor pixel size.
 	double GetNominalPixelSizeUm() const {return 1.0;}
-	double GetPixelSizeUm() const {return 1.0 * GetBinning();}
 
 	// action interface
 	// ----------------

--- a/DeviceAdapters/GigECamera/GigECamera.h
+++ b/DeviceAdapters/GigECamera/GigECamera.h
@@ -189,10 +189,6 @@ public:
 	int StopSequenceAcquisition();
 	bool IsCapturing();
 
-	// pixel-size-related functions
-	// the GenICam spec and the JAI sdk have no way to query sensor pixel size.
-	double GetNominalPixelSizeUm() const {return 1.0;}
-
 	// action interface
 	// ----------------
 	int OnCameraChoice( MM::PropertyBase* pProp, MM::ActionType eAct );

--- a/DeviceAdapters/IDSPeak/IDSPeak.cpp
+++ b/DeviceAdapters/IDSPeak/IDSPeak.cpp
@@ -42,7 +42,6 @@
 #include <ids_peak_comfort_c/ids_peak_comfort_c.h>
 
 using namespace std;
-const double CIDSPeak::nominalPixelSizeUm_ = 1.0;
 double g_IntensityFactor_ = 1.0;
 const char* g_PixelType_8bit = "8bit";
 const char* g_PixelType_16bit = "16bit";

--- a/DeviceAdapters/IDSPeak/IDSPeak.h
+++ b/DeviceAdapters/IDSPeak/IDSPeak.h
@@ -159,7 +159,6 @@ public:
     int RunSequenceOnThread();
     bool IsCapturing();
     void OnThreadExiting() throw();
-    double GetNominalPixelSizeUm() const { return nominalPixelSizeUm_; }
     int GetBinning() const;
     int SetBinning(int bS);
 
@@ -233,8 +232,6 @@ private:
     int SetAllowedBinning();
     void GenerateEmptyImage(ImgBuffer& img);
     int ResizeImageBuffer();
-
-    static const double nominalPixelSizeUm_;
 
     bool enableTemp_ = false;
     bool enableAnalogGain_ = false;

--- a/DeviceAdapters/IDSPeak/IDSPeak.h
+++ b/DeviceAdapters/IDSPeak/IDSPeak.h
@@ -160,7 +160,6 @@ public:
     bool IsCapturing();
     void OnThreadExiting() throw();
     double GetNominalPixelSizeUm() const { return nominalPixelSizeUm_; }
-    double GetPixelSizeUm() const { return nominalPixelSizeUm_ * GetBinning(); }
     int GetBinning() const;
     int SetBinning(int bS);
 

--- a/DeviceAdapters/IDS_uEye/IDS_uEye.h
+++ b/DeviceAdapters/IDS_uEye/IDS_uEye.h
@@ -270,9 +270,6 @@ class CIDS_uEye : public CCameraBase<CIDS_uEye>
   bool IsCapturing();
   void OnThreadExiting() throw(); 
 
-  double GetNominalPixelSizeUm() const 
-  {return nominalPixelSizeUm_;}
-
   int GetBinning() const;
   int SetBinning(int bS);
   int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}

--- a/DeviceAdapters/IDS_uEye/IDS_uEye.h
+++ b/DeviceAdapters/IDS_uEye/IDS_uEye.h
@@ -273,9 +273,6 @@ class CIDS_uEye : public CCameraBase<CIDS_uEye>
   double GetNominalPixelSizeUm() const 
   {return nominalPixelSizeUm_;}
 
-  double GetPixelSizeUm() const 
-  {return nominalPixelSizeUm_ * GetBinning();}
-
   int GetBinning() const;
   int SetBinning(int bS);
   int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}

--- a/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.cpp
+++ b/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.cpp
@@ -38,7 +38,6 @@
 
 
 using namespace std;
-const double CMightex_BUF_USBCCDCamera::nominalPixelSizeUm_ = 1.0;
 double g_IntensityFactor_ = 1.0;
 int OnExposureCnt = 0;
 //CMightex_BUF_USBCCDCamera *gMyCamera;

--- a/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.h
+++ b/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.h
@@ -97,7 +97,6 @@ public:
    int ThreadRun(MM::MMTime startTime);
    bool IsCapturing();
    void OnThreadExiting() throw(); 
-   double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
    int GetBinning() const;
    int SetBinning(int bS);
 
@@ -152,8 +151,6 @@ private:
    void TestResourceLocking(const bool);
    void GenerateEmptyImage(ImgBuffer& img);
    int ResizeImageBuffer();
-
-   static const double nominalPixelSizeUm_;
 
    double dPhase_;
    ImgBuffer img_;

--- a/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.h
+++ b/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.h
@@ -98,7 +98,6 @@ public:
    bool IsCapturing();
    void OnThreadExiting() throw(); 
    double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-   double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
    int GetBinning() const;
    int SetBinning(int bS);
 

--- a/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.cpp
+++ b/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.cpp
@@ -38,7 +38,6 @@
 
 
 using namespace std;
-const double CMightex_SB_Camera::nominalPixelSizeUm_ = 1.0;
 double g_IntensityFactor_ = 1.0;
 int OnExposureCnt = 0;
 

--- a/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.h
+++ b/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.h
@@ -97,7 +97,6 @@ public:
    int ThreadRun(MM::MMTime startTime);
    bool IsCapturing();
    void OnThreadExiting() throw(); 
-   double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
    int GetBinning() const;
    int SetBinning(int bS);
 
@@ -137,8 +136,6 @@ private:
    void TestResourceLocking(const bool);
    void GenerateEmptyImage(ImgBuffer& img);
    int ResizeImageBuffer();
-
-   static const double nominalPixelSizeUm_;
 
    double dPhase_;
    ImgBuffer img_;

--- a/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.h
+++ b/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.h
@@ -98,7 +98,6 @@ public:
    bool IsCapturing();
    void OnThreadExiting() throw(); 
    double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-   double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
    int GetBinning() const;
    int SetBinning(int bS);
 

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
@@ -42,9 +42,6 @@ using namespace std;
 CvCapture* capture_;
 IplImage* frame_; // do not modify, do not release!
 
-const double COpenCVgrabber::nominalPixelSizeUm_ = 1.0;
-
-
 // External names used used by the rest of the system
 // to load particular device from the "DemoCamera.dll" library
 const char* g_CameraDeviceName = "OpenCVgrabber";

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.h
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.h
@@ -110,7 +110,6 @@ public:
    int ThreadRun();
    bool IsCapturing();
    void OnThreadExiting() throw(); 
-   double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
    int GetBinning() const;
    int SetBinning(int bS);
    int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}
@@ -143,9 +142,6 @@ private:
    void RGB3toRGB4(const char* srcPixels, char* destPixels, int width, int height);
 
    int ResizeImageBuffer();
-
-   static const double nominalPixelSizeUm_;
-
 
    // CvCapture* capture_;
    // IplImage* frame_; // do not modify, do not release!

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.h
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.h
@@ -111,7 +111,6 @@ public:
    bool IsCapturing();
    void OnThreadExiting() throw(); 
    double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-   double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
    int GetBinning() const;
    int SetBinning(int bS);
    int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}

--- a/DeviceAdapters/Piper/CameraAdapter.cpp
+++ b/DeviceAdapters/Piper/CameraAdapter.cpp
@@ -183,8 +183,6 @@ void CALLBACK PipeCallback( INT16 /*nPipe*/, INT16 nCmd, LPVOID pvCam, LPVOID ap
    }
 }
 
-const double CCameraAdapter::nominalPixelSizeUm_ = 1.0;
-
 // Local property names
 static LPCTSTR sc_pszPropFrameGrabber = "CameraID-FrameGrabber";
 static LPCTSTR sc_pszPropCameraName = "CameraID-Name";

--- a/DeviceAdapters/Piper/CameraAdapter.h
+++ b/DeviceAdapters/Piper/CameraAdapter.h
@@ -102,7 +102,6 @@ public:
    virtual int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    virtual int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    virtual int ClearROI();
-   virtual double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
    virtual int GetBinning() const;
    virtual int SetBinning(int binSize);
    virtual bool IsCapturing();
@@ -158,8 +157,6 @@ public:
    int OnReadoutTime(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
-   static const double nominalPixelSizeUm_;
-
    string m_sMyName;
    BOOL m_bIsConnected;
    bool m_bIsInitialized;

--- a/DeviceAdapters/Piper/CameraAdapter.h
+++ b/DeviceAdapters/Piper/CameraAdapter.h
@@ -103,7 +103,6 @@ public:
    virtual int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    virtual int ClearROI();
    virtual double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-   virtual double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
    virtual int GetBinning() const;
    virtual int SetBinning(int binSize);
    virtual bool IsCapturing();

--- a/DeviceAdapters/PlayerOne/POACamera.cpp
+++ b/DeviceAdapters/PlayerOne/POACamera.cpp
@@ -192,7 +192,6 @@ POACamera::POACamera() :
     gammaValue_(g_gamma_def),
     p8bitGammaTable(nullptr),
     p16bitGammaTable(nullptr),
-    nominalPixelSizeUm_(1.0),
     pRGB24(nullptr),
     RGB24BufSize_(0),
     readoutUs_(0.0),
@@ -380,8 +379,6 @@ int POACamera::Initialize()
     p8bitGammaTable = new unsigned char[256];
     p16bitGammaTable = new unsigned short[65536];
     ResetGammaTable();
-
-    nominalPixelSizeUm_ = camProp_.pixelSize;
 
     char* pCameraName = camProp_.cameraModelName;
 

--- a/DeviceAdapters/PlayerOne/POACamera.h
+++ b/DeviceAdapters/PlayerOne/POACamera.h
@@ -113,7 +113,6 @@ public:
     int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
     int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
     int ClearROI();
-    double GetNominalPixelSizeUm() const { return nominalPixelSizeUm_; }
     int GetBinning() const;
     int SetBinning(int bS);
 
@@ -216,7 +215,6 @@ private:
     double gammaValue_;
     unsigned char *p8bitGammaTable;
     unsigned short *p16bitGammaTable;
-    double nominalPixelSizeUm_;
     double exposureMaximum_;
     ImgBuffer img_;
     double ccdT_;

--- a/DeviceAdapters/PlayerOne/POACamera.h
+++ b/DeviceAdapters/PlayerOne/POACamera.h
@@ -114,7 +114,6 @@ public:
     int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
     int ClearROI();
     double GetNominalPixelSizeUm() const { return nominalPixelSizeUm_; }
-    double GetPixelSizeUm() const { return nominalPixelSizeUm_ * GetBinning(); }
     int GetBinning() const;
     int SetBinning(int bS);
 

--- a/DeviceAdapters/QSI/QSICameraAdapter.cpp
+++ b/DeviceAdapters/QSI/QSICameraAdapter.cpp
@@ -585,15 +585,6 @@ unsigned int QSICameraAdapter::GetImageWidth() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-double QSICameraAdapter::GetPixelSizeUm() const
-{
-  if( m_pixelSizeX == m_pixelSizeY )
-    return m_pixelSizeX;
-  else
-    return 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
 // Returns the actual dimensions of the current ROI.
 //
 int QSICameraAdapter::GetROI( unsigned int & x, unsigned int & y, unsigned int & xSize, unsigned int & ySize )

--- a/DeviceAdapters/QSI/QSICameraAdapter.h
+++ b/DeviceAdapters/QSI/QSICameraAdapter.h
@@ -51,7 +51,6 @@ public:
   unsigned int GetImageBytesPerPixel() const;
   unsigned int GetImageHeight() const;
   unsigned int GetImageWidth() const;
-  double GetPixelSizeUm() const;
   int GetROI( unsigned int & x, unsigned int & y, unsigned int & xSize, unsigned int & ySize ); 
   int InsertImage();
   int IsExposureSequenceable( bool & seq ) const;

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
@@ -91,7 +91,6 @@
 #undef DOLIVEPAIR
 
 using namespace std;
-const double CRaptorEPIX::nominalPixelSizeUm_ = 1.0;
 double g_IntensityFactor_ = 1.0;
 bool bEagle4210 = false;
 

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.h
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.h
@@ -201,7 +201,6 @@ public:
    bool IsCapturing();
    void OnThreadExiting() throw(); 
    double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-   double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
    int GetBinning() const;
    int SetBinning(int bS);
    int GetBinningX() const;

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.h
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.h
@@ -200,7 +200,6 @@ public:
    int ThreadRun();
    bool IsCapturing();
    void OnThreadExiting() throw(); 
-   double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
    int GetBinning() const;
    int SetBinning(int bS);
    int GetBinningX() const;
@@ -424,8 +423,6 @@ private:
            
 
    //int serialWriteReadCmd(int unit, unsigned char* bufin, int insize, unsigned char* bufout, int outsize );
-
-   static const double nominalPixelSizeUm_;
 
    int cameraType_;
    double dPhase_;

--- a/DeviceAdapters/Revealer/MMSCCam.cpp
+++ b/DeviceAdapters/Revealer/MMSCCam.cpp
@@ -13,8 +13,6 @@
 #include "SCDefines.h"
 
 
-const double SCCamera::nominalPixelSizeUm_ = 1.0;
-
 const char* gCameraDeviceName  = "Revealer";
 const char* g_PixelType_8bit = "8bit";
 const char* g_PixelType_16bit = "16bit";
@@ -723,10 +721,6 @@ bool SCCamera::IsCapturing(){
     msg << "IsCapturing" << ":" << !thd_->IsStopped();
     LogMessage(msg.str().c_str());
     return !thd_->IsStopped(); 
-}
-
-double SCCamera::GetNominalPixelSizeUm() const{
-    return nominalPixelSizeUm_;
 }
 
 int SCCamera::GetBinning() const {

--- a/DeviceAdapters/Revealer/MMSCCam.cpp
+++ b/DeviceAdapters/Revealer/MMSCCam.cpp
@@ -729,10 +729,6 @@ double SCCamera::GetNominalPixelSizeUm() const{
     return nominalPixelSizeUm_;
 }
 
-double SCCamera::GetPixelSizeUm() const { 
-    return nominalPixelSizeUm_ * GetBinning();
-}
-
 int SCCamera::GetBinning() const {
     uint64_t binning = 0;
     SC_GetEnumFeatureValue(devHandle_, "BinningMode", &binning);

--- a/DeviceAdapters/Revealer/MMSCCam.h
+++ b/DeviceAdapters/Revealer/MMSCCam.h
@@ -70,7 +70,6 @@ public:
     int RunSequenceOnThread(MM::MMTime startTime);
     bool IsCapturing();
     void OnThreadExiting() throw(); 
-    double GetNominalPixelSizeUm() const;
     int GetBinning() const;
     int SetBinning(int bS);
 
@@ -113,7 +112,6 @@ public:
 	};
 
 private:
-    static const double nominalPixelSizeUm_;
     int32_t insertCount_ = 0;
 
     bool initialized_ = false;

--- a/DeviceAdapters/Revealer/MMSCCam.h
+++ b/DeviceAdapters/Revealer/MMSCCam.h
@@ -71,7 +71,6 @@ public:
     bool IsCapturing();
     void OnThreadExiting() throw(); 
     double GetNominalPixelSizeUm() const;
-    double GetPixelSizeUm() const;
     int GetBinning() const;
     int SetBinning(int bS);
 

--- a/DeviceAdapters/SimpleCam/CameraFrontend.h
+++ b/DeviceAdapters/SimpleCam/CameraFrontend.h
@@ -90,7 +90,6 @@ public:
    int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize); 
    int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize); 
    int ClearROI();
-   double GetPixelSizeUm() const {return GetBinning();}
    int GetBinning() const;
    int SetBinning(int binSize);
 

--- a/DeviceAdapters/Spot/SpotCamera.cpp
+++ b/DeviceAdapters/Spot/SpotCamera.cpp
@@ -83,8 +83,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 // SpotCamera device adapter
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-//const double SpotCamera::fNominalPixelSizeUm = 1.0;
-
 /**
  * SpotCamera constructor.
  * Setup default all variables and create device properties required to exist

--- a/DeviceAdapters/TISCam/TIScamera.h
+++ b/DeviceAdapters/TISCam/TIScamera.h
@@ -91,7 +91,6 @@ long     GetImageBufferSize() const;
 unsigned GetBitDepth() const;
 
     unsigned GetNumberOfComponents() const;
-	double GetPixelSizeUm() const {return 1.0 * GetBinning();};
 	int GetBinning() const;
 	int SetBinning(int binSize);
    int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}

--- a/DeviceAdapters/TUCam/MMTUCam.cpp
+++ b/DeviceAdapters/TUCam/MMTUCam.cpp
@@ -37,7 +37,6 @@
 #pragma comment(lib, "shlwapi.lib")
 
 using namespace std;
-const double CMMTUCam::nominalPixelSizeUm_ = 1.0;
 double g_IntensityFactor_ = 1.0;
 
 // External names used used by the rest of the system

--- a/DeviceAdapters/TUCam/MMTUCam.h
+++ b/DeviceAdapters/TUCam/MMTUCam.h
@@ -236,7 +236,6 @@ public:
     bool IsCapturing();
     void OnThreadExiting() throw(); 
     double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-    double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
     int GetBinning() const;
     int SetBinning(int bS);
 

--- a/DeviceAdapters/TUCam/MMTUCam.h
+++ b/DeviceAdapters/TUCam/MMTUCam.h
@@ -235,7 +235,6 @@ public:
     int RunSequenceOnThread(MM::MMTime startTime);
     bool IsCapturing();
     void OnThreadExiting() throw(); 
-    double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
     int GetBinning() const;
     int SetBinning(int bS);
 
@@ -382,8 +381,6 @@ private:
 	bool IsSupport201DNew()     { return DHYANA_201D     == m_nPID && m_nBCD >= 0x2000; }
 	bool IsSupport400BSIV3New() { return DHYANA_400BSIV3 == m_nPID && m_nBCD >= 0x2000; }
 	bool IsSupportAries16()     { return 0xE424 == m_nPID || 0xE425 == m_nPID; }
-
-    static const double nominalPixelSizeUm_;
 
     double exposureMaximum_;
     double exposureMinimum_;

--- a/DeviceAdapters/TwainCamera/TwainCamera.cpp
+++ b/DeviceAdapters/TwainCamera/TwainCamera.cpp
@@ -33,7 +33,6 @@
 using namespace std;
 int TwainCamera::imageSizeW_ = 512;
 int TwainCamera::imageSizeH_ = 512;
-const double TwainCamera::nominalPixelSizeUm_ = 1.0;
 
 const char* g_CameraDeviceName = "TwainCam";
 #define ThisCameraType TwainCamera

--- a/DeviceAdapters/TwainCamera/TwainCamera.h
+++ b/DeviceAdapters/TwainCamera/TwainCamera.h
@@ -95,7 +95,6 @@ public:
    int ClearROI();
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StopSequenceAcquisition();
-   double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
    int GetBinning() const;
    int SetBinning(int binSize);
    int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}
@@ -132,7 +131,6 @@ private:
    int ThreadRun();
    int PushImage();
 
-   static const double nominalPixelSizeUm_;
    static int imageSizeW_;
    static int imageSizeH_;
 

--- a/DeviceAdapters/TwainCamera/TwainCamera.h
+++ b/DeviceAdapters/TwainCamera/TwainCamera.h
@@ -96,7 +96,6 @@ public:
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StopSequenceAcquisition();
    double GetNominalPixelSizeUm() const {return nominalPixelSizeUm_;}
-   double GetPixelSizeUm() const {return nominalPixelSizeUm_ * GetBinning();}
    int GetBinning() const;
    int SetBinning(int binSize);
    int IsExposureSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}

--- a/MMCore/Devices/CameraInstance.cpp
+++ b/MMCore/Devices/CameraInstance.cpp
@@ -54,7 +54,6 @@ unsigned CameraInstance::GetImageWidth() const { RequireInitialized(__func__); r
 unsigned CameraInstance::GetImageHeight() const { RequireInitialized(__func__); return GetImpl()->GetImageHeight(); }
 unsigned CameraInstance::GetImageBytesPerPixel() const { RequireInitialized(__func__); return GetImpl()->GetImageBytesPerPixel(); }
 unsigned CameraInstance::GetBitDepth() const { RequireInitialized(__func__); return GetImpl()->GetBitDepth(); }
-double CameraInstance::GetPixelSizeUm() const { RequireInitialized(__func__); return GetImpl()->GetPixelSizeUm(); }
 int CameraInstance::GetBinning() const { RequireInitialized(__func__); return GetImpl()->GetBinning(); }
 int CameraInstance::SetBinning(int binSize) { RequireInitialized(__func__); return GetImpl()->SetBinning(binSize); }
 void CameraInstance::SetExposure(double exp_ms) { RequireInitialized(__func__); return GetImpl()->SetExposure(exp_ms); }

--- a/MMCore/Devices/CameraInstance.h
+++ b/MMCore/Devices/CameraInstance.h
@@ -49,7 +49,6 @@ public:
    unsigned GetImageHeight() const;
    unsigned GetImageBytesPerPixel() const;
    unsigned GetBitDepth() const;
-   double GetPixelSizeUm() const;
    int GetBinning() const;
    int SetBinning(int binSize);
    void SetExposure(double exp_ms);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -5585,27 +5585,29 @@ std::string CMMCore::getCurrentPixelSizeConfig(bool cached) MMCORE_LEGACY_THROW(
       for (size_t j=0; j < cfgData->size(); j++)
       {
          PropertySetting cs = cfgData->getSetting(j); // config setting
-         if (!curState.isPropertyIncluded(cs.getDeviceLabel().c_str(), cs.getPropertyName().c_str()))
+         const auto deviceLabel = cs.getDeviceLabel();
+         const auto propName = cs.getPropertyName();
+         if (!curState.isPropertyIncluded(deviceLabel.c_str(), propName.c_str()))
          {
             try
             {
-				std::string value;
-				if (!cached)
-				{
-                   value = getProperty(cs.getDeviceLabel().c_str(), cs.getPropertyName().c_str());
-				}
-				else
-				{
-               MMThreadGuard scg(stateCacheLock_);
-               value = stateCache_.getSetting(cs.getDeviceLabel().c_str(), cs.getPropertyName().c_str()).getPropertyValue();
-				}
-               PropertySetting ss(cs.getDeviceLabel().c_str(), cs.getPropertyName().c_str(), value.c_str()); // state setting
+               std::string value;
+               if (!cached)
+               {
+                  value = getProperty(deviceLabel.c_str(), propName.c_str());
+               }
+               else
+               {
+                  MMThreadGuard scg(stateCacheLock_);
+                  value = stateCache_.getSetting(deviceLabel.c_str(), propName.c_str()).getPropertyValue();
+               }
+               PropertySetting ss(deviceLabel.c_str(), propName.c_str(), value.c_str()); // state setting
                curState.addSetting(ss);
             }
             catch (CMMError& err)
             {
                // just log error
-               logError("GetPixelSizeUm", err.getMsg().c_str());
+               logError(deviceLabel.c_str(), err.getMsg().c_str());
             }
          }
       }
@@ -5769,7 +5771,7 @@ std::vector<double> CMMCore::getPixelSizeAffineByID(const char* resolutionID) MM
 
 /**
  * Returns the product of all Magnifiers in the system or 1.0 when none is found
- * This is used internally by GetPixelSizeUm
+ * This is used internally by getPixelSizeUm
  *
  * @return products of all magnifier devices in the system or 1.0 when none is found
  */

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1322,11 +1322,9 @@ public:
    */
    virtual int StopSequenceAcquisition() = 0;
 
-   /**
-    * Returns binnings factor.  Used to calculate current pixelsize
-    * Not appropriately named.
-    */
-   virtual double GetPixelSizeUm() const {return this->GetBinning();}
+   // It appears that this function was never used by MMCore and is slated for
+   // removal. Concrete cameras should not override.
+   double GetPixelSizeUm() const final { return 0.0; }
 
    virtual unsigned GetNumberOfComponents() const
    {

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -409,8 +409,7 @@ namespace MM {
        */
       virtual unsigned GetBitDepth() const = 0;
       /**
-       * Returns binnings factor.  Used to calculate current pixelsize
-       * Not appropriately named.  Implemented in DeviceBase.h
+       * Unused and slated for removal. Implemented in DeviceBase.h.
        */
       virtual double GetPixelSizeUm() const = 0;
       /**


### PR DESCRIPTION
This is in preparation for #596.

Remove overrides of `MM::Camera::GetPixelSizeUm()` (a function that is never called by MMCore and never was since at least 2007) from concrete cameras. Also prevent accidental re-introduction by declaring `CCameraBase`'s (now empty) implementation `final`.

Also remove a related function `GetNominalPixelSizeUm()`, which is *not* in `MM::Camera` but was present in many cameras -- likely by copy-paste -- including DemoCamera.

None of these functions were ever called or callable, so this just removes dead code.

Does not change the device interface yet, but prepares us for removing `GetPixelSizeUm()` from the interface.