### PR TITLE
Address AlliedVisionCamera issues

### DIFF
--- a/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.cpp
+++ b/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.cpp
@@ -434,8 +434,15 @@ double AlliedVisionCamera::GetExposure() const
 
 void AlliedVisionCamera::SetExposure(double exp_ms)
 {
-    SetProperty(m_exposureFeatureName.c_str(), CDeviceUtils::ConvertToString(exp_ms * MS_TO_US));
-    GetCoreCallback()->OnExposureChanged(this, exp_ms);
+    int err = SetProperty(m_exposureFeatureName.c_str(), CDeviceUtils::ConvertToString(exp_ms * MS_TO_US));
+    if (err != DEVICE_OK)
+    {
+        LOG_ERROR(err, "Failed to set exposure");
+        return;
+    }
+
+    double actualExposure = GetExposure();
+    GetCoreCallback()->OnExposureChanged(this, actualExposure);
 }
 
 int AlliedVisionCamera::SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize)


### PR DESCRIPTION
I am facing hard crashes when running an AlliedVision Prosilica GT2000-NIR camera, and have also observed some other driver malfunctions. I am interfacing with the camera via `pymmcore`.

- [x] `CMMCore.getROI()` always yields zeros -> fixed in `AlliedVisionCamera::GetROI`
- [x] `CMMCore.setExposure()` occasionally fails to set correct value (_Edit: traced back to round-off error in conversion from `float` to micro-seconds._)
- Deferred to separate PR: `CMMCore.snapImage()` results in occasional hard crashes (sometimes hundreds of captures in), specifically C++ segmentation fault (exit code 0xC0000005) in `pymmcore`