### PR TITLE
Updating Zaber Motion Library to 7.14.0

### DIFF
--- a/DeviceAdapters/Zaber/ConnectionManager.cpp
+++ b/DeviceAdapters/Zaber/ConnectionManager.cpp
@@ -18,7 +18,7 @@ std::shared_ptr<zml::Connection> ConnectionManager::getConnection(std::string po
 		std::regex parser("^share:\\/\\/([^:\\/]+)(:\\d+)?(\\/.*)?$", std::regex_constants::ECMAScript);
 		std::smatch partMatch;
 		if (!std::regex_match(port, partMatch, parser)) {
-			throw zmlbase::InvalidArgumentException("Invalid network share connection string: " + port);
+			throw zmlexc::InvalidArgumentException("Invalid network share connection string: " + port);
 		}
 
 		std::string host = partMatch[1].str();
@@ -37,7 +37,7 @@ std::shared_ptr<zml::Connection> ConnectionManager::getConnection(std::string po
 	}
 
 	auto id = connection->getInterfaceId();
-	connection->getDisconnected().subscribe([=, this](std::shared_ptr<zmlbase::MotionLibException>) {
+	connection->setDisconnectedCallback([this, port, id](std::shared_ptr<zmlexc::MotionLibException>) {
 		removeConnection(port, id);
 	});
 	connections_[port] = connection;

--- a/DeviceAdapters/Zaber/ConnectionManager.h
+++ b/DeviceAdapters/Zaber/ConnectionManager.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 namespace zmlbase = zaber::motion;
+namespace zmlexc = zaber::motion::exceptions;
 namespace zml = zaber::motion::ascii;
 
 class ConnectionManager
@@ -19,4 +20,3 @@ private:
 	std::mutex lock_;
 	std::map<std::string, std::weak_ptr<zml::Connection>> connections_;
 };
-

--- a/DeviceAdapters/Zaber/Makefile.am
+++ b/DeviceAdapters/Zaber/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS) $(ZML_CPPFLAGS)
+AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS) $(ZML_CPPFLAGS) -std=c++17
 
 deviceadapter_LTLIBRARIES = libmmgr_dal_Zaber.la
 libmmgr_dal_Zaber_la_SOURCES = \

--- a/DeviceAdapters/Zaber/Zaber.cpp
+++ b/DeviceAdapters/Zaber/Zaber.cpp
@@ -160,7 +160,7 @@ void ZaberBase::resetConnection() {
 		// the connection destructor can throw in the rarest occasions
 		connection_ = nullptr;
 	}
-	catch (const zmlbase::MotionLibException e)
+	catch (const zmlexc::MotionLibException e)
 	{
 	}
 }
@@ -425,17 +425,17 @@ int ZaberBase::handleException(std::function<void()> wrapped) {
 		wrapped();
 		return DEVICE_OK;
 	}
-	catch (const zmlbase::ConnectionFailedException e) {
+	catch (const zmlexc::ConnectionFailedException e) {
 		core_->LogMessage(device_, e.what(), true);
 		resetConnection();
 		return DEVICE_NOT_CONNECTED;
 	}
-	catch (const zmlbase::ConnectionClosedException e) {
+	catch (const zmlexc::ConnectionClosedException e) {
 		core_->LogMessage(device_, e.what(), true);
 		resetConnection();
 		return DEVICE_NOT_CONNECTED;
 	}
-	catch (const zmlbase::CommandFailedException e) {
+	catch (const zmlexc::CommandFailedException e) {
 		core_->LogMessage(device_, e.what(), true);
 		auto reason = e.getDetails().getResponseData();
 		if (reason == "BADCOMMAND") {
@@ -452,19 +452,19 @@ int ZaberBase::handleException(std::function<void()> wrapped) {
 		}
 		return ERR_COMMAND_REJECTED;
 	}
-	catch (const zmlbase::RequestTimeoutException e) {
+	catch (const zmlexc::RequestTimeoutException e) {
 		core_->LogMessage(device_, e.what(), true);
 		return DEVICE_NOT_CONNECTED;
 	}
-	catch (const zmlbase::MovementFailedException e) {
+	catch (const zmlexc::MovementFailedException e) {
 		core_->LogMessage(device_, e.what(), true);
 		return ERR_MOVEMENT_FAILED;
 	}
-	catch (const zmlbase::InvalidOperationException e) {
+	catch (const zmlexc::InvalidOperationException e) {
 		core_->LogMessage(device_, e.what(), true);
 		return ERR_INVALID_OPERATION;
 	}
-	catch (const zmlbase::MotionLibException e) {
+	catch (const zmlexc::MotionLibException e) {
 		core_->LogMessage(device_, e.what(), true);
 		return DEVICE_ERR;
 	}

--- a/DeviceAdapters/Zaber/Zaber.h
+++ b/DeviceAdapters/Zaber/Zaber.h
@@ -35,6 +35,7 @@
 #include "ConnectionManager.h"
 
 namespace zmlbase = zaber::motion;
+namespace zmlexc = zaber::motion::exceptions;
 namespace zml = zaber::motion::ascii;
 namespace zmlmi = zaber::motion::microscopy;
 

--- a/DeviceAdapters/Zaber/Zaber.vcxproj
+++ b/DeviceAdapters/Zaber/Zaber.vcxproj
@@ -59,13 +59,14 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_USRDLL;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)\Zaber\zaber-motion-3.4.4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)\Zaber\zaber-motion-7.14.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>zml.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)\Zaber\zaber-motion-3.4.4\win64\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>zaber-motion.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)\Zaber\zaber-motion-7.14.0\lib\win_x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -441,26 +441,26 @@ AM_CONDITIONAL([BUILD_ALLIED_VISION_CAMERA], [test "x$use_vimba_x" = xyes])
 
 
 # Zaber Motion Library (hack: only support 3rdpartypublic copy currently)
-zml_version="3.4.4"
-zml_so_version="3.4"
+zml_version="7.14.0"
+zml_so_version="7.14"
 AC_MSG_CHECKING([for Zaber Motion Library in 3rdpartypublic])
 zml_header_to_check="${thirdpartypublic}/Zaber/zaber-motion-${zml_version}/include/zaber/motion/library.h"
 AM_CONDITIONAL([BUILD_ZABER], [test -f $zml_header_to_check])
 if test -f "$zml_header_to_check"; then
    AC_MSG_RESULT([found])
    ZML_CPPFLAGS="-I${thirdpartypublic}/Zaber/zaber-motion-${zml_version}/include"
-   ZML_LIBS="-lzml"
+   ZML_LIBS="-lzaber-motion"
    case $host in
       *linux*)
          # Linux builds by users should install ZML libs
-         zml_linux_libdir="${thirdpartypublic}/Zaber/zaber-motion-${zml_version}/linux-amd64/lib"
+         zml_linux_libdir="${thirdpartypublic}/Zaber/zaber-motion-${zml_version}/lib/linux_x64"
          ZML_LDFLAGS="-L${zml_linux_libdir} -Wl,-rpath,"'\$$ORIGIN'
-         ZML_LIBS_TO_COPY="${zml_linux_libdir}/libzml.so.${zml_so_version} ${zml_linux_libdir}/libzaber-motion-lib-linux-amd64.so.${zml_version}"
+         ZML_LIBS_TO_COPY="${zml_linux_libdir}/libzaber-motion.so.${zml_so_version} ${zml_linux_libdir}/libzaber-motion-core.so.${zml_version}"
          ;;
 
       *apple-darwin*)
          # macOS build for packaging does not ship ZML
-         ZML_LDFLAGS="-L${thirdpartypublic}/Zaber/zaber-motion-${zml_version}/darwin/lib"
+         ZML_LDFLAGS="-L${thirdpartypublic}/Zaber/zaber-motion-${zml_version}/lib/darwin_x64"
          ZML_LIBS_TO_COPY=""
          ;;
    esac


### PR DESCRIPTION
Hello Mark,

We are updating to our latest library version 7.14.0. The changes in code are minimal. However, since the previous version, we have cleaned up and renamed some of the binaries. Furthermore, we now have a standard archive that we use when integrating with other software. This leads to changes in linking paths, but the naming is now consistent.

With that, please download our support package: [https://api.zaber.io/downloads/software-downloads?product=zml_cpp_support&version=7.14.0](https://api.zaber.io/downloads/software-downloads?product=zml_cpp_support&version=7.14.0). The folder inside called "ZaberMotionCppSupport" needs to be renamed to "zaber-motion-7.14.0" and copied to the 3rdpartypublic folder. There are platforms inside the lib folder that can be deleted to reduce the size. Only darwin_x64, linux_x64, win_x64 need to stay. Please note, there are still simlinks inside.

Lastly, I wanted to offer a solution for the future. We are happy to somehow download our package dynamically during some build phase. As you see, the package itself is versioned. I am not familiar with the automake build system, but if you direct us to the right place, we should be able to do it.

Thank you for helping us keep our integration running.