### PR TITLE
Do not add tags with phys cam name in multi cam

### DIFF
--- a/DeviceAdapters/ArduinoCounter/ArduinoCounter.cpp
+++ b/DeviceAdapters/ArduinoCounter/ArduinoCounter.cpp
@@ -522,13 +522,6 @@ int ArduinoCounterCamera::StartSequenceAcquisition(double interval)
       MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
       if (camera != 0)
       {
-         std::ostringstream os;
-         os << i;
-         camera->AddTag(MM::g_Keyword_CameraChannelName, usedCameras_[i].c_str(),
-            usedCameras_[i].c_str());
-         camera->AddTag(MM::g_Keyword_CameraChannelIndex, usedCameras_[i].c_str(),
-            os.str().c_str());
-
          int ret = camera->StartSequenceAcquisition(interval);
          if (ret != DEVICE_OK)
             return ret;
@@ -573,13 +566,6 @@ int ArduinoCounterCamera::StopSequenceAcquisition()
             return ret;
          if (ret2 != DEVICE_OK)
             return ret2;
-
-         std::ostringstream os;
-         os << i;
-         camera->AddTag(MM::g_Keyword_CameraChannelName, usedCameras_[i].c_str(),
-            "");
-         camera->AddTag(MM::g_Keyword_CameraChannelIndex, usedCameras_[i].c_str(),
-            os.str().c_str());
       }
    }
    return DEVICE_OK;

--- a/DeviceAdapters/TeensyPulseGenerator/CameraPulser.cpp
+++ b/DeviceAdapters/TeensyPulseGenerator/CameraPulser.cpp
@@ -516,13 +516,6 @@ int CameraPulser::StartSequenceAcquisition(double interval)
       MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
       if (camera != 0)
       {
-         std::ostringstream os;
-         os << i;
-         camera->AddTag(MM::g_Keyword_CameraChannelName, usedCameras_[i].c_str(),
-            usedCameras_[i].c_str());
-         camera->AddTag(MM::g_Keyword_CameraChannelIndex, usedCameras_[i].c_str(),
-            os.str().c_str());
-
          ret = camera->StartSequenceAcquisition(interval);
          if (ret != DEVICE_OK)
             return ret;
@@ -585,13 +578,6 @@ int CameraPulser::StopSequenceAcquisition()
          ret = camera->StopSequenceAcquisition();
          if (ret != DEVICE_OK)
             return ret;
-
-         std::ostringstream os;
-         os << i;
-         camera->AddTag(MM::g_Keyword_CameraChannelName, usedCameras_[i].c_str(),
-            "");
-         camera->AddTag(MM::g_Keyword_CameraChannelIndex, usedCameras_[i].c_str(),
-            os.str().c_str());
       }
    }
    std::ostringstream os;

--- a/DeviceAdapters/Utilities/MultiCamera.cpp
+++ b/DeviceAdapters/Utilities/MultiCamera.cpp
@@ -464,13 +464,6 @@ int MultiCamera::StartSequenceAcquisition(double interval)
       MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
       if (camera != 0)
       {
-         std::ostringstream os;
-         os << i;
-         camera->AddTag(MM::g_Keyword_CameraChannelName, usedCameras_[i].c_str(),
-            usedCameras_[i].c_str());
-         camera->AddTag(MM::g_Keyword_CameraChannelIndex, usedCameras_[i].c_str(),
-            os.str().c_str());
-
          int ret = camera->StartSequenceAcquisition(interval);
          if (ret != DEVICE_OK)
             return ret;
@@ -489,13 +482,6 @@ int MultiCamera::StartSequenceAcquisition(long numImages, double interval_ms, bo
       MM::Camera* camera = (MM::Camera*)GetDevice(usedCameras_[i].c_str());
       if (camera != 0)
       {
-         std::ostringstream os;
-         os << i;
-         camera->AddTag(MM::g_Keyword_CameraChannelName, usedCameras_[i].c_str(),
-            usedCameras_[i].c_str());
-         camera->AddTag(MM::g_Keyword_CameraChannelIndex, usedCameras_[i].c_str(),
-            os.str().c_str());
-
          int ret = camera->StartSequenceAcquisition(numImages, interval_ms, stopOnOverflow);
          if (ret != DEVICE_OK)
             return ret;
@@ -512,16 +498,8 @@ int MultiCamera::StopSequenceAcquisition()
       if (camera != 0)
       {
          int ret = camera->StopSequenceAcquisition();
-
-         // 
          if (ret != DEVICE_OK)
             return ret;
-         std::ostringstream os;
-         os << i;
-         camera->AddTag(MM::g_Keyword_CameraChannelName, usedCameras_[i].c_str(),
-            "");
-         camera->AddTag(MM::g_Keyword_CameraChannelIndex, usedCameras_[i].c_str(),
-            os.str().c_str());
       }
    }
    return DEVICE_OK;


### PR DESCRIPTION
Closes #773.

These "tags" contain device label + key + value.

The code deleted here was setting the keys CameraChannelIndex/Name under the device label of the physical camera (as opposed to the multi-camera device itself). There is no code in MMCoreJ, MMStudio, plugins, and acquisition engines (including pymmcore-plus) that ever reads these tags, so remove them entirely.

Aside from being a red herring when trying to understand tag usage, there was no correct way to add/remove tags at start and stop of sequence acquisition, because application code is not technically required to call stopSequenceAcquisition() after a finite sequence acquisition.

(In the case of ArduinoCounter and CameraPulser, the equivalent code was already missing from one of the 2 overloads of
StartSequenceAcquisition.)

There was no code calling RemoveTag() for these tags.

Multi Camera, ArduinoCounter, and CameraPulser still retain code that sets CameraChannelIndex/Name under its own device label; this is done when the physical cameras are set and remains unchanged here.