### PR TITLE
Do not run workflow requiring secrets on cloned repositories

### DIFF
--- a/.github/workflows/trigger-mm-test-adapters.yml
+++ b/.github/workflows/trigger-mm-test-adapters.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   dispatch:
+    if: github.repository == 'micro-manager/mmCoreAndDevices'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The title says it all.
Whenever I sync my clone with upstream, the modified workflow is executed on the clone and fails immediately with following error due to missing secrets:
`[@octokit/auth-app] appId option is required`.