### PR TITLE
CI: build MMCoreJ linux arm64 native library (Meson)

### DIFF
--- a/.github/workflows/ci-mmdevice-mmcore.yml
+++ b/.github/workflows/ci-mmdevice-mmcore.yml
@@ -92,6 +92,10 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: linux-x86_64
+            manylinux-image: quay.io/pypa/manylinux_2_28_x86_64
+          - os: ubuntu-24.04-arm
+            name: linux-arm64
+            manylinux-image: quay.io/pypa/manylinux_2_28_aarch64
           - os: windows-2025
             name: windows-x86_64
             cxx: cl
@@ -124,7 +128,7 @@ jobs:
           cp -R MMCore MMCoreJ_wrap/subprojects/mmcore
           docker run --rm -v "${{ github.workspace }}"/MMCoreJ_wrap:/work \
             -w /work \
-            quay.io/pypa/manylinux_2_28_x86_64 \
+            ${{ matrix.manylinux-image }} \
             bash scripts/build_jni_linux.sh
       - name: Build (non-Linux)
         if: "!startsWith(matrix.os, 'ubuntu-')"


### PR DESCRIPTION
We'll want to support Raspberry Pi, among other things.