### PR TITLE
Do not prefix camera metadata with label

### DIFF
--- a/DeviceAdapters/Andor/Andor.cpp
+++ b/DeviceAdapters/Andor/Andor.cpp
@@ -5703,21 +5703,14 @@ unsigned int AndorCamera::PopulateROIDropdownFVB()
 
    void AndorCamera::AddSRRFMetadataInfo(Metadata & md)
    {
-      char label[MM::MaxStrLength];
-      this->GetLabel(label);
       MM::MMTime tEnd = GetCurrentMMTime();
 
-      MetadataSingleTag mstSRRFFrameTime(SRRFControl_->GetSRRFFrameTimeMetadataName(), label, true);
-      mstSRRFFrameTime.SetValue(CDeviceUtils::ConvertToString((tEnd - startSRRFImageTime_).getMsec()));
-      md.SetTag(mstSRRFFrameTime);
+      md.PutImageTag(std::string("Andor-") + SRRFControl_->GetSRRFFrameTimeMetadataName(),
+         CDeviceUtils::ConvertToString((tEnd - startSRRFImageTime_).getMsec()));
    }
 
    void AndorCamera::AddMetadataInfo(Metadata & md)
    {
-      // create metadata
-      char label[MM::MaxStrLength];
-      this->GetLabel(label);
-
       MM::MMTime timestamp = this->GetCurrentMMTime();
 
       //These append md tag name to label of device; transient props appear per image.  All in .txt file with stack.
@@ -5731,9 +5724,8 @@ unsigned int AndorCamera::PopulateROIDropdownFVB()
       //md.PutImageTag(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(imageCounter_));
       //md.PutImageTag(MM::g_Keyword_Binning, binSize_);
 
-      MetadataSingleTag mst(MM::g_Keyword_Elapsed_Time_ms, label, true);
-      mst.SetValue(CDeviceUtils::ConvertToString(timestamp.getMsec()));
-      md.SetTag(mst);
+      md.PutImageTag(std::string("Andor-") + MM::g_Keyword_Elapsed_Time_ms,
+         CDeviceUtils::ConvertToString(timestamp.getMsec()));
 
       if (metaDataAvailable_)
       {
@@ -5742,44 +5734,36 @@ unsigned int AndorCamera::PopulateROIDropdownFVB()
          unsigned int ret = GetMetaDataInfo(&timeOfStart, &timeFromStart, imageCounter_);
          if (ret == DRV_SUCCESS)
          {
-            MetadataSingleTag mstHW("ElapsedTime-ms(HW)", label, true);
-            mstHW.SetValue(CDeviceUtils::ConvertToString(timeFromStart));
-            md.SetTag(mstHW);
+            md.PutImageTag(std::string("Andor-") + "ElapsedTime-ms(HW)",
+               CDeviceUtils::ConvertToString(timeFromStart));
          }
       }
 
-      MetadataSingleTag mstCount(MM::g_Keyword_Metadata_ImageNumber, label, true);
-      mstCount.SetValue(CDeviceUtils::ConvertToString(imageCounter_));
-      md.SetTag(mstCount);
+      md.PutImageTag(std::string("Andor-") + MM::g_Keyword_Metadata_ImageNumber,
+         CDeviceUtils::ConvertToString(imageCounter_));
 
-      MetadataSingleTag mstB(MM::g_Keyword_Binning, label, true);
-      mstB.SetValue(CDeviceUtils::ConvertToString(binSize_));
-      md.SetTag(mstB);
+      md.PutImageTag(MM::g_Keyword_Binning,
+         CDeviceUtils::ConvertToString(binSize_));
 
       if (updateTemperatureWhileSequencing_) 
       {
          float temp = 0.;
          unsigned int ret = GetTemperatureF(&temp);
+         std::string currentTempTag = "Andor-CurrentTemperature";
 
          if(ret == DRV_NOT_INITIALIZED || ret == DRV_ACQUIRING || ret == DRV_ERROR_ACK)
          {
-            MetadataSingleTag mstTemperature("CurrentTemperature", label, true);
             ostringstream os;
 
             os << "Get Temperature failed with error: " << ret << endl;
 
-            mstTemperature.SetValue(os.str().c_str());
-            md.SetTag(mstTemperature);
+            md.PutImageTag(currentTempTag, os.str());
          }
          else
          {
-            char * buffer = new char[MAX_CHARS_PER_DESCRIPTION];
+            char buffer[MAX_CHARS_PER_DESCRIPTION];
             snprintf(buffer, MAX_CHARS_PER_DESCRIPTION, "%.2f", temp);
-
-            MetadataSingleTag mstTemperature("CurrentTemperature", label, true);
-            mstTemperature.SetValue(buffer);
-            md.SetTag(mstTemperature);
-            delete buffer;
+            md.PutImageTag(currentTempTag, buffer);
          }
       }
 

--- a/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
+++ b/DeviceAdapters/AndorSDK3/AndorSDK3.cpp
@@ -1286,12 +1286,13 @@ int CAndorSDK3Camera::InsertImage()
 {
    char deviceName[MM::MaxStrLength];
    GetProperty(MM::g_Keyword_CameraName, deviceName);
+   std::string prefix = deviceName;
+   prefix += '-';
    
    Metadata md;
 
-   MetadataSingleTag mstCount(MM::g_Keyword_Metadata_ImageNumber, deviceName, true);
-   mstCount.SetValue(CDeviceUtils::ConvertToString(thd_->GetImageCounter()));      
-   md.SetTag(mstCount);
+   md.PutImageTag(prefix + MM::g_Keyword_Metadata_ImageNumber,
+      CDeviceUtils::ConvertToString(thd_->GetImageCounter()));
 
    if (0 == thd_->GetImageCounter())
    {
@@ -1301,9 +1302,7 @@ int CAndorSDK3Camera::InsertImage()
    stringstream ss;
    double d_result = (timeStamp_-sequenceStartTime_)/static_cast<double>(fpgaTSclockFrequency_);
    ss << d_result*1000 << " [" << d_result << " seconds]";
-   MetadataSingleTag mst(MM::g_Keyword_Elapsed_Time_ms, deviceName, true);
-   mst.SetValue(ss.str().c_str());
-   md.SetTag(mst);
+   md.PutImageTag(prefix + MM::g_Keyword_Elapsed_Time_ms, ss.str());
 
    MMThreadGuard g(imgPixelsLock_);
    return InsertMMImage(img_, md);
@@ -1319,9 +1318,7 @@ int CAndorSDK3Camera::InsertImageWithSRRF()
    stringstream ss;
    double frameTimeInS = (startSRRFImageTime_ - startSRRFSequenceTime_) / static_cast<double>(fpgaTSclockFrequency_);
    ss << frameTimeInS * 1000;
-   MetadataSingleTag mstSRRFFrameTime(SRRFControl_->GetSRRFFrameTimeMetadataName(), deviceName, true);
-   mstSRRFFrameTime.SetValue(ss.str().c_str());
-   md.SetTag(mstSRRFFrameTime);
+   md.PutImageTag(deviceName + std::string("-") + SRRFControl_->GetSRRFFrameTimeMetadataName(), ss.str());
 
    MMThreadGuard g(imgPixelsLock_);
 

--- a/DeviceAdapters/PICAM/PICAMUniversal.cpp
+++ b/DeviceAdapters/PICAM/PICAMUniversal.cpp
@@ -2533,15 +2533,7 @@ int Universal::BuildMetadata( Metadata& md )
    md.PutImageTag<long64>("PICAM-TimeStampBOF", pFrameInfo_->TimeStampBOF);
 #endif
 
-   MetadataSingleTag mstElapsed(MM::g_Keyword_Elapsed_Time_ms, label, true);
    MM::MMTime elapsed = timestamp - startTime_;
-   mstElapsed.SetValue(CDeviceUtils::ConvertToString(elapsed.getMsec()));
-   md.SetTag(mstElapsed);
-
-   MetadataSingleTag mstCount(MM::g_Keyword_Metadata_ImageNumber, label, true);
-   mstCount.SetValue(CDeviceUtils::ConvertToString(curImageCnt_));
-   md.SetTag(mstCount);
-
    double actualInterval = elapsed.getMsec() / curImageCnt_;
    SetProperty(MM::g_Keyword_ActualInterval_ms, CDeviceUtils::ConvertToString(actualInterval));
 

--- a/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
@@ -4215,7 +4215,7 @@ int Universal::ProcessNotification( const NotificationEntry& entry )
 
         // The time elapsed since start of the acquisition until current frame readout
         // Now added by MM automatically, no need to do it here.
-        // md.PutTag(MM::g_Keyword_Elapsed_Time_ms, deviceLabel_, CDeviceUtils::ConvertToString(elapsedTimeMsec));
+        // md.PutImageTag(MM::g_Keyword_Elapsed_Time_ms, CDeviceUtils::ConvertToString(elapsedTimeMsec));
 
         const double actualInterval = elapsedTimeMsec / imagesInserted_;
         SetProperty(MM::g_Keyword_ActualInterval_ms, CDeviceUtils::ConvertToString(actualInterval)); 

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.cpp
@@ -5879,50 +5879,34 @@ int CRaptorEPIX::InsertImage()
    md.PutImageTag(MM::g_Keyword_Metadata_ROI_X, CDeviceUtils::ConvertToString( (long) roiX_)); 
    md.PutImageTag(MM::g_Keyword_Metadata_ROI_Y, CDeviceUtils::ConvertToString( (long) roiY_)); 
    //md.PutImageTag("FieldCount", CDeviceUtils::ConvertToString( (long) fieldCount_)); 
+
+	std::string prefix =
+#ifdef HORIBA_COMPILE
+		"HoribaEPIX-";
+#else
+		"RaptorEPIX-";
+#endif
  
-	MetadataSingleTag mst1("Interval Wait Time", label, true);
-	mst1.SetValue(CDeviceUtils::ConvertToString(myIntervalWaitTime_*1000.0));
-	md.SetTag(mst1);
+	md.PutImageTag(prefix + "Interval Wait Time", CDeviceUtils::ConvertToString(myIntervalWaitTime_*1000.0));
 
-	MetadataSingleTag mst4("Frame Diff Time", label, true);
-	mst4.SetValue(CDeviceUtils::ConvertToString(myFrameDiffTime_*1000.0));
-	md.SetTag(mst4);
+	md.PutImageTag(prefix + "Frame Diff Time", CDeviceUtils::ConvertToString(myFrameDiffTime_*1000.0));
 
-	
-	MetadataSingleTag mst3(MM::g_Keyword_Elapsed_Time_ms, label, true);
-	mst3.SetValue(CDeviceUtils::ConvertToString((myReadoutStartTime_ - mySequenceStartTime_)*1000.0));
-	md.SetTag(mst3);
+	md.PutImageTag(prefix + MM::g_Keyword_Elapsed_Time_ms,
+		CDeviceUtils::ConvertToString((myReadoutStartTime_ - mySequenceStartTime_)*1000.0));
 
 	dCurrentClock2 = myClock();
 
 	if(trigSnap_)
 	{
-		MetadataSingleTag mst5("Trigger to Capture Time", label, true);
-		mst5.SetValue(CDeviceUtils::ConvertToString((myCaptureTime_ - myReadoutStartTime_)*1000.0));
-		md.SetTag(mst5);
+		md.PutImageTag(prefix + "Trigger to Capture Time",
+			CDeviceUtils::ConvertToString((myCaptureTime_ - myReadoutStartTime_)*1000.0));
 
-		MetadataSingleTag mst6("Trigger to Data Time", label, true);
-		mst6.SetValue(CDeviceUtils::ConvertToString((myCaptureTime2_ - myReadoutStartTime_)*1000.0));
-		md.SetTag(mst6);
+		md.PutImageTag(prefix + "Trigger to Data Time",
+			CDeviceUtils::ConvertToString((myCaptureTime2_ - myReadoutStartTime_)*1000.0));
 	}
-	MetadataSingleTag mst("Field Count", label, true);
-	//mst.SetValue(CDeviceUtils::ConvertToString((timeStamp - sequenceStartTime_).getMsec()));
-	mst.SetValue(CDeviceUtils::ConvertToString(fieldCount_));
-	md.SetTag(mst);
+	md.PutImageTag(prefix + "Field Count", CDeviceUtils::ConvertToString(fieldCount_));
 
-	MetadataSingleTag mst2("Field Buffer", label, true);
-	//mst.SetValue(CDeviceUtils::ConvertToString((timeStamp - sequenceStartTime_).getMsec()));
-	mst2.SetValue(CDeviceUtils::ConvertToString(fieldBuffer_));
-	md.SetTag(mst2);
-
-/*	MetadataSingleTag mstCount(MM::g_Keyword_Metadata_ImageNumber, label, true);
-	mstCount.SetValue(CDeviceUtils::ConvertToString(imageCounter_));      
-	md.SetTag(mstCount);
-
-	MetadataSingleTag mstB(MM::g_Keyword_Binning, label, true);
-	mstB.SetValue(CDeviceUtils::ConvertToString(binSize_));      
-	md.SetTag(mstB);
-*/
+	md.PutImageTag(prefix + "Field Buffer", CDeviceUtils::ConvertToString(fieldBuffer_));
 
    imageCounter_++;
  

--- a/DeviceAdapters/TISCam/TIScamera.h
+++ b/DeviceAdapters/TISCam/TIScamera.h
@@ -114,7 +114,6 @@ unsigned GetBitDepth() const;
 	int StopSequenceAcquisition();
     int StopSequenceAcquisition(bool temporary);
 
-	int RestartSequenceAcquisition();
 	bool IsCapturing();
 
 	// action interface for the camera
@@ -194,12 +193,8 @@ private:
 
 	long binSize_;
 
-
-	MM::MMTime sequenceStartTime_;
-
 	double interval_ms_;
 	long lastImage_;
-	long imageCounter_;
     MM::MMTime startTime_;
  	unsigned long sequenceLength_;
    bool stopOnOverflow_;

--- a/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
+++ b/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
@@ -1013,36 +1013,31 @@ int BitFlowCamera::LiveThread::svc()
       }
 
       char label[MM::MaxStrLength];
-   
       cam_->GetLabel(label);
+      std::string labelStr = label;
 
       MM::MMTime timestamp = cam_->GetCurrentMMTime();
       Metadata md;
+      std::string prefix = "TwoPhoton-";
 
-      MetadataSingleTag mstElapsed(MM::g_Keyword_Elapsed_Time_ms, label, true);
       MM::MMTime elapsed = timestamp - cam_->startTime_;
-      mstElapsed.SetValue(CDeviceUtils::ConvertToString(elapsed.getMsec()));
-	  md.SetTag(mstElapsed);
+      md.PutImageTag(prefix + MM::g_Keyword_Elapsed_Time_ms,
+         CDeviceUtils::ConvertToString(elapsed.getMsec()));
 
-	  MetadataSingleTag mstCount(MM::g_Keyword_Metadata_ImageNumber, label, true);
-	  mstCount.SetValue(CDeviceUtils::ConvertToString(imageCounter_));
-	  md.SetTag(mstCount);
-
+      md.PutImageTag(prefix + MM::g_Keyword_Metadata_ImageNumber,
+         CDeviceUtils::ConvertToString(imageCounter_));
 
 	  // insert all channels
 	  for (unsigned i=0; i<cam_->GetNumberOfChannels(); i++)
 	  {
 		  char buf[MM::MaxStrLength];
-		  MetadataSingleTag mstChannel(MM::g_Keyword_CameraChannelIndex, label, true);
 		  snprintf(buf, MM::MaxStrLength, "%d", i);
-		  mstChannel.SetValue(buf);
-		  md.SetTag(mstChannel);
+		  md.PutImageTag(MM::g_Keyword_CameraChannelIndex, buf);
+		  md.PutImageTag(labelStr + MM::g_Keyword_CameraChannelIndex, buf); // compat
 
-		  MetadataSingleTag mstChannelName(MM::g_Keyword_CameraChannelName, label, true);
 		  cam_->GetChannelName(i, buf);
-		  mstChannelName.SetValue(buf);
-		  md.SetTag(mstChannelName);
-
+		  md.PutImageTag(MM::g_Keyword_CameraChannelName, buf);
+		  md.PutImageTag(labelStr + MM::g_Keyword_CameraChannelName, buf); // compat
 
 		  ret = cam_->GetCoreCallback()->InsertImage(cam_, cam_->GetImageBuffer(i),
 			  cam_->GetImageWidth(),


### PR DESCRIPTION
Fix the minority of cameras that use metadata keys "MyLabel-Key" instead of "Key" for some or all fields of the camera-generated metadata. In the case of TISCam, delete the redundant fields.

Affected cameras: Andor, AndorSDK3, PICAM, PrincetonInstruments, RaptorEPIX (& HoribaEPIX), TIScam, TwoPhoton.
PVCAM change is commented code only.

Fixes #831.