### PR TITLE
fix: stop sequence in TesterCamera::SendSequence

### DIFF
--- a/DeviceAdapters/SequenceTester/SequenceTester.cpp
+++ b/DeviceAdapters/SequenceTester/SequenceTester.cpp
@@ -583,6 +583,11 @@ TesterCamera::SendSequence(bool finite, long count, bool stopOnOverflow)
    }
 
    delete[] bytes;
+
+   {
+      std::lock_guard<std::mutex> lock(sequenceMutex_);
+      stopSequence_ = true;
+   }
 }
 
 


### PR DESCRIPTION
@marktsuchida, while testing out the multi-cam stuff with sequencing, I tried to use a SequenceTester camera, but found that my script hung forever in `while core.isSequenceRunning`.

with claude, I think I tracked it down to `TesterCamera::IsCapturing()` returning true forever after a sequence completed naturally, because `SendSequence()` never set `stopSequence_ = true` when finishing ?