### PR TITLE
MMDevice: deprecate obsolete constants

### DIFF
--- a/DeviceAdapters/SutterLambda2/LambdaVF5.cpp
+++ b/DeviceAdapters/SutterLambda2/LambdaVF5.cpp
@@ -173,7 +173,7 @@ int LambdaVF5::onWavelength(MM::PropertyBase* pProp, MM::ActionType eAct) {
 		}
 		return hub_->SetCommand(cmd);
 	}
-   return MM_CODE_ERR;
+   return DEVICE_ERR;
 }
 
 int LambdaVF5::onTiltSpeed(MM::PropertyBase* pProp, MM::ActionType eAct) {
@@ -260,7 +260,7 @@ int LambdaVF5::onTTLOut(MM::PropertyBase* pProp, MM::ActionType eAct) {
 		}
 		return configureTTL(ttlOutRisingEdge_, ttlOutEnabled_, true, 1);
 	}
-   return MM_CODE_ERR;
+   return DEVICE_ERR;
 }
 
 int LambdaVF5::onTTLIn(MM::PropertyBase* pProp, MM::ActionType eAct) {
@@ -288,7 +288,7 @@ int LambdaVF5::onTTLIn(MM::PropertyBase* pProp, MM::ActionType eAct) {
 		}
 		return configureTTL(ttlInRisingEdge_, ttlInEnabled_, false, 1);
 	}
-   return MM_CODE_ERR;
+   return DEVICE_ERR;
 }
 
 int LambdaVF5::onTTLInPolarity(MM::PropertyBase* pProp, MM::ActionType eAct) {
@@ -316,7 +316,7 @@ int LambdaVF5::onTTLInPolarity(MM::PropertyBase* pProp, MM::ActionType eAct) {
 		}
 		return configureTTL(ttlInRisingEdge_, ttlInEnabled_, false, 1);
 	}
-   return MM_CODE_ERR;
+   return DEVICE_ERR;
 }
 
 int LambdaVF5::onTTLOutPolarity(MM::PropertyBase* pProp, MM::ActionType eAct) {
@@ -344,7 +344,7 @@ int LambdaVF5::onTTLOutPolarity(MM::PropertyBase* pProp, MM::ActionType eAct) {
 		}
 		return configureTTL(ttlOutRisingEdge_, ttlOutEnabled_, true, 1);
 	}
-   return MM_CODE_ERR;
+   return DEVICE_ERR;
 }
 
 
@@ -373,7 +373,7 @@ int LambdaVF5::onSequenceType(MM::PropertyBase* pProp, MM::ActionType eAct) {
 		}
 		return DEVICE_OK;
 	}
-   return MM_CODE_ERR;
+   return DEVICE_ERR;
 }
 
 int LambdaVF5::resetSequenceIndex(unsigned char channel) {

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -20,13 +20,12 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
 // AUTHOR:        Nenad Amodaj, nenad@amodaj.com, 06/07/2005
-// 
-// CVS:           $Id: MMCoreJ.i 16466 2017-08-23 21:46:52Z nico $
-//
 
 #if SWIG_VERSION < 0x020000 || SWIG_VERSION >= 0x040000
 #error SWIG 2.x or 3.x is currently required to build MMCoreJ
 #endif
+
+#define MMDEVICE_CLIENT_BUILD
 
 %module (directors="1") MMCoreJ
 %feature("director") MMEventCallback;

--- a/MMCoreJ_wrap/MMCoreJ_wrap.vcxproj
+++ b/MMCoreJ_wrap/MMCoreJ_wrap.vcxproj
@@ -59,6 +59,7 @@
       </PrecompiledHeader>
       <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalOptions>/w34996 %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions>MMDEVICE_CLIENT_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)MMCoreJ_wrap.dll</OutputFile>
@@ -73,7 +74,7 @@
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>..\MMCore;..\MMDevice;$(JAVA_HOME)\include\win32;$(JAVA_HOME)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MMDEVICE_CLIENT_BUILD;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>
       </PrecompiledHeader>

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -1613,8 +1613,8 @@ namespace MM {
 
       // These functions violate the separation between device adapters and
       // will be removed as soon as we remove all uses. Never use in new code.
-      MM_DEPRECATED(virtual int GetFocusPosition(double& pos)) = 0;
-      MM_DEPRECATED(virtual MM::SignalIO* GetSignalIODevice(const MM::Device* caller, const char* deviceName)) = 0;
+      MMDEVICE_DEPRECATED virtual int GetFocusPosition(double& pos) = 0;
+      MMDEVICE_DEPRECATED virtual MM::SignalIO* GetSignalIODevice(const MM::Device* caller, const char* deviceName) = 0;
 
       virtual MM::Hub* GetParentHub(const MM::Device* caller) const = 0;
    };

--- a/MMDevice/MMDeviceConstants.h
+++ b/MMDevice/MMDeviceConstants.h
@@ -23,28 +23,26 @@
 
 #ifdef MMDEVICE_CLIENT_BUILD
 // Hide deprecation warnings when building MMCore
-#   define MM_DEPRECATED(prototype) prototype
+#   define MMDEVICE_DEPRECATED
 #else
-#   ifdef _MSC_VER
-#      define MM_DEPRECATED(prototype) __declspec(deprecated) prototype
-#   elif defined(__GNUC__)
-#      define MM_DEPRECATED(prototype) prototype __attribute__((deprecated))
-#   else
-#      define MM_DEPRECATED(prototype) prototype
-#   endif
+#   define MMDEVICE_DEPRECATED [[deprecated]]
 #endif
 
-///////////////////////////////////////////////////////////////////////////////
-// Global error codes
-//
-#define MM_CODE_OK 0       // command succeeded
-#define MM_CODE_ERR 1      // undefined error occurred
+// Obsolete, redundant with DEVICE_OK, DEVICE_ERR.
+// We can't cleanly deprecate a #define macro, so use const int. But to
+// avoid changing the SWIG-generated APIs, keep the macros for SWIG only.
+#ifdef SWIG
+#define MM_CODE_OK 0
+#define MM_CODE_ERR 1
+#else
+MMDEVICE_DEPRECATED const int MM_CODE_OK = 0;
+MMDEVICE_DEPRECATED const int MM_CODE_ERR = 1;
+#endif
 
 //////////////////////////////////////////////////////////////////////////////
 // Global constants
 //
 // common device error codes
-// TODO: revise values - the range might clash with the native driver codes
 
 #define DEVICE_OK                      0
 #define DEVICE_ERR                     1 // generic, undefined error
@@ -176,7 +174,7 @@ namespace MM {
    const char* const g_Keyword_Metadata_Height      = "Height";
    const char* const g_Keyword_Metadata_CameraLabel = "Camera";
    const char* const g_Keyword_Metadata_Exposure    = "Exposure-ms";
-   MM_DEPRECATED(const char* const g_Keyword_Meatdata_Exposure) = "Exposure-ms"; // Typo
+   MMDEVICE_DEPRECATED const char* const g_Keyword_Meatdata_Exposure = "Exposure-ms"; // Typo
    const char* const g_Keyword_Metadata_Score       = "Score";
    const char* const g_Keyword_Metadata_ImageNumber = "ImageNumber";
    // Removed: g_Keyword_Metadata_StartTime         = "StartTime-ms";
@@ -209,27 +207,27 @@ namespace MM {
    const char* const g_CFGGroup_System_Shutdown = "Shutdown";
    const char* const g_CFGGroup_PixelSizeUm = "PixelSize_um";
 
-   // serial port constants
-   const int _DATABITS_5 = 5;
-   const int _DATABITS_6 = 6;
-   const int _DATABITS_7 = 7;
-   const int _DATABITS_8 = 8;
+   // Obsolete serial port constants
+   MMDEVICE_DEPRECATED const int _DATABITS_5 = 5;
+   MMDEVICE_DEPRECATED const int _DATABITS_6 = 6;
+   MMDEVICE_DEPRECATED const int _DATABITS_7 = 7;
+   MMDEVICE_DEPRECATED const int _DATABITS_8 = 8;
 
-   const int _FLOWCONTROL_NONE = 0;
-   const int _FLOWCONTROL_RTSCTS_IN = 1;
-   const int _FLOWCONTROL_RTSCTS_OUT = 2;
-   const int _FLOWCONTROL_XONXOFF_IN = 4;
-   const int _FLOWCONTROL_XONXOFF_OUT = 8;
+   MMDEVICE_DEPRECATED const int _FLOWCONTROL_NONE = 0;
+   MMDEVICE_DEPRECATED const int _FLOWCONTROL_RTSCTS_IN = 1;
+   MMDEVICE_DEPRECATED const int _FLOWCONTROL_RTSCTS_OUT = 2;
+   MMDEVICE_DEPRECATED const int _FLOWCONTROL_XONXOFF_IN = 4;
+   MMDEVICE_DEPRECATED const int _FLOWCONTROL_XONXOFF_OUT = 8;
 
-   const int _PARITY_EVEN = 2;
-   const int _PARITY_MARK = 3;
-   const int _PARITY_NONE = 0;
-   const int _PARITY_ODD = 1;
-   const int _PARITY_SPACE = 4;
+   MMDEVICE_DEPRECATED const int _PARITY_EVEN = 2;
+   MMDEVICE_DEPRECATED const int _PARITY_MARK = 3;
+   MMDEVICE_DEPRECATED const int _PARITY_NONE = 0;
+   MMDEVICE_DEPRECATED const int _PARITY_ODD = 1;
+   MMDEVICE_DEPRECATED const int _PARITY_SPACE = 4;
 
-   const int _STOPBITS_1 = 1;
-   const int _STOPBITS_1_5 = 3;
-   const int _STOPBITS_2 = 2;
+   MMDEVICE_DEPRECATED const int _STOPBITS_1 = 1;
+   MMDEVICE_DEPRECATED const int _STOPBITS_1_5 = 3;
+   MMDEVICE_DEPRECATED const int _STOPBITS_2 = 2;
 
 
    //////////////////////////////////////////////////////////////////////////////
@@ -287,10 +285,8 @@ namespace MM {
       FocusDirectionAwayFromSample = -1,
    };
 
-   //////////////////////////////////////////////////////////////////////////////
-   // Notification constants
-   //
-   enum DeviceNotification {
+   // Long unused
+   enum MMDEVICE_DEPRECATED DeviceNotification {
       Attention,
       Done,
       StatusChanged

--- a/MMDevice/Property.h
+++ b/MMDevice/Property.h
@@ -254,7 +254,7 @@ public:
          }
       } catch (...)
       {
-         return MM_CODE_ERR;
+         return DEVICE_ERR;
       }
 
       return DEVICE_OK;
@@ -269,7 +269,7 @@ public:
             return DEVICE_SEQUENCE_TOO_LARGE;
       } catch (...)
       {
-         return MM_CODE_ERR;
+         return DEVICE_ERR;
       }
 
       return DEVICE_OK;


### PR DESCRIPTION
Deprecate rather than remove, because these constants are also part of the MMCoreJ and pymmcore API.

Removal
- Requires major version bump of MMCoreJ and pymmcore[-nano] (and, realistically, MMCore).
- Does NOT require Device Interface Version change

`MM_CODE_OK` and `MM_CODE_ERR` - redundant with `DEVICE_OK` and `DEVICE_ERR`. There were a few uses; removed.

Serial port settings - not sure but certainly not used in a long time.

`enum DeviceNotification` - was part of an unfinished attempt around 15 years ago, the rest of which has been removed.

- [x] Changing `MM_CODE_OK/ERR` from macro to `const int` ***does*** change SWIG-generated API; fix
- [x] Make sure adding `#define MMDEVICE_CLIENT_BUILD` in SWIG input (MMCoreJ.i) doesn't change the MMCoreJ API