### PR TITLE
CoreCallback: No longer check if a config group has more than 1 property before sending the ConfigGroupChanged callback. 

### DIFF
--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -437,9 +437,6 @@ int CoreCallback::OnPropertyChanged(const MM::Device* device, const char* propNa
          {
             Configuration config = 
                core_->getConfigData((*it).c_str(), (*itc).c_str());
-            // only callback when there is more than 1 property in a group
-            // This is needed, since the UI treats groups with one 
-            // property differently, whereas the core does not....
             if (config.isPropertyIncluded(label, propName)) {
                found = true;
                // If we are part of this configuration, notify that it 


### PR DESCRIPTION
This causes error with previous version of the Java UI, but I will shortly create a PR to address those.  The Core should not make a distinction between groups with one or more properties.  This really was a work-around a problem in the UI code (that is now fixed as well).