### PR TITLE
MMDevice: Delete an unused macro

### DIFF
--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -2563,20 +2563,3 @@ class CPressurePumpBase : public CDeviceBase<MM::PressurePump, U>
         return DEVICE_UNSUPPORTED_COMMAND;
     }
 };
-
-
-// _t, a macro for timing single lines.
-// This macros logs the text of the line, x, measures
-// the time it takes, and then logs that time.
-// Usage example:
-// _t( ex = GetExposure(); )
-
-
-#define _t(x) \
-   { \
-      LogMessage(#x, true); \
-      _start_time = GetCurrentMMTime(); \
-      x; \
-      _end_time = GetCurrentMMTime(); \
-      LogTimeDiff(_start_time,_end_time, true); \
-   }


### PR DESCRIPTION
Has multiple issues and should not be in DeviceBase. Doesn't even work since 2011.