### PR TITLE
AMF: Fix vcxproj header/source grouping

### DIFF
--- a/DeviceAdapters/AMF/AMF.vcxproj
+++ b/DeviceAdapters/AMF/AMF.vcxproj
@@ -14,11 +14,11 @@
     <ClInclude Include="AMF_Commands.h" />
     <ClInclude Include="AMF_LSP_Hub.h" />
     <ClInclude Include="AMF_RVM.h" />
+    <ClInclude Include="AMF_LSP_Pump.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AMF_LSP_Hub.cpp" />
     <ClCompile Include="AMF_LSP_Pump.cpp" />
-    <ClCompile Include="AMF_LSP_Pump.h" />
     <ClCompile Include="AMF_RVM.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/DeviceAdapters/AMF/AMF.vcxproj.filters
+++ b/DeviceAdapters/AMF/AMF.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClInclude Include="AMF_LSP_Hub.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClCompile Include="AMF_LSP_Pump.h">
+      <Filter>Header Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AMF_RVM.cpp">
@@ -34,9 +37,6 @@
     </ClCompile>
     <ClCompile Include="AMF_LSP_Pump.cpp">
       <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="AMF_LSP_Pump.h">
-      <Filter>Header Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
AMF_LSP_Pump.h was listed as a source file. Compiling it results in AMF_LSP_Pump.obj, which conflicts with the output of compiling AMF_LSP_Pump.cpp (if the compiler tries to write at the same time). This caused sporadic build failures. At least, that's what I think was happening.

(The last 2 nightly builds are missing on Windows due to this issue.)