### PR TITLE
JAI: Support per-component exposure/gain/black level

### DIFF
--- a/DeviceAdapters/JAI/JAI.h
+++ b/DeviceAdapters/JAI/JAI.h
@@ -222,6 +222,8 @@ private:
 	PvGenParameterArray* genParams;
 	std::string connectionId;
 	std::vector<PvBuffer*> pvBuffers;
+	std::string commonExposureSelector_;  // e.g., "Common"
+	std::string commonGainSelector_;      // e.g., "AnalogAll"
 
    friend class AcqSequenceThread;
    AcqSequenceThread*   liveAcqThd_;

--- a/DeviceAdapters/JAI/PropertyHandlers.cpp
+++ b/DeviceAdapters/JAI/PropertyHandlers.cpp
@@ -201,7 +201,7 @@ int JAICamera::GetSelectorExposure(const std::string& selector, double& expMs)
 	PvResult pvr2 = genParams->GetFloatValue("ExposureTime", expUs);
 	expMs = expUs * 1e-3;
 
-	pvr = ets->SetValue(int64_t(0));
+	pvr = ets->SetValue(commonExposureSelector_.c_str());
 	if (!pvr.IsOK())
 		return processPvError(pvr);
 
@@ -220,7 +220,7 @@ int JAICamera::SetSelectorExposure(const std::string& selector, double expMs)
 	const double expUs = expMs * 1e3;
 	PvResult pvr2 = genParams->SetFloatValue("ExposureTime", expUs);
 
-	pvr = ets->SetValue(int64_t(0));
+	pvr = ets->SetValue(commonExposureSelector_.c_str());
 	if (!pvr.IsOK())
 		return processPvError(pvr);
 
@@ -241,7 +241,7 @@ int JAICamera::GetSelectorExposureMinMax(const std::string& selector, double& eM
 	eMinMs = eMinUs * 1e-3;
 	eMaxMs = eMaxUs * 1e-3;
 
-	pvr = ets->SetValue(int64_t(0));
+	pvr = ets->SetValue(commonExposureSelector_.c_str());
 	if (!pvr.IsOK())
 		return processPvError(pvr);
 
@@ -327,7 +327,7 @@ int JAICamera::GetSelectorGain(const std::string& selector, double& gain)
 
 	PvResult pvr2 = genParams->GetFloatValue("Gain", gain);
 
-	pvr = gs->SetValue(int64_t(0));
+	pvr = gs->SetValue(commonGainSelector_.c_str());
 	if (!pvr.IsOK())
 		return processPvError(pvr);
 
@@ -345,7 +345,7 @@ int JAICamera::SetSelectorGain(const std::string& selector, double gain)
 
 	PvResult pvr2 = genParams->SetFloatValue("Gain", gain);
 
-	pvr = gs->SetValue(int64_t(0));
+	pvr = gs->SetValue(commonGainSelector_.c_str());
 	if (!pvr.IsOK())
 		return processPvError(pvr);
 
@@ -363,7 +363,7 @@ int JAICamera::GetSelectorGainMinMax(const std::string& selector, double& gMin, 
 
 	PvResult pvr2 = genParams->GetFloatRange("Gain", gMin, gMax);
 
-	pvr = gs->SetValue(int64_t(0));
+	pvr = gs->SetValue(commonGainSelector_.c_str());
 	if (!pvr.IsOK())
 		return processPvError(pvr);
 
@@ -444,14 +444,9 @@ int JAICamera::GetSelectorBlackLevel(const std::string& selector, double& level)
 	if (!pvr.IsOK())
 		return processPvError(pvr);
 
-	PvResult pvr2 = genParams->GetFloatValue("BlackLevel", level);
-
-	pvr = bls->SetValue(int64_t(0));
+	pvr = genParams->GetFloatValue("BlackLevel", level);
 	if (!pvr.IsOK())
 		return processPvError(pvr);
-
-	if (!pvr2.IsOK())
-		return processPvError(pvr2);
 	return DEVICE_OK;
 }
 
@@ -462,14 +457,9 @@ int JAICamera::SetSelectorBlackLevel(const std::string& selector, double level)
 	if (!pvr.IsOK())
 		return processPvError(pvr);
 
-	PvResult pvr2 = genParams->SetFloatValue("BlackLevel", level);
-
-	pvr = bls->SetValue(int64_t(0));
+	pvr = genParams->SetFloatValue("BlackLevel", level);
 	if (!pvr.IsOK())
 		return processPvError(pvr);
-
-	if (!pvr2.IsOK())
-		return processPvError(pvr2);
 	return DEVICE_OK;
 }
 
@@ -480,14 +470,9 @@ int JAICamera::GetSelectorBlackLevelMinMax(const std::string& selector, double& 
 	if (!pvr.IsOK())
 		return processPvError(pvr);
 
-	PvResult pvr2 = genParams->GetFloatRange("BlackLevel", minLevel, maxLevel);
-
-	pvr = bls->SetValue(int64_t(0));
+	pvr = genParams->GetFloatRange("BlackLevel", minLevel, maxLevel);
 	if (!pvr.IsOK())
 		return processPvError(pvr);
-
-	if (!pvr2.IsOK())
-		return processPvError(pvr2);
 	return DEVICE_OK;
 }
 


### PR DESCRIPTION
This is for the JAI Apex cameras that have 3 sensor chips for prism-separated RGB (such as the AP-3200T-USB, with which I tested this).

Adds these properties when supported (the actual property name suffixes are formed by querying the camera):

- ExposureIsIndividual Off/On
- Exposure_Blue
- Exposure_Green
- Exposure_Red

- GainIsIndividual Off/On
- Gain_AnalogBlue
- Gain_AnalogGreen
- Gain_AnalogRed
- Gain_DigitalBlue
- Gain_DigitalRed

- BlackLevel_DigitalAll
- BlackLevel_DigitalBlue
- BlackLevel_DigitalRed

The BlackLevel has no on/off switch for individual settings. It probably doesn't need adjustment, but it's there if needed.

(Assisted by Claude Code; any errors are mine.)