### PR TITLE
JAI: Update individual RGB exposure min/max when frame rate changes

### DIFF
--- a/DeviceAdapters/JAI/JAI.cpp
+++ b/DeviceAdapters/JAI/JAI.cpp
@@ -339,6 +339,7 @@ int JAICamera::Initialize()
 						CreateProperty(propName.c_str(), CDeviceUtils::ConvertToString(eMs),
 							MM::Float, false, action);
 						SetPropertyLimits(propName.c_str(), eMinMs, eMaxMs);
+						individualExposureSelectors_.push_back(selectorName);
 					}
 				}
 			}

--- a/DeviceAdapters/JAI/JAI.h
+++ b/DeviceAdapters/JAI/JAI.h
@@ -39,7 +39,7 @@
 #endif
 
 #include <string>
-#include <map>
+#include <vector>
 
 static const char* g_DeviceJAICam = "JAICamera";
 static const char* g_Gain = "Gain";
@@ -228,6 +228,7 @@ private:
 	std::string connectionId;
 	std::vector<PvBuffer*> pvBuffers;
 	std::string commonExposureSelector_;  // e.g., "Common"
+	std::vector<std::string> individualExposureSelectors_;  // e.g., {"Red", "Green", "Blue"}
 	std::string commonGainSelector_;      // e.g., "AnalogAll"
 
    friend class AcqSequenceThread;

--- a/DeviceAdapters/JAI/PropertyHandlers.cpp
+++ b/DeviceAdapters/JAI/PropertyHandlers.cpp
@@ -126,6 +126,18 @@ int JAICamera::OnFrameRate(MM::PropertyBase* pProp, MM::ActionType eAct)
 		if (!pvr.IsOK())
 			return processPvError(pvr);
 		SetPropertyLimits(MM::g_Keyword_Exposure, expMinUs / 1000, expMaxUs / 1000);
+
+		// adjust individual exposure limits (if any)
+		for (const auto& selector : individualExposureSelectors_)
+		{
+			double eMinMs{}, eMaxMs{};
+			int ret = GetSelectorExposureMinMax(selector, eMinMs, eMaxMs);
+			if (ret == DEVICE_OK)
+			{
+				const std::string propName = "Exposure_" + selector;
+				SetPropertyLimits(propName.c_str(), eMinMs, eMaxMs);
+			}
+		}
 	}
 	else if (eAct == MM::BeforeGet)
 	{


### PR DESCRIPTION
For individual (per-component) exposure properties (for cameras that support it).