### PR TITLE
Rename DemoCamera BlurRate property to BeadBlurRate for consistency

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -394,10 +394,10 @@ int CDemoCamera::Initialize()
    assert(nRet == DEVICE_OK);
    SetPropertyLimits("BeadBrightness", 0.125, 8.0);
    
-   pAct = new CPropertyAction(this, &CDemoCamera::OnBlurRate);
-   nRet = CreateFloatProperty("BlurRate", blurRate_, false, pAct);
+   pAct = new CPropertyAction(this, &CDemoCamera::OnBeadBlurRate);
+   nRet = CreateFloatProperty("BeadBlurRate", beadBlurRate_, false, pAct);
    assert(nRet == DEVICE_OK);
-   SetPropertyLimits("BlurRate", 0.1, 1.0);
+   SetPropertyLimits("BeadBlurRate", 0.1, 1.0);
 
    // Simulate application crash
    pAct = new CPropertyAction(this, &CDemoCamera::OnCrash);
@@ -1953,15 +1953,15 @@ int CDemoCamera::OnBeadBrightness(MM::PropertyBase* pProp, MM::ActionType eAct)
    return DEVICE_OK;
 }
 
-int CDemoCamera::OnBlurRate(MM::PropertyBase* pProp, MM::ActionType eAct)
+int CDemoCamera::OnBeadBlurRate(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
    {
-      pProp->Set(blurRate_);
+      pProp->Set(beadBlurRate_);
    }
    else if (eAct == MM::AfterSet)
    {
-      pProp->Get(blurRate_);
+      pProp->Get(beadBlurRate_);
    }
    return DEVICE_OK;
 }

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -251,7 +251,7 @@ public:
    int OnBeadDensity(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnBeadSize(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnBeadBrightness(MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnBlurRate(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnBeadBlurRate(MM::PropertyBase* pProp, MM::ActionType eAct);
 
    // Special public DemoCamera methods
    void AddBackgroundAndNoise(ImgBuffer& img, double mean, double stdDev);
@@ -341,7 +341,7 @@ private:
    int beadDensity_ = 100;
    double beadSize_ = 2.0;
    double beadBrightness_ = 1.0;
-   double blurRate_ = 0.5;
+   double beadBlurRate_ = 0.5;
 };
 
 class MySequenceThread : public MMDeviceThreadBase

--- a/DeviceAdapters/DemoCamera/DemoImageGeneration.cpp
+++ b/DeviceAdapters/DemoCamera/DemoImageGeneration.cpp
@@ -863,7 +863,7 @@ void CDemoCamera::GenerateBeadsImage(ImgBuffer& img, double exposure)
    GenerateBeadPositions();
    
    // Calculate blur (no cap)
-   double blurRadius = blurRate_ * std::abs(zPos);
+   double blurRadius = beadBlurRate_ * std::abs(zPos);
    
    // 1px = 1um
    double pixelSizeUm = 1.0;


### PR DESCRIPTION
This PR renames the `BlurRate` property used in the new virtual beads mode for the DemoCamera to `BeadBlurRate` for consistency with other introduced properties such as BeadDensity.