### PR TITLE
MMCore/MMDevice Meson build: Remove manual propagation of 'tests' option

### DIFF
--- a/MMCore/meson.build
+++ b/MMCore/meson.build
@@ -4,7 +4,7 @@
 project(
     'MMCore',
     'cpp',
-    meson_version: '>=1.2.0',
+    meson_version: '>=1.8.0',
     default_options: [
         'cpp_std=c++14',
         'warning_level=3',
@@ -17,23 +17,12 @@ if cxx.get_id() in ['msvc', 'clang-cl']
     add_project_arguments('-DNOMINMAX', language: 'cpp')
 endif
 
-if get_option('tests').enabled()
-    tests_option = 'enabled'
-elif get_option('tests').disabled()
-    tests_option = 'disabled'
-else
-    tests_option = 'auto'
-endif
-
 # mmdevice is provided via a .wrap, but it should be manually copied into
 # subprojects in order to control the version that gets fetched.
 mmdevice_proj = subproject(
     'mmdevice',
     default_options: {
-        'client_interface': true,
-        # Propagate value of 'tests' option ('yield: true' in MMDeivce's
-        # 'tests' option did not seem to work; Meson 1.3.1).
-        'tests': tests_option,
+        'client_interface': true,  # Build for use by mmcore
     },
 )
 mmdevice_dep = mmdevice_proj.get_variable('mmdevice_dep')

--- a/MMDevice/meson.build
+++ b/MMDevice/meson.build
@@ -4,7 +4,7 @@
 project(
     'MMDevice',
     'cpp',
-    meson_version: '>=1.1.0', # May relax
+    meson_version: '>=1.8.0',
     default_options: [
         'cpp_std=c++14',
         'warning_level=3',


### PR DESCRIPTION
The comment about 'yield' (in the definition of 'tests' in MMDevice/meson_options.txt) not working does not appear to be the case with current versions of Meson (tested with 1.10.0). So remove the workaround.

Also increase minimum Meson version to 1.8.0 (an arbitrary choice, but 1.8.0 adds the ability to override a yielded option in a subproject from the command line.)