### PR TITLE
MMDevice: Remove use of obsolete pthread attr name

### DIFF
--- a/MMDevice/DeviceThreads.h
+++ b/MMDevice/DeviceThreads.h
@@ -101,14 +101,7 @@ public:
 #else
       pthread_mutexattr_t a;
       pthread_mutexattr_init(&a);
-      pthread_mutexattr_settype(&a,
-#ifdef __linux__
-         // Not sure if _NP is needed any more
-         PTHREAD_MUTEX_RECURSIVE_NP
-#else
-         PTHREAD_MUTEX_RECURSIVE
-#endif
-      );
+      pthread_mutexattr_settype(&a, PTHREAD_MUTEX_RECURSIVE);
       pthread_mutex_init(&lock_, &a);
       pthread_mutexattr_destroy(&a);
 #endif


### PR DESCRIPTION
PTHREAD_MUTEX_RECURSIVE (without the _NP "non-portable") has been available on Linux (glibc) since around the beginning of this century, I think.