### PR TITLE
MMCore: Deprecate prepareSequenceAcquisition(); make no-op

### DIFF
--- a/MMCore/Devices/CameraInstance.cpp
+++ b/MMCore/Devices/CameraInstance.cpp
@@ -132,7 +132,6 @@ int CameraInstance::GetMultiROI(unsigned* xs, unsigned* ys, unsigned* widths,
 int CameraInstance::StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow) { RequireInitialized(__func__); return GetImpl()->StartSequenceAcquisition(numImages, interval_ms, stopOnOverflow); }
 int CameraInstance::StartSequenceAcquisition(double interval_ms) { RequireInitialized(__func__); return GetImpl()->StartSequenceAcquisition(interval_ms); }
 int CameraInstance::StopSequenceAcquisition() { RequireInitialized(__func__); return GetImpl()->StopSequenceAcquisition(); }
-int CameraInstance::PrepareSequenceAcqusition() { RequireInitialized(__func__); return GetImpl()->PrepareSequenceAcqusition(); }
 bool CameraInstance::IsCapturing() { RequireInitialized(__func__); return GetImpl()->IsCapturing(); }
 
 std::string CameraInstance::GetTags()

--- a/MMCore/Devices/CameraInstance.h
+++ b/MMCore/Devices/CameraInstance.h
@@ -72,7 +72,6 @@ public:
    int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
    int StartSequenceAcquisition(double interval_ms);
    int StopSequenceAcquisition();
-   int PrepareSequenceAcqusition();
    bool IsCapturing();
    std::string GetTags();
    void AddTag(const char* key, const char* deviceLabel, const char* value);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -106,7 +106,7 @@ namespace mmi = mmcore::internal;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 11, MMCore_versionMinor = 12, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 11, MMCore_versionMinor = 13, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2925,9 +2925,11 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
 }
 
 /**
- * Prepare the camera for the sequence acquisition to save the time in the
- * StartSequenceAcqusition() call which is supposed to come next.
+ * Deprecated and only checks that the camera is not running a sequence acquisition.
+ *
+ * @deprecated
  */
+MMCORE_DEPRECATED
 void CMMCore::prepareSequenceAcquisition(const char* label) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<mmi::CameraInstance> pCam =
@@ -2938,14 +2940,7 @@ void CMMCore::prepareSequenceAcquisition(const char* label) MMCORE_LEGACY_THROW(
       throw CMMError(getCoreErrorText(MMERR_NotAllowedDuringSequenceAcquisition).c_str(),
                      MMERR_NotAllowedDuringSequenceAcquisition);
 
-   LOG_DEBUG(coreLogger_) << "Will prepare camera " << label <<
-      " for sequence acquisition";
-   int nRet = pCam->PrepareSequenceAcqusition();
-   if (nRet != DEVICE_OK)
-      throw CMMError(getDeviceErrorText(nRet, pCam).c_str(), MMERR_DEVICE_GENERIC);
-
-   LOG_DEBUG(coreLogger_) << "Did prepare camera " << label <<
-      " for sequence acquisition";
+   LOG_DEBUG(coreLogger_) << "Prepare camera " << label << " for sequence acquisition (deprecated; no-op)";
 }
 
 

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -412,7 +412,7 @@ public:
          bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError);
    void startSequenceAcquisition(const char* cameraLabel, long numImages,
          double intervalMs, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError);
-   void prepareSequenceAcquisition(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
+   MMCORE_DEPRECATED void prepareSequenceAcquisition(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
    void startContinuousSequenceAcquisition(double intervalMs) MMCORE_LEGACY_THROW(CMMError);
    void stopSequenceAcquisition() MMCORE_LEGACY_THROW(CMMError);
    void stopSequenceAcquisition(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.micro-manager.mmcorej</groupId>
     <artifactId>MMCoreJ</artifactId>
-    <version>11.12.0</version>
+    <version>11.13.0</version>
 
     <name>MMCore Java API</name>
     <description>Java bindings for MMCore, the device abstraction layer of Micro-Manager, the microscope control and acquisition platform.</description>


### PR DESCRIPTION
Part of #595.

This function was implemented incorrectly in many cameras and rarely did anything useful.

Keep the check for camera existing and sequence acquisition running, to minimize impact on any user code calling this (which is expected to be rare).

Bump MMCore version to 11.13.0.