### PR TITLE
Prevent override of PrepareSequenceAcqusition()

### DIFF
--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1479,7 +1479,8 @@ public:
       CDeviceUtils::CopyLimitedString(serializedMetadata, md.Serialize());
    }
 
-   virtual int PrepareSequenceAcqusition() {return DEVICE_OK;}
+   // To be removed; devices should no longer override.
+   virtual int PrepareSequenceAcqusition() final {return DEVICE_OK;}
 
    /**
     * @brief Start sequence acquisition.


### PR DESCRIPTION
All uses by devices have been removed and the function is slated for removal.

Part of #595.