### PR TITLE
Fix race condition in AlliedVisionCamera property callbacks

### DIFF
--- a/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.h
+++ b/DeviceAdapters/AlliedVisionCamera/AlliedVisionCamera.h
@@ -20,7 +20,6 @@
 #define ALLIEDVISIONCAMERA_H
 
 #include <array>
-#include <atomic>
 #include <functional>
 #include <mutex>
 #include <regex>
@@ -472,7 +471,7 @@ private:
     static const std::unordered_set<std::string> m_macAddressFeatures;
 
     mutable std::recursive_mutex m_propertyMutex; //<! Mutex for property callback serialization
-    std::atomic<bool> m_propertiesReady;          //<! Flag indicating property creation is complete
+    bool m_propertiesReady;                        //<! Flag indicating property creation is complete
 };
 
 #endif


### PR DESCRIPTION
**Summary**

- Fix hard crashes caused by unsynchronized concurrent modification of MM property allowed-values containers (`std::map`) from Vimba SDK invalidation callback threads
- Add `std::recursive_mutex` to serialize `onProperty()` calls, preventing concurrent `ClearAllowedValues()` / `SetAllowedValues()` from corrupting the map's internal tree
- Add `std::atomic<bool>` init guard to skip Vimba callbacks that arrive before `setupProperties()` completes, preventing a race between property creation and callback-driven updates
- Use `try_to_lock` in the Vimba callback to avoid blocking the SDK's callback thread, which would deadlock with in-progress Vimba feature queries
- Refresh property limits before programmatic `SetProperty` calls

**Context**

The Vimba SDK fires feature invalidation callbacks on separate worker threads (documented in `VmbCTypeDefinitions.h`). These callbacks call `UpdateProperty() → onProperty() → setAllowedValues() → SetAllowedValues() → ClearAllowedValues()`. When multiple callbacks fire simultaneously, the `std::map::clear()` on one thread races with iteration/insertion on another, causing heap corruption detected as a debug CRT breakpoint (operator delete on already-freed tree nodes).

The mutex is recursive because `setFeatureValue()` for Command features re-enters `onProperty()` via `SetProperty()` on the same thread.

The issue was first observed when using a AlliedVision Prosilica GT2000NIR camera on Windows 11 via `pymmcore` on a recent nightly MM build. The acquisition sequence boils down to

```python
while True:
    core.setExposure(exposure_time)
    core.waitForDevice(CAMERA_DEVICE)

    core.snapImage()
    img = core.getImage()
    [...]
    time.sleep(delay)  # longer delays reduce the crash tendencies, but do not eliminate it
```

An additional issue was that setting of exposure values failed every once in a while.

**Disclaimer**

AI was used to debug and fix the hard crashes previously reported in #823. As suggested by @marktsuchida (thank you!), I attached the Visual Studio debugger to a running Python, which eventually produced a call stack that could be investigated.

While initial tests are promising, I will leave this in draft until I have confidence that this is fixed.

