### PR TITLE
Miscellaneous cleanup for CCameraBase

### DIFF
--- a/DeviceAdapters/ASIWPTR/wptr.cpp
+++ b/DeviceAdapters/ASIWPTR/wptr.cpp
@@ -70,7 +70,6 @@ int ClearPort(MM::Device& device, MM::Core& core, const std::string& port) {
 }
 
 WPTRobot::WPTRobot() :
-    CGenericBase<WPTRobot>(),
     initialized_(false),
     numPos_(0),
     port_(""),

--- a/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
+++ b/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
@@ -137,7 +137,7 @@ MODULE_API void DeleteDevice(MM::Device * pDevice)
 * perform most of the initialization in the Initialize() method.
 */
 CAndorSDK3Camera::CAndorSDK3Camera()
-: CCameraBase<CAndorSDK3Camera> (),
+:
   deviceManager(NULL),
   cameraDevice(NULL),
   bufferControl(NULL),

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -112,7 +112,6 @@ stream_callback (void *user_data, ArvStreamCallbackType type, ArvBuffer *arv_buf
  * Camera class and methods.
  */
 AravisCamera::AravisCamera(const char *name) :
-  CCameraBase<AravisCamera>(),
   capturing(false),
   counter(0),
   exposure_time(0.0),

--- a/DeviceAdapters/Basler/BaslerPylonCamera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylonCamera.cpp
@@ -147,7 +147,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 * Constructor.
 */
 BaslerCamera::BaslerCamera() :
-	CCameraBase<BaslerCamera>(),
 	maxWidth_(0),
 	maxHeight_(0),
 	exposure_us_(0),

--- a/DeviceAdapters/CNCMicroscope/RAMPSStage/XYStage.cpp
+++ b/DeviceAdapters/CNCMicroscope/RAMPSStage/XYStage.cpp
@@ -28,7 +28,6 @@ const char* g_StepSizeProp = "Step Size";
 // ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 RAMPSXYStage::RAMPSXYStage() :
-    CXYStageBase<RAMPSXYStage>(),
     stepSize_um_(0.025),
     posX_um_(0.0),
     posY_um_(0.0),

--- a/DeviceAdapters/Conix/Conix.cpp
+++ b/DeviceAdapters/Conix/Conix.cpp
@@ -539,7 +539,6 @@ int HexaFluor::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 // ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ConixXYStage::ConixXYStage() : 
-CXYStageBase<ConixXYStage>(),
 port_("Undefined"),
 stepSize_um_(0.015),
 posX_um_(0.0),
@@ -890,7 +889,6 @@ int ConixXYStage::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct)
 // ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ConixZStage::ConixZStage() : 
-CStageBase<ConixZStage>(),
 port_("Undefined"),
 stepSize_um_(0.1),
 posZ_um_(0.0),

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
@@ -52,7 +52,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 }
 
 ClassGalaxy::ClassGalaxy() :
-    CCameraBase<ClassGalaxy>(),
         ImageHandler_(0),
         Width_(0),
         Height_(0),

--- a/DeviceAdapters/ESP32/esp32.cpp
+++ b/DeviceAdapters/ESP32/esp32.cpp
@@ -1758,7 +1758,7 @@ bool CESP32Stage::Busy()
     return false;
 }
 
-CESP32XYStage::CESP32XYStage() : CXYStageBase<CESP32XYStage>(),
+CESP32XYStage::CESP32XYStage() :
 stepSize_X_um_(0.1),
 stepSize_Y_um_(0.1),
 posX_um_(0.0),

--- a/DeviceAdapters/Hikrobot/HikrobotCamera.cpp
+++ b/DeviceAdapters/Hikrobot/HikrobotCamera.cpp
@@ -84,7 +84,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 * Constructor.
 */
 HikrobotCamera::HikrobotCamera() :
-	CCameraBase<HikrobotCamera>(),
 	maxWidth_(0),
 	maxHeight_(0),
 	exposure_us_(0),

--- a/DeviceAdapters/IDSPeak/IDSPeak.cpp
+++ b/DeviceAdapters/IDSPeak/IDSPeak.cpp
@@ -363,7 +363,6 @@ bool IDSPeakHub::Busy()
 * perform most of the initialization in the Initialize() method.
 */
 CIDSPeak::CIDSPeak(int idx) :
-    CCameraBase<CIDSPeak>(),
     initialized_(false),
     readoutUs_(0.0),
     bitDepth_(8),

--- a/DeviceAdapters/IDS_uEye/IDS_uEye.cpp
+++ b/DeviceAdapters/IDS_uEye/IDS_uEye.cpp
@@ -138,7 +138,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 * perform most of the initialization in the Initialize() method.
 */
 CIDS_uEye::CIDS_uEye() :
-   CCameraBase<CIDS_uEye> (),
    dPhase_(0),
    initialized_(false),
    readoutUs_(0.0),

--- a/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
@@ -1568,7 +1568,6 @@ int ZDrive::OnSpeed(MM::PropertyBase* pProp, MM::ActionType eAct)
  * LeicaXYStage: Micro-Manager implementation of X and Y Stage
 */
 XYStage::XYStage (): 
-   CXYStageBase<XYStage>(),
    initialized_ (false),
    originXSteps_(0),
    originYSteps_(0)

--- a/DeviceAdapters/LeicaDMSTC/LeicaDMSTC.cpp
+++ b/DeviceAdapters/LeicaDMSTC/LeicaDMSTC.cpp
@@ -183,7 +183,6 @@ int Hub::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct)
 // LeicaDMSTC XYStage 
 ///////////////////////////////////////////////////////////////////////////////
 XYStage::XYStage () :
-	CXYStageBase<XYStage>(),
 	initialized_ (false),
 	stepSize_um_(10),	
    name_ (g_LeicaDMSTCXYDrive)

--- a/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.cpp
+++ b/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.cpp
@@ -610,7 +610,6 @@ int CMightex_BUF_USBCCDCamera::GetCameraBufferCount(int width, int height)
 * perform most of the initialization in the Initialize() method.
 */
 CMightex_BUF_USBCCDCamera::CMightex_BUF_USBCCDCamera() :
-   CCameraBase<CMightex_BUF_USBCCDCamera> (),
    dPhase_(0),
    initialized_(false),
    readoutUs_(0.0),

--- a/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.cpp
+++ b/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.cpp
@@ -404,7 +404,6 @@ int CMightex_SB_Camera::GetCameraBufferCount(int width, int height)
 * perform most of the initialization in the Initialize() method.
 */
 CMightex_SB_Camera::CMightex_SB_Camera() :
-   CCameraBase<CMightex_SB_Camera> (),
    dPhase_(0),
    initialized_(false),
    readoutUs_(0.0),

--- a/DeviceAdapters/NikonKs/NikonKsCam.cpp
+++ b/DeviceAdapters/NikonKs/NikonKsCam.cpp
@@ -170,7 +170,6 @@ void NikonKsCam::DoEvent(const lx_uint32 eventCameraHandle, CAM_Event* pEvent, v
 * perform most of the initialization in the Initialize() method.
 */
 NikonKsCam::NikonKsCam() :
-    CCameraBase<NikonKsCam>(),
     featureDesc_(NULL),
     isOpened_(false),
     isInitialized_(false),

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
@@ -138,7 +138,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 * perform most of the initialization in the Initialize() method.
 */
 COpenCVgrabber::COpenCVgrabber() :
-   CCameraBase<COpenCVgrabber> (),
    cameraID_(0),
    initialized_(false),
    readoutUs_(0.0),

--- a/DeviceAdapters/PIEZOCONCEPT/PIEZOCONCEPT.cpp
+++ b/DeviceAdapters/PIEZOCONCEPT/PIEZOCONCEPT.cpp
@@ -531,7 +531,7 @@ bool CPiezoConceptStage::Busy()
 }
 
 
-CPiezoConceptXYStage::CPiezoConceptXYStage() : CXYStageBase<CPiezoConceptXYStage>(),
+CPiezoConceptXYStage::CPiezoConceptXYStage() :
 stepSize_X_um_(0.1),
 stepSize_Y_um_(0.1),
 posX_um_(0.0),

--- a/DeviceAdapters/PI_GCS_2/PIXYStage.cpp
+++ b/DeviceAdapters/PI_GCS_2/PIXYStage.cpp
@@ -52,8 +52,7 @@ const char* g_PI_XYStageAlternativeHomingCommandYAxis = "Axis Y: Alternative Hom
 // PIXYStage
 
 PIXYStage::PIXYStage ()
-   : CXYStageBase<PIXYStage> ()
-   , axisXName_ ("1")
+   : axisXName_ ("1")
    , axisXStageType_ ("")
    , axisXHomingMode_ ("REF")
    , axisYName_ ("2")

--- a/DeviceAdapters/PlayerOne/POACamera.cpp
+++ b/DeviceAdapters/PlayerOne/POACamera.cpp
@@ -179,7 +179,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 * perform most of the initialization in the Initialize() method.
 */
 POACamera::POACamera() :
-    CCameraBase<POACamera>(),
     exposureMaximum_(2000000.0),
     initialized_(false),
     roiX_(0),

--- a/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
@@ -128,7 +128,6 @@ const int n_param = sizeof(param_set)/sizeof(SParam);
 ///////////////////////////////////////////////////////////////////////////////
 // &Universal constructor/destructor
 Universal::Universal(short cameraId) :
-CCameraBase<Universal> (),
 restart_(false),
 initialized_(false),
 busy_(false),

--- a/DeviceAdapters/Prior/Prior.cpp
+++ b/DeviceAdapters/Prior/Prior.cpp
@@ -778,7 +778,6 @@ int Wheel::OnSpeed(MM::PropertyBase* /*pProp*/, MM::ActionType /*eAct*/)
 // XYStage
 //
 XYStage::XYStage() :
-   CXYStageBase<XYStage>(),
    initialized_(false), 
    port_("Undefined"), 
    stepSizeXUm_(0.0), 

--- a/DeviceAdapters/PriorLegacy/PriorLegacy.cpp
+++ b/DeviceAdapters/PriorLegacy/PriorLegacy.cpp
@@ -97,7 +97,6 @@ int ClearPort(MM::Device& device, MM::Core& core, std::string port)
 // XYStageH128
 //
 XYStage::XYStage() : // LIN 01/01/2012 DIDN'T RENAME FUNCTION. ASSUMING MMCORE WILL EXPECT TO CALL ON XYStage()
-   CXYStageBase<XYStage>(),
    initialized_(false), 
    port_("Undefined"), 
    stepSizeXUm_(0.1), // LIN 01/02/2012 changed initial value from 0.0 to 0.1

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
@@ -912,7 +912,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 * perform most of the initialization in the Initialize() method.
 */
 CRaptorEPIX::CRaptorEPIX(int nCameraType) :
-   CCameraBase<CRaptorEPIX> (),
    cameraType_(0),
    dPhase_(0),
    exposure_(0),

--- a/DeviceAdapters/Revealer/MMSCCam.cpp
+++ b/DeviceAdapters/Revealer/MMSCCam.cpp
@@ -127,7 +127,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 * perform most of the initialization in the Initialize() method.
 */
 SCCamera::SCCamera() :
-    CCameraBase<SCCamera> (),
     insertCount_(0),
     initialized_(false),
     devHandle_(nullptr),

--- a/DeviceAdapters/Scientifica/Scientifica.cpp
+++ b/DeviceAdapters/Scientifica/Scientifica.cpp
@@ -94,7 +94,6 @@ int ClearPort(MM::Device& device, MM::Core& core, std::string port)
 // XYStage
 //
 XYStage::XYStage() :
-   CXYStageBase<XYStage>(),
    initialized_(false), 
    port_("Undefined"), 
    stepSizeXUm_(0.1), 

--- a/DeviceAdapters/Sensicam/Sensicam.cpp
+++ b/DeviceAdapters/Sensicam/Sensicam.cpp
@@ -80,7 +80,6 @@ MODULE_API MM::Device* CreateDevice(const char* pszDeviceName)
 // CSensicam constructor/destructor
 
 CSensicam::CSensicam() :
-   CCameraBase<CSensicam> (),
    sequenceRunning_(false),
    m_bInitialized(false),
    m_bBusy(false),

--- a/DeviceAdapters/SigmaKoki/Camera.cpp
+++ b/DeviceAdapters/SigmaKoki/Camera.cpp
@@ -118,7 +118,6 @@ int ClearPort(MM::Device& device, MM::Core& core, std::string port)
 Camera::Camera() :
 	// initialization of parameters
 	SigmaBase(this),
-	CCameraBase<Camera>(),
 	initialized_(false),
 	isMonochrome_(false),
 	enabledROI_(false),

--- a/DeviceAdapters/Spot/SpotCamera.cpp
+++ b/DeviceAdapters/Spot/SpotCamera.cpp
@@ -95,7 +95,7 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
  * the constructor. We should do as little as possible in the constructor and
  * perform most of the initialization in the Initialize() method.
  */
-SpotCamera::SpotCamera(const char* /*szDeviceName*/) : CCameraBase<SpotCamera>(),
+SpotCamera::SpotCamera(const char* /*szDeviceName*/) :
    initialized( false ),   
    numberOfChannels_( 4 ), // EF - changed to 4 for valid number for MMImageWindow, line 125ff, byteDepth = 4
 	pImplementation_(NULL),

--- a/DeviceAdapters/StandaStage/StandaStage.cpp
+++ b/DeviceAdapters/StandaStage/StandaStage.cpp
@@ -614,7 +614,6 @@ int CStandaStage::OnStageMaxPos(MM::PropertyBase* pProp, MM::ActionType eAct)
 // ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 CStandaXYStage::CStandaXYStage() : 
-CXYStageBase<CStandaXYStage>(),
 stepSize_X_um_(0.015),
 stepSize_Y_um_(0.015),
 stepsPerSecond_(2000.0),

--- a/DeviceAdapters/TISCam/TIScamera.cpp
+++ b/DeviceAdapters/TISCam/TIScamera.cpp
@@ -155,7 +155,7 @@ As a general guideline Micro-Manager devices do not access hardware in the
 the constructor. We should do as little as possible in the constructor and
 perform most of the initialization in the Initialize() method.
 ==============================================================================*/
-CTIScamera::CTIScamera() : CCameraBase<CTIScamera> (),
+CTIScamera::CTIScamera() :
    initialized_(false),
 
    pSelectDevice(NULL),

--- a/DeviceAdapters/TUCam/MMTUCam.cpp
+++ b/DeviceAdapters/TUCam/MMTUCam.cpp
@@ -251,7 +251,6 @@ int CMMTUCam::s_nCntCam  = 0;
 * perform most of the initialization in the Initialize() method.
 */
 CMMTUCam::CMMTUCam() :
-    CCameraBase<CMMTUCam> (),
     exposureMaximum_(10000.0),     
     exposureMinimum_(0.0),
     dPhase_(0),

--- a/DeviceAdapters/Thorlabs/XYStage.cpp
+++ b/DeviceAdapters/Thorlabs/XYStage.cpp
@@ -129,7 +129,6 @@ class XYStage::CommandThread : public MMDeviceThreadBase
 ///////////////////////////////////////////////////////////////////////////////
 
 XYStage::XYStage() :
-   CXYStageBase<XYStage>(),
    initialized_(false),
    home_(false),
    port_("Undefined"), 

--- a/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.cpp
+++ b/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.cpp
@@ -94,7 +94,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 * perform most of the initialization in the Initialize() method.
 */
 ThorlabsUSBCam::ThorlabsUSBCam() :
-   CCameraBase<ThorlabsUSBCam> (),
    initialized_(false),
    bitDepth_(8),
    roiX_(0),

--- a/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
+++ b/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
@@ -101,7 +101,6 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
  * Constructor.
  */
 BitFlowCamera::BitFlowCamera(bool dual) :
-   CCameraBase<BitFlowCamera> (),
    initialized_(false),
    inputChannel_(0),
    expNumFrames_(1),

--- a/DeviceAdapters/WOSM/WOSM.cpp
+++ b/DeviceAdapters/WOSM/WOSM.cpp
@@ -1903,7 +1903,7 @@ bool CWOSMStage::Busy()
     return false;
 }
 
-CWOSMXYStage::CWOSMXYStage() : CXYStageBase<CWOSMXYStage>(),
+CWOSMXYStage::CWOSMXYStage() :
 stepSize_X_um_(0.1),
 stepSize_Y_um_(0.1),
 posX_um_(0.0),

--- a/DeviceAdapters/WOSM/WOSM_rev.cpp
+++ b/DeviceAdapters/WOSM/WOSM_rev.cpp
@@ -1933,7 +1933,7 @@ bool CWOSMStage::Busy()
     return false;
 }
 
-CWOSMXYStage::CWOSMXYStage() : CXYStageBase<CWOSMXYStage>(),
+CWOSMXYStage::CWOSMXYStage() :
 stepSize_X_um_(0.1),
 stepSize_Y_um_(0.1),
 posX_um_(0.0),

--- a/DeviceAdapters/WieneckeSinske/XYStageDevice.cpp
+++ b/DeviceAdapters/WieneckeSinske/XYStageDevice.cpp
@@ -55,7 +55,6 @@ using namespace std;
 // XYStageDeviceDevice
 //
 XYStageDevice::XYStageDevice (): 
-CXYStageBase<XYStageDevice>(),
 	initialized_ (false),
 	stepSize_um_(0.001),
 	can29_(),

--- a/DeviceAdapters/WieneckeSinske/ZPiezoCanDevice.cpp
+++ b/DeviceAdapters/WieneckeSinske/ZPiezoCanDevice.cpp
@@ -47,7 +47,6 @@
 // ZPiezoCANDevice
 //
 ZPiezoCANDevice::ZPiezoCANDevice (): 
-CStageBase<ZPiezoCANDevice>(),
 	initialized_ (false),
 	stepSize_um_(0.001),
 	can29_(),

--- a/DeviceAdapters/WieneckeSinske/ZPiezoWSDevice.cpp
+++ b/DeviceAdapters/WieneckeSinske/ZPiezoWSDevice.cpp
@@ -47,7 +47,6 @@
 // ZPiezoWSDevice
 //
 ZPiezoWSDevice::ZPiezoWSDevice (): 
-CStageBase<ZPiezoWSDevice>(),
 	initialized_ (false),
 	stepSize_um_(0.001),
 	ws_(),

--- a/DeviceAdapters/ZeissAxioZoom/DevicesX.cpp
+++ b/DeviceAdapters/ZeissAxioZoom/DevicesX.cpp
@@ -273,7 +273,6 @@ int MotorFocus::OnVelocity(MM::PropertyBase* pProp, MM::ActionType eAct)
  * ZeissXYStageX: Micro-Manager implementation of X and Y Stage
  */
 XYStageX::XYStageX (): 
-   CXYStageBase<XYStageX>(),
    stepSize_um_(0.001),
    initialized_ (false),
    moveMode_ (0),

--- a/DeviceAdapters/ZeissCAN29/ZeissCAN29.cpp
+++ b/DeviceAdapters/ZeissCAN29/ZeissCAN29.cpp
@@ -1869,7 +1869,6 @@ void Axis::ReportNewPosition(ZeissUByte /* devId */, ZeissLong& position) {
  * ZeissXYStage: Micro-Manager implementation of X and Y Stage
  */
 XYStage::XYStage (): 
-   CXYStageBase<XYStage>(),
    stepSize_um_(0.001),
    initialized_ (false),
    moveMode_ (0),

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1303,11 +1303,6 @@ public:
 
    }
 
-   virtual ~CCameraBase()
-   {
-      
-   }
-
    virtual const unsigned char* GetImageBuffer() = 0;
    virtual unsigned GetImageWidth() const = 0;
    virtual unsigned GetImageHeight() const = 0;

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1278,12 +1278,13 @@ template <class U>
 class CCameraBase : public CDeviceBase<MM::Camera, U>
 {
 public:
-
-   using CDeviceBase<MM::Camera, U>::CreateProperty;
-   using CDeviceBase<MM::Camera, U>::SetAllowedValues;
-   using CDeviceBase<MM::Camera, U>::GetBinning;
+   // These 2 'using' declarations were originally introduced in order to allow
+   // C[Legacy]CameraBase member functions to call these functions (which would
+   // have also been possible with 'this->'). The 2 functions are protected in
+   // CDeviceBase. However, they are made public here, and some concrete
+   // cameras ended up depending on that. So they need to be kept for now,
+   // until and unless such cameras are fixed.
    using CDeviceBase<MM::Camera, U>::GetCoreCallback;
-   using CDeviceBase<MM::Camera, U>::SetProperty;
    using CDeviceBase<MM::Camera, U>::LogMessage;
 
    CCameraBase()
@@ -1292,14 +1293,14 @@ public:
       std::vector<std::string> allowedValues;
       allowedValues.push_back("0");
       allowedValues.push_back("1");
-      CreateProperty(MM::g_Keyword_Transpose_SwapXY, "0", MM::Integer, false);
-      SetAllowedValues(MM::g_Keyword_Transpose_SwapXY, allowedValues);
-      CreateProperty(MM::g_Keyword_Transpose_MirrorX, "0", MM::Integer, false);
-      SetAllowedValues(MM::g_Keyword_Transpose_MirrorX, allowedValues);
-      CreateProperty(MM::g_Keyword_Transpose_MirrorY, "0", MM::Integer, false);
-      SetAllowedValues(MM::g_Keyword_Transpose_MirrorY, allowedValues);
-      CreateProperty(MM::g_Keyword_Transpose_Correction, "0", MM::Integer, false);
-      SetAllowedValues(MM::g_Keyword_Transpose_Correction, allowedValues);
+      this->CreateProperty(MM::g_Keyword_Transpose_SwapXY, "0", MM::Integer, false);
+      this->SetAllowedValues(MM::g_Keyword_Transpose_SwapXY, allowedValues);
+      this->CreateProperty(MM::g_Keyword_Transpose_MirrorX, "0", MM::Integer, false);
+      this->SetAllowedValues(MM::g_Keyword_Transpose_MirrorX, allowedValues);
+      this->CreateProperty(MM::g_Keyword_Transpose_MirrorY, "0", MM::Integer, false);
+      this->SetAllowedValues(MM::g_Keyword_Transpose_MirrorY, allowedValues);
+      this->CreateProperty(MM::g_Keyword_Transpose_Correction, "0", MM::Integer, false);
+      this->SetAllowedValues(MM::g_Keyword_Transpose_Correction, allowedValues);
 
    }
 
@@ -1325,7 +1326,7 @@ public:
     * Returns binnings factor.  Used to calculate current pixelsize
     * Not appropriately named.
     */
-   virtual double GetPixelSizeUm() const {return GetBinning();}
+   virtual double GetPixelSizeUm() const {return this->GetBinning();}
 
    virtual unsigned GetNumberOfComponents() const
    {


### PR DESCRIPTION
Some followup to #590. See commits for details.

The removal of 'using' declarations needs confirmation:
- [x] Builds on Windows
- [ ] Builds on macOS
- [ ] Builds on Linux