### PR TITLE
Allow XY stage devices to perform um <-> steps conversion

### DIFF
--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1881,6 +1881,25 @@ public:
          ySteps = originYSteps_ + nint (y_um / this->GetStepSizeYUm());
    }
 
+   // This converts an absolute position (xSteps, ySteps), under the current
+   // adapter origin and x/y mirroring, to an absolute um position. Do not use
+   // for relative offsets.
+   void ConvertPositionStepsToUm(long xSteps, long ySteps, double& x_um, double& y_um)
+   {
+      bool mirrorX, mirrorY;
+      GetOrientation(mirrorX, mirrorY);
+
+      if (mirrorX)
+         x_um = (originXSteps_ - xSteps) * this->GetStepSizeXUm();
+      else
+         x_um =  - ((originXSteps_ - xSteps) * this->GetStepSizeXUm());
+
+      if (mirrorY)
+         y_um = (originYSteps_ - ySteps) * this->GetStepSizeYUm();
+      else
+         y_um = - ((originYSteps_ - ySteps) * this->GetStepSizeYUm());
+   }
+
    virtual int SetPositionUm(double x, double y)
    {
       const double xPos = x;
@@ -1952,28 +1971,17 @@ public:
       return DEVICE_OK;
    }
 
-   virtual int GetPositionUm(double& x, double& y)
+   virtual int GetPositionUm(double& x_um, double& y_um)
    {
-      bool mirrorX, mirrorY;
-      GetOrientation(mirrorX, mirrorY);
-
       long xSteps, ySteps;
       int ret = this->GetPositionSteps(xSteps, ySteps);
       if (ret != DEVICE_OK)
          return ret;
 
-      if (mirrorX)
-         x = (originXSteps_ - xSteps) * this->GetStepSizeXUm();
-      else
-         x =  - ((originXSteps_ - xSteps) * this->GetStepSizeXUm());
+      ConvertPositionStepsToUm(xSteps, ySteps, x_um, y_um);
 
-      if (mirrorY)
-         y = (originYSteps_ - ySteps) * this->GetStepSizeYUm();
-      else
-         y = - ((originYSteps_ - ySteps) * this->GetStepSizeYUm());
-
-      xPos_ = x;
-      yPos_ = y;
+      xPos_ = x_um;
+      yPos_ = y_um;
 
       return DEVICE_OK;
    }

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -38,6 +38,7 @@
 #include <iomanip>
 #include <map>
 #include <sstream>
+#include <utility>
 
 // common error messages
 const char* const g_Msg_ERR = "Unknown error in the device";
@@ -1866,11 +1867,12 @@ public:
    // This converts an absolute position (x_um, y_um), under the current
    // adapter origin and x/y mirroring, to an absolute step position. Do not
    // use for relative offsets.
-   void ConvertPositionUmToSteps(double x_um, double y_um, long& xSteps, long& ySteps)
+   std::pair<long, long> ConvertPositionUmToSteps(double x_um, double y_um)
    {
       bool mirrorX, mirrorY;
       GetOrientation(mirrorX, mirrorY);
 
+      long xSteps{}, ySteps{};
       if (mirrorX)
          xSteps = originXSteps_ - nint (x_um / this->GetStepSizeXUm());
       else
@@ -1879,16 +1881,19 @@ public:
          ySteps = originYSteps_ - nint (y_um / this->GetStepSizeYUm());
       else
          ySteps = originYSteps_ + nint (y_um / this->GetStepSizeYUm());
+
+      return {xSteps, ySteps};
    }
 
    // This converts an absolute position (xSteps, ySteps), under the current
    // adapter origin and x/y mirroring, to an absolute um position. Do not use
    // for relative offsets.
-   void ConvertPositionStepsToUm(long xSteps, long ySteps, double& x_um, double& y_um)
+   std::pair<double, double> ConvertPositionStepsToUm(long xSteps, long ySteps)
    {
       bool mirrorX, mirrorY;
       GetOrientation(mirrorX, mirrorY);
 
+      double x_um{}, y_um{};
       if (mirrorX)
          x_um = (originXSteps_ - xSteps) * this->GetStepSizeXUm();
       else
@@ -1898,21 +1903,20 @@ public:
          y_um = (originYSteps_ - ySteps) * this->GetStepSizeYUm();
       else
          y_um = - ((originYSteps_ - ySteps) * this->GetStepSizeYUm());
+
+      return {x_um, y_um};
    }
 
-   virtual int SetPositionUm(double x, double y)
+   virtual int SetPositionUm(double x_um, double y_um)
    {
-      const double xPos = x;
-      const double yPos = y;
-      long xSteps{};
-      long ySteps{};
-
-      ConvertPositionUmToSteps(xPos, yPos, xSteps, ySteps);
+      auto posSteps = ConvertPositionUmToSteps(x_um, y_um);
+      long xSteps = posSteps.first;
+      long ySteps = posSteps.second;
 
       int ret = this->SetPositionSteps(xSteps, ySteps);
       if (ret == DEVICE_OK) {
-         xPos_ = xPos;
-         yPos_ = yPos;
+         xPos_ = x_um;
+         yPos_ = y_um;
          this->OnXYStagePositionChanged(xPos_, yPos_);
       }
       return ret;
@@ -1978,7 +1982,9 @@ public:
       if (ret != DEVICE_OK)
          return ret;
 
-      ConvertPositionStepsToUm(xSteps, ySteps, x_um, y_um);
+      auto pos_um = ConvertPositionStepsToUm(xSteps, ySteps);
+      x_um = pos_um.first;
+      y_um = pos_um.second;
 
       xPos_ = x_um;
       yPos_ = y_um;

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1864,15 +1864,10 @@ public:
    }
 
 
-   virtual int SetPositionUm(double x, double y)
+   virtual int CalculatePositionSteps(long& xSteps, long& ySteps, double x, double y)
    {
       bool mirrorX, mirrorY;
       GetOrientation(mirrorX, mirrorY);
-      double xPos = x;
-      double yPos = y;
-
-      long xSteps = 0;
-      long ySteps = 0;
 
       if (mirrorX)
          xSteps = originXSteps_ - nint (x / this->GetStepSizeXUm());
@@ -1883,7 +1878,22 @@ public:
       else
          ySteps = originYSteps_ + nint (y / this->GetStepSizeYUm());
 
-      int ret = this->SetPositionSteps(xSteps, ySteps);
+      return DEVICE_OK;
+   }
+
+
+   virtual int SetPositionUm(double x, double y)
+   {
+      double xPos = x;
+      double yPos = y;
+      long xSteps = 0;
+      long ySteps = 0;
+
+      int ret = CalculatePositionSteps(xSteps, ySteps, x, y);
+      if (ret != DEVICE_OK)
+         return ret;
+
+      ret = this->SetPositionSteps(xSteps, ySteps);
       if (ret == DEVICE_OK) {
          xPos_ = xPos;
          yPos_ = yPos;

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1863,37 +1863,34 @@ public:
       this->AddAllowedValue(MM::g_Keyword_Transpose_MirrorY, "1");
    }
 
-
-   virtual int CalculatePositionSteps(long& xSteps, long& ySteps, double x, double y)
+   // This converts an absolute position (x_um, y_um), under the current
+   // adapter origin and x/y mirroring, to an absolute step position. Do not
+   // use for relative offsets.
+   void ConvertPositionUmToSteps(double x_um, double y_um, long& xSteps, long& ySteps)
    {
       bool mirrorX, mirrorY;
       GetOrientation(mirrorX, mirrorY);
 
       if (mirrorX)
-         xSteps = originXSteps_ - nint (x / this->GetStepSizeXUm());
+         xSteps = originXSteps_ - nint (x_um / this->GetStepSizeXUm());
       else
-         xSteps = originXSteps_ + nint (x / this->GetStepSizeXUm());
+         xSteps = originXSteps_ + nint (x_um / this->GetStepSizeXUm());
       if (mirrorY)
-         ySteps = originYSteps_ - nint (y / this->GetStepSizeYUm());
+         ySteps = originYSteps_ - nint (y_um / this->GetStepSizeYUm());
       else
-         ySteps = originYSteps_ + nint (y / this->GetStepSizeYUm());
-
-      return DEVICE_OK;
+         ySteps = originYSteps_ + nint (y_um / this->GetStepSizeYUm());
    }
-
 
    virtual int SetPositionUm(double x, double y)
    {
-      double xPos = x;
-      double yPos = y;
-      long xSteps = 0;
-      long ySteps = 0;
+      const double xPos = x;
+      const double yPos = y;
+      long xSteps{};
+      long ySteps{};
 
-      int ret = CalculatePositionSteps(xSteps, ySteps, x, y);
-      if (ret != DEVICE_OK)
-         return ret;
+      ConvertPositionUmToSteps(xPos, yPos, xSteps, ySteps);
 
-      ret = this->SetPositionSteps(xSteps, ySteps);
+      int ret = this->SetPositionSteps(xSteps, ySteps);
       if (ret == DEVICE_OK) {
          xPos_ = xPos;
          yPos_ = yPos;

--- a/MMDevice/unittest/XYStageStepsUm-Tests.cpp
+++ b/MMDevice/unittest/XYStageStepsUm-Tests.cpp
@@ -1,0 +1,178 @@
+#include <catch2/catch_all.hpp>
+
+#include "DeviceBase.h"
+
+// Test that the um <-> steps conversions in CXYStageBase are correct.
+
+namespace {
+
+class MockXYStage : public CXYStageBase<MockXYStage> {
+    long stepsX_ = 0;
+    long stepsY_ = 0;
+
+public:
+    int Initialize() override { return DEVICE_OK; }
+    int Shutdown() override { return DEVICE_OK; }
+    bool Busy() override { return false; }
+    void GetName(char*) const override {}
+
+    int GetLimitsUm(double &, double &, double &, double &) override {
+        return DEVICE_ERR;
+    }
+    int GetStepLimits(long &, long &, long &, long &) override {
+        return DEVICE_ERR;
+    }
+    int Home() override { return DEVICE_ERR; }
+    int Stop() override { return DEVICE_ERR; }
+    int SetOrigin() override { return DEVICE_ERR; }
+    int IsXYStageSequenceable(bool &) const override { return DEVICE_ERR; }
+
+    double GetStepSizeXUm() override { return 7.0; }
+    double GetStepSizeYUm() override { return 5.0; }
+
+    int SetPositionSteps(long xSteps, long ySteps) override {
+        stepsX_ = xSteps;
+        stepsY_ = ySteps;
+        return DEVICE_OK;
+    }
+
+    int GetPositionSteps(long& xSteps, long& ySteps) override {
+        xSteps = stepsX_;
+        ySteps = stepsY_;
+        return DEVICE_OK;
+    }
+
+};
+
+}
+
+TEST_CASE("CXYStageBase-GetPositionUm") {
+    const int flipX = GENERATE(0, 1);
+    const int flipY = GENERATE(0, 1);
+    CAPTURE(flipX, flipY);
+
+    auto mxy = MockXYStage();
+    REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorX,
+                            std::to_string(flipX).c_str()) == DEVICE_OK);
+    REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorY,
+                            std::to_string(flipY).c_str()) == DEVICE_OK);
+
+    double xUm{-1}, yUm{-1};
+    REQUIRE(mxy.GetPositionUm(xUm, yUm) == DEVICE_OK);
+    CHECK(xUm == 0.0);
+    CHECK(yUm == 0.0);
+
+    REQUIRE(mxy.SetPositionSteps(2, 3) == DEVICE_OK);
+
+    REQUIRE(mxy.GetPositionUm(xUm, yUm) == DEVICE_OK);
+    CHECK(xUm == (flipX ? -14.0 : 14.0));
+    CHECK(yUm == (flipY ? -15.0 : 15.0));
+}
+
+TEST_CASE("CXYStageBase-SetAdapterOriginUm") {
+    const auto adapterOriginX_um = GENERATE(0.0, 13.0);
+    const auto adapterOriginY_um = GENERATE(0.0, 17.0);
+    const int flipX = GENERATE(0, 1);
+    const int flipY = GENERATE(0, 1);
+    CAPTURE(adapterOriginX_um, adapterOriginY_um, flipX, flipY);
+
+    auto mxy = MockXYStage();
+    REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorX,
+                            std::to_string(flipX).c_str()) == DEVICE_OK);
+    REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorY,
+                            std::to_string(flipY).c_str()) == DEVICE_OK);
+
+    REQUIRE(mxy.SetAdapterOriginUm(adapterOriginX_um, adapterOriginY_um) == DEVICE_OK);
+
+    // Current position in steps does not change on setting adapter origin
+    // (i.e., stage does not move):
+    long xSteps{-1}, ySteps{-1};
+    REQUIRE(mxy.GetPositionSteps(xSteps, ySteps) == DEVICE_OK);
+    CHECK(xSteps == 0);
+    CHECK(ySteps == 0);
+
+    // Current position becomes the given um coordinates:
+    double xUm{}, yUm{};
+    REQUIRE(mxy.GetPositionUm(xUm, yUm) == DEVICE_OK);
+    CHECK(xUm == std::round(adapterOriginX_um / 7.0) * 7.0);
+    CHECK(yUm == std::round(adapterOriginY_um / 5.0) * 5.0);
+}
+
+TEST_CASE("CXYStageBase-SetPositionUm") {
+    const auto adapterOriginX_um = GENERATE(0.0, 13.0);
+    const auto adapterOriginY_um = GENERATE(0.0, 17.0);
+    const int flipX = GENERATE(0, 1);
+    const int flipY = GENERATE(0, 1);
+    CAPTURE(adapterOriginX_um, adapterOriginY_um, flipX, flipY);
+
+    auto mxy = MockXYStage();
+
+    SECTION("translate-then-flip") {
+        REQUIRE(mxy.SetAdapterOriginUm(adapterOriginX_um, adapterOriginY_um)
+                == DEVICE_OK);
+        REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorX,
+                                std::to_string(flipX).c_str()) == DEVICE_OK);
+        REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorY,
+                                std::to_string(flipY).c_str()) == DEVICE_OK);
+
+        REQUIRE(mxy.SetPositionUm(42.0, 55.0) == DEVICE_OK);
+
+        long xSteps{}, ySteps{};
+        REQUIRE(mxy.GetPositionSteps(xSteps, ySteps) == DEVICE_OK);
+        CHECK(xSteps == std::lround(((flipX ? -1 : 1) * 42.0 - adapterOriginX_um) / 7.0));
+        CHECK(ySteps == std::lround(((flipY ? -1 : 1) * 55.0 - adapterOriginY_um) / 5.0));
+    }
+
+    SECTION("flip-then-translate") {
+        REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorX,
+                                std::to_string(flipX).c_str()) == DEVICE_OK);
+        REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorY,
+                                std::to_string(flipY).c_str()) == DEVICE_OK);
+        REQUIRE(mxy.SetAdapterOriginUm(adapterOriginX_um, adapterOriginY_um)
+                == DEVICE_OK);
+
+        REQUIRE(mxy.SetPositionUm(42.0, 55.0) == DEVICE_OK);
+
+        long xSteps{}, ySteps{};
+        REQUIRE(mxy.GetPositionSteps(xSteps, ySteps) == DEVICE_OK);
+        CHECK(xSteps == std::lround(((flipX ? -1 : 1) * (42.0 - adapterOriginX_um)) / 7.0));
+        CHECK(ySteps == std::lround(((flipY ? -1 : 1) * (55.0 - adapterOriginY_um)) / 5.0));
+    }
+}
+
+TEST_CASE("CXYStageBase-SetRelativePositionUm") {
+    const auto adapterOriginX_um = GENERATE(0.0, 13.0);
+    const auto adapterOriginY_um = GENERATE(0.0, 17.0);
+    const int flipX = GENERATE(0, 1);
+    const int flipY = GENERATE(0, 1);
+    CAPTURE(adapterOriginX_um, adapterOriginY_um, flipX, flipY);
+
+    auto mxy = MockXYStage();
+
+    SECTION("translate-then-flip") {
+        REQUIRE(mxy.SetAdapterOriginUm(adapterOriginX_um, adapterOriginY_um)
+                == DEVICE_OK);
+        REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorX,
+                                std::to_string(flipX).c_str()) == DEVICE_OK);
+        REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorY,
+                                std::to_string(flipY).c_str()) == DEVICE_OK);
+    }
+
+    SECTION("flip-then-translate") {
+        REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorX,
+                                std::to_string(flipX).c_str()) == DEVICE_OK);
+        REQUIRE(mxy.SetProperty(MM::g_Keyword_Transpose_MirrorY,
+                                std::to_string(flipY).c_str()) == DEVICE_OK);
+        REQUIRE(mxy.SetAdapterOriginUm(adapterOriginX_um, adapterOriginY_um)
+                == DEVICE_OK);
+    }
+
+    REQUIRE(mxy.SetRelativePositionUm(42.0, 55.0) == DEVICE_OK);
+
+    // We moved relative to steps (0, 0), so the adapter (microns) origin
+    // does not play a role in the steps position we end up in.
+    long xSteps{}, ySteps{};
+    REQUIRE(mxy.GetPositionSteps(xSteps, ySteps) == DEVICE_OK);
+    CHECK(xSteps == std::lround(((flipX ? -1 : 1) * 42.0) / 7.0));
+    CHECK(ySteps == std::lround(((flipY ? -1 : 1) * 55.0) / 5.0));
+}

--- a/MMDevice/unittest/meson.build
+++ b/MMDevice/unittest/meson.build
@@ -14,6 +14,7 @@ mmdevice_test_sources = files(
     'FloatPropertyTruncation-Tests.cpp',
     'MMTime-Tests.cpp',
     'RegisteredDeviceCollection-Tests.cpp',
+    'XYStageStepsUm-Tests.cpp',
 )
 
 mmdevice_test_exe = executable(


### PR DESCRIPTION
This includes (part of) a commit by @jondaniels from https://github.com/micro-manager/micro-manager/pull/2172 (but I changed the function name and signature and made it non-virtual).

Allow concrete devices to access the correct um -> steps conversion (which requires knowledge of the "adapter origin") so that hardware sequencing can be implemented correctly.

I also added the steps -> um conversion, for symmetry.