### PR TITLE
DeviceBase: Remove OnXYStagePropertyChanged callbacks in code setting the XY stage positions.

### DIFF
--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1945,7 +1945,7 @@ template <class U>
 class CXYStageBase : public CDeviceBase<MM::XYStage, U>
 {
 public:
-   CXYStageBase() : originXSteps_(0), originYSteps_(0)
+   CXYStageBase() : originXSteps_(0), originYSteps_(0), xPos_(0), yPos_(0)
    {
       // set-up directionality properties
       this->CreateProperty(MM::g_Keyword_Transpose_MirrorX, "0", MM::Integer, false);
@@ -2006,7 +2006,12 @@ public:
       long xSteps = posSteps.first;
       long ySteps = posSteps.second;
 
-      return this->SetPositionSteps(xSteps, ySteps);
+      int ret = this->SetPositionSteps(xSteps, ySteps);
+      if (ret == DEVICE_OK) {
+         xPos_ = x_um;
+         yPos_ = y_um;
+      }
+      return ret;
    }
 
    /**
@@ -2018,13 +2023,20 @@ public:
    {
       bool mirrorX, mirrorY;
       GetOrientation(mirrorX, mirrorY);
+      double xPos = xPos_ + dx;
+      double yPos = yPos_ + dy;
 
       if (mirrorX)
          dx = -dx;
       if (mirrorY)
          dy = -dy;
 
-      return SetRelativePositionSteps(nint(dx / this->GetStepSizeXUm()), nint(dy / this->GetStepSizeYUm()));
+      int ret = SetRelativePositionSteps(nint(dx / this->GetStepSizeXUm()), nint(dy / this->GetStepSizeYUm()));
+      if (ret == DEVICE_OK) {
+         xPos_ = xPos;
+         yPos_ = yPos;
+      }
+      return ret;
    }
 
    /**
@@ -2066,6 +2078,9 @@ public:
       auto pos_um = ConvertPositionStepsToUm(xSteps, ySteps);
       x_um = pos_um.first;
       y_um = pos_um.second;
+
+      xPos_ = x_um;
+      yPos_ = y_um;
 
       return DEVICE_OK;
    }


### PR DESCRIPTION
This is undoing commit d1962c6f8b which I made myself in 2011.  
Getting this callback automatically, even when the stage is not anywhere near the desired position has become annoying and confusing.

Closes #806. Will open another PR for the addition of a function to report whether or not the stage uses callbacks.