### PR TITLE
MMDevice Meson: Disable tests for device adapters

### DIFF
--- a/MMDevice/meson.build
+++ b/MMDevice/meson.build
@@ -59,7 +59,22 @@ mmdevice_lib = static_library(
     gnu_symbol_visibility: 'inlineshidden',
 )
 
-subdir('unittest')
+# Special handling for 'tests' option. We want to:
+# - Enable tests by default when built as a stand-alone project ('auto' but
+#   will be enabled unless wrap fallback disabled).
+# - Disable by default when built as subproject of a device adapter, because
+#   we might be building many at once. But allow to enable if wanted.
+# - Follow the parent project when built as subproject of mmcore ('yield: true'
+#   in the option definition).
+build_tests = get_option('tests').allowed()
+if meson.is_subproject() and not get_option('client_interface')
+    if get_option('tests').auto()
+        build_tests = false
+    endif
+endif
+if build_tests
+    subdir('unittest')
+endif
 
 mmdevice_dep = declare_dependency(
     compile_args: build_mode_args,

--- a/MMDevice/meson_options.txt
+++ b/MMDevice/meson_options.txt
@@ -1,6 +1,6 @@
 option('client_interface', type: 'boolean', value: false,
     description: 'Build for use by MMCore, as opposed to by a device adapter',
 )
-option('tests', type: 'feature', value: 'enabled', yield: true,
+option('tests', type: 'feature', value: 'auto', yield: true,
     description: 'Build unit tests',
 )


### PR DESCRIPTION
If we ever build more than a few device adapters at the same time (without using a parent Meson project), each build will build MMDevice. This is fine because MMDevice builds fast, but not great if MMDevice tests are enabled because then Catch2 is downloaded and built (unless found on the system).

However, we probably want the device adapter's own tests (if any) to be enabled by default.

So disable MMDevice tests by default when MMDevice is being built as a subproject.

But don't disable tests if MMDevice is being built as a subproject of MMCore. This is important because any tests specific to the client_interface build might never get exercised otherwise. And we don't have many MMCores.

When building a device adapter, it will still be possible to enable MMDevice tests with -Dmmdevice:tests=enabled.