### PR TITLE
iSIMWaveforms: Always include MockDAQAdapter in list of DAQ devices

### DIFF
--- a/DeviceAdapters/iSIMWaveforms/MockDAQAdapter.h
+++ b/DeviceAdapters/iSIMWaveforms/MockDAQAdapter.h
@@ -109,10 +109,6 @@ public:
             logger_("[MockDAQ] clearTasks()");
     }
 
-private:
-    LogCallback logger_;
-    size_t channelCount_ = 0;
-
     std::vector<std::string> getDeviceNames() const override
     {
         return {"MockDev1", "MockDev2"};
@@ -150,4 +146,8 @@ private:
             return {"/MockDev2/PFI0", "/MockDev2/PFI1"};
         return {};
     }
+
+private:
+    LogCallback logger_;
+    size_t channelCount_ = 0;
 };

--- a/DeviceAdapters/iSIMWaveforms/iSIMWaveforms.h
+++ b/DeviceAdapters/iSIMWaveforms/iSIMWaveforms.h
@@ -180,6 +180,7 @@ private:
 	                                            const WaveformParams& params) const;
 
 	// DAQ configuration helpers
+	std::unique_ptr<IDAQDevice> CreateDaqAdapter(const std::string& deviceName);
 	void ConfigureDAQChannels();
 	std::vector<std::string> GetEnabledModInChannels() const;
 	std::vector<std::string> GetConfiguredModInChannels() const;


### PR DESCRIPTION
This is the follow-up PR to #829 . In that PR, @marktsuchida suggested that the mock DAQ devices should always be options for the DAQ device to ensure that the MockDAQAdapter code always compiles and is usable. This helps avoid bit rot.

In this PR, the mock devices always appear at the bottom of the device list. Real DAQ devices appear at the top.

This PR also fixes a subtle bug in that the device property for this device adapter has to come first alphabetically before any channel name properties. (Selecting a device let's you select between multiple DAQ boards and mock DAQs.) As a result I renamed the property from `Device` to `AO Device` and left a comment in the code. The reason is MM sets device properties from a configuration file in alphabetical order. `AO Device` needs to be set first so that we know what the allowed AO channel values are for a given device.

For example, if the the property name is `Device` and it is set to `MockDev1` but there is a real DAQ board called `Dev1` available, then when the configuration file loads:

1. Micro-Manager will try to set `AOTF Blanking Channel` to `MockDev1/aoN` as configured
2. `MockDev1/aoN` is not in the list of allowed channels because the device adapter has picked `Dev1` as its default device, `Dev1` coming before `MockDev1` alphabetically. The `Device` property hasn't yet been updated to `MockDev1`.
3. An invalid property value exception is raised.

If however, the property name is `AO Device`:

1. Micro-Manager will set the device from `Dev1` to `MockDev1`
2. Changing the property triggers an update of the available AO channels
3. Configuration proceeds without errors

I'm not a huge fan of this solution but I don't immediately see another way of doing this without making the whole thing a hub device, which seems like overkill.

<img width="473" height="282" alt="image" src="https://github.com/user-attachments/assets/4c226810-7fdb-48da-b8e5-592ce256417c" />
