### PR TITLE
RAMPS: Fix inverted checks for "ok" response

### DIFF
--- a/DeviceAdapters/CNCMicroscope/RAMPSStage/RAMPS.cpp
+++ b/DeviceAdapters/CNCMicroscope/RAMPSStage/RAMPS.cpp
@@ -217,7 +217,7 @@ bool RAMPSHub::Busy() {
     status_ = "Busy";
     return true;
   }
-  if (!answer.compare("ok")) {
+  if (answer != "ok") {
     LogMessage(std::string("busy expected OK, didn't get it."));
     LogMessage(answer);
     return true;
@@ -374,6 +374,10 @@ int RAMPSHub::ReadResponse(std::string &returnString, float timeout)
     {
       LogMessage(std::string("answer get error!_"));
       return ret;
+    }
+    // Trim trailing CR (handles both LF and CRLF line endings)
+    if (!an.empty() && an.back() == '\r') {
+      an.pop_back();
     }
     returnString = an;
   }
@@ -539,7 +543,7 @@ int RAMPSHub::GetStatus()
     LogMessage(std::string("answer get error!_"));
     return ret;
   }
-  if (!an.compare("ok"))
+  if (an != "ok")
   {
     LogMessage(std::string("answer get error!_"));
     return ret;
@@ -607,7 +611,7 @@ int RAMPSHub::SetVelocity(double x, double y, double z) {
   if (ret != DEVICE_OK) return ret;
   ret = pHub->ReadResponse(result);
   if (ret != DEVICE_OK) return ret;
-  if (!result.compare("ok")) {
+  if (result != "ok") {
     LogMessage("Expected OK");
   }
 
@@ -626,7 +630,7 @@ int RAMPSHub::SetAcceleration(double x, double y, double z) {
   if (ret != DEVICE_OK) return ret;
   ret = pHub->ReadResponse(result);
   if (ret != DEVICE_OK) return ret;
-  if (!result.compare("ok") ) {
+  if (result != "ok") {
     LogMessage("Expected OK");
   }
 

--- a/DeviceAdapters/CNCMicroscope/RAMPSStage/XYStage.cpp
+++ b/DeviceAdapters/CNCMicroscope/RAMPSStage/XYStage.cpp
@@ -141,7 +141,7 @@ int RAMPSXYStage::SetPositionSteps(long x, long y)
 	  LogMessage("Error sending XY move.");
 	  return ret;
   }
-  if (!answer.compare("ok")) {
+  if (answer != "ok") {
 	  LogMessage("Failed to get ok response to XY move.");
   }
   ret = OnXYStagePositionChanged(posX_um_, posY_um_);
@@ -182,7 +182,7 @@ int RAMPSXYStage::Home() {
     LogMessage("error getting response to homing command.");
     return ret;
   }
-  if (!answer.compare("ok")) {
+  if (answer != "ok") {
     LogMessage("Homing command: expected ok.");
     return DEVICE_ERR;
   }
@@ -210,7 +210,7 @@ int RAMPSXYStage::SetAdapterOriginUm(double x, double y) {
     LogMessage("error getting response to origin command.");
     return ret;
   }
-  if (!answer.compare("ok")) {
+  if (answer != "ok") {
     LogMessage("Origin command: expected ok.");
     return DEVICE_ERR;
   }

--- a/DeviceAdapters/CNCMicroscope/RAMPSStage/ZStage.cpp
+++ b/DeviceAdapters/CNCMicroscope/RAMPSStage/ZStage.cpp
@@ -148,7 +148,7 @@ int RAMPSZStage::SetPositionSteps(long steps)
 	  LogMessage("Error sending Z move.");
 	  return ret;
   }
-  if (!answer.compare("ok")) {
+  if (answer != "ok") {
 	  LogMessage("Failed to get ok response to Z move.");
   }
   ret = OnStagePositionChanged(posZ_um_);
@@ -185,7 +185,7 @@ int RAMPSZStage::Home() {
     LogMessage("error getting response to homing command.");
     return ret;
   }
-  if (!answer.compare("ok")) {
+  if (answer != "ok") {
     LogMessage("Homing command: expected ok.");
     return DEVICE_ERR;
   }
@@ -212,7 +212,7 @@ int RAMPSZStage::SetAdapterOriginUm(double z) {
     LogMessage("error getting response to origin command.");
     return ret;
   }
-  if (!answer.compare("ok")) {
+  if (answer != "ok") {
     LogMessage("origin command: expected ok.");
     return DEVICE_ERR;
   }


### PR DESCRIPTION
`if (!answer.compare("ok"))` is equivalent to `if (answer == "ok")` but was being used where the opposite was intended.

This caused it to "work" when the device sent CRLF terminators, because `ok\r` doesn't match `ok`. This might be why the bug was not discovered previously, so add support for both LF and CRLF terminators.

(Assisted by Claude Code; any errors are mine.)

Closes #471.