### PR TITLE
Remove GetComponentName() overrides

### DIFF
--- a/DeviceAdapters/FLICamera/FLICamera.cpp
+++ b/DeviceAdapters/FLICamera/FLICamera.cpp
@@ -392,18 +392,6 @@ const unsigned char* CFLICamera::GetImageBuffer()
 	return img_.GetPixels();
 }
 
-int CFLICamera::GetComponentName(unsigned channel, char* name)
-{
-  if (channel >= GetNumberOfComponents())
-     return DEVICE_NONEXISTENT_CHANNEL;
-
-	char buf[32];
-	snprintf(buf, sizeof(buf), "Channel %d", channel);
-
-  CDeviceUtils::CopyLimitedString(name, buf);
-  return DEVICE_OK;
-}
-
 unsigned CFLICamera::GetNumberOfChannels() const 
 {
   return 1;

--- a/DeviceAdapters/FLICamera/FLICamera.h
+++ b/DeviceAdapters/FLICamera/FLICamera.h
@@ -61,7 +61,6 @@ class CFLICamera : public CLegacyCameraBase<CFLICamera>
 		int GetBinning() const;
 		int SetBinning(int binSize);
 		int IsExposureSequenceable(bool& seq) const {seq = false; return DEVICE_OK;}
-		int GetComponentName(unsigned channel, char* name);
 		unsigned GetNumberOfChannels() const;
 		unsigned GetNumberOfComponents() const;
 

--- a/DeviceAdapters/GigECamera/GigECamera.cpp
+++ b/DeviceAdapters/GigECamera/GigECamera.cpp
@@ -696,21 +696,6 @@ unsigned int CGigECamera::GetNumberOfComponents() const
 	return color_ ? 4 : 1;
 }
 
- int CGigECamera::GetComponentName(unsigned comp, char* name)
- {
-	if ( comp > 4 )
-	{
-		name = "invalid comp";
-		return DEVICE_ERR;
-	}
-
-	std::string rgba ("RGBA");
-	CDeviceUtils::CopyLimitedString(name, &rgba.at(comp) );
-
-	return DEVICE_OK;
- }
-
-
 /**
 * Sets the camera Region Of Interest.
 * Required by the MM::Camera API.

--- a/DeviceAdapters/GigECamera/GigECamera.h
+++ b/DeviceAdapters/GigECamera/GigECamera.h
@@ -114,11 +114,6 @@ public:
 	unsigned GetNumberOfComponents() const;
 
 	/**
-    * Returns the name for each component
-    */
-	int GetComponentName(unsigned comp, char* name);
-
-	/**
 	* Returns the size in bytes of the image buffer.
 	* Required by the MM::Camera API.
 	* For multi-channel cameras, return the size of a single channel

--- a/DeviceAdapters/IIDC/MMIIDCCamera.h
+++ b/DeviceAdapters/IIDC/MMIIDCCamera.h
@@ -105,7 +105,6 @@ public:
 
    // virtual const unsigned int* GetImageBufferAsRGB32(); // TODO
    // virtual unsigned GetNumberOfComponents() const;
-   // virtual int GetComponentName(unsigned component, char* name);
 
    virtual long GetImageBufferSize() const;
    virtual unsigned GetImageWidth() const;

--- a/DeviceAdapters/Motic/MoticCamera.h
+++ b/DeviceAdapters/Motic/MoticCamera.h
@@ -98,34 +98,6 @@ public:
     return 4;
   }
 
-  int GetComponentName(unsigned channel, char* name)
-  {
-    if(m_iBytesPerPixel == 1 || m_iBytesPerPixel == 2)
-    {
-       CDeviceUtils::CopyLimitedString(name, "Grayscale");
-    }
-    else if(channel == 0)
-    {
-      CDeviceUtils::CopyLimitedString(name, "Blue");
-    }
-    else if(channel == 1)
-    {
-      CDeviceUtils::CopyLimitedString(name, "Green");
-    }
-    else if(channel == 2)
-    {
-      CDeviceUtils::CopyLimitedString(name, "Red");
-    }
-    else if(channel == 3)
-    {
-      CDeviceUtils::CopyLimitedString(name, "Alpha");
-    }
-    else
-    {
-      return DEVICE_NONEXISTENT_CHANNEL;
-    }
-    return DEVICE_OK; 
-  }
 //    unsigned GetNumberOfChannels() const 
 //    {
 //       return 3;

--- a/DeviceAdapters/Motic_mac/MUCamSource.cpp
+++ b/DeviceAdapters/Motic_mac/MUCamSource.cpp
@@ -630,35 +630,6 @@ unsigned MUCamSource::GetNumberOfComponents() const
     return 4;
 }
 
-int MUCamSource::GetComponentName(unsigned channel, char* name)
-{
-    if(bytesPerPixel_ == 1 || bytesPerPixel_ == 2)
-    {
-        CDeviceUtils::CopyLimitedString(name, "Grayscale");
-    }
-    else if(channel == 0)
-    {
-        CDeviceUtils::CopyLimitedString(name, "Blue");
-    }
-    else if(channel == 1)
-    {
-        CDeviceUtils::CopyLimitedString(name, "Green");
-    }
-    else if(channel == 2)
-    {
-        CDeviceUtils::CopyLimitedString(name, "Red");
-    }
-    else if(channel == 3)
-    {
-        CDeviceUtils::CopyLimitedString(name, "Alpha");
-    }
-    else
-    {
-        return DEVICE_NONEXISTENT_CHANNEL;
-    }
-    return DEVICE_OK;
-}
-
 const unsigned int* MUCamSource::GetImageBufferAsRGB32()
 {
     return (unsigned int*)img_.GetPixels();

--- a/DeviceAdapters/Motic_mac/MUCamSource.h
+++ b/DeviceAdapters/Motic_mac/MUCamSource.h
@@ -97,7 +97,6 @@ public:
     
     //////////////////////////////////////////////////////////////////////////
     unsigned GetNumberOfComponents() const;
-    int GetComponentName(unsigned channel, char* name);
     const unsigned int* GetImageBufferAsRGB32();
     
 private:

--- a/DeviceAdapters/NikonKs/NikonKsCam.cpp
+++ b/DeviceAdapters/NikonKs/NikonKsCam.cpp
@@ -1109,21 +1109,6 @@ int NikonKsCam::SetBinning(int /* binF */)
     return DEVICE_OK;
 }
 
-int NikonKsCam::GetComponentName(unsigned comp, char* name)
-{
-    if (comp > 4)
-    {
-        name = "invalid comp";
-        return DEVICE_ERR;
-    }
-
-    std::string rgba("RGBA");
-    CDeviceUtils::CopyLimitedString(name, &rgba.at(comp));
-
-    return DEVICE_OK;
-}
-
-
 //Sequence functions, mostly copied from other drivers with slight modification
 /**
  * Required by the MM::Camera API

--- a/DeviceAdapters/NikonKs/NikonKsCam.h
+++ b/DeviceAdapters/NikonKs/NikonKsCam.h
@@ -72,7 +72,6 @@ public:
 	unsigned GetImageBytesPerPixel() const{return img_.Depth();};
 	unsigned GetBitDepth() const{return bitDepth_;};
 	long GetImageBufferSize() const{return img_.Width() * img_.Height() * GetImageBytesPerPixel();}
-	int GetComponentName(unsigned comp, char* name);
 	unsigned GetNumberOfComponents() const{return numComponents_;};
 	double GetExposure() const;
 	void SetExposure(double exp);

--- a/DeviceAdapters/QCam/QICamera.cpp
+++ b/DeviceAdapters/QCam/QICamera.cpp
@@ -4130,14 +4130,6 @@ unsigned QICamera::GetNumberOfComponents() const
    //return 1;
 }
 
-int QICamera::GetComponentName(unsigned comp, char* name)
-{
-   char compName[MM::MaxStrLength];
-   snprintf(compName, MM::MaxStrLength, "component-%d", comp);
-   CDeviceUtils::CopyLimitedString(name, compName);
-   return DEVICE_OK;
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // Private QICamera methods
 ///////////////////////////////////////////////////////////////////////////////

--- a/DeviceAdapters/QCam/QICamera.h
+++ b/DeviceAdapters/QCam/QICamera.h
@@ -201,7 +201,6 @@ public:
     int RestartSequenceAcquisition();
     bool IsCapturing() { return m_sthd->IsRunning(); };
     unsigned GetNumberOfComponents() const;
-    int GetComponentName(unsigned comp, char* name);
 
     // action interface
     // ----------------

--- a/DeviceAdapters/SimpleCam/CameraFrontend.cpp
+++ b/DeviceAdapters/SimpleCam/CameraFrontend.cpp
@@ -473,42 +473,6 @@ unsigned int CCameraFrontend::GetNumberOfComponents() const
 }
 
 /**
-* Returns the name for each channel. 
-*/
-int CCameraFrontend::GetComponentName(unsigned int channel, char* name)
-{
-   if (imgGrayScale_)
-   {
-      if (channel == 0)
-         CDeviceUtils::CopyLimitedString(name, "Grayscale");
-      else
-         return DEVICE_NONEXISTENT_CHANNEL;
-   }
-   else 
-   {
-      switch (channel)
-      {
-         case 0:
-            CDeviceUtils::CopyLimitedString(name, "Blue");
-            break;
-         case 1:
-            CDeviceUtils::CopyLimitedString(name, "Green");
-            break;
-         case 2:
-            CDeviceUtils::CopyLimitedString(name, "Red");
-            break;
-         case 3:
-            CDeviceUtils::CopyLimitedString(name, "Alpha");
-            break;
-         default:
-            return DEVICE_NONEXISTENT_CHANNEL;
-            break;
-      }
-   }
-   return DEVICE_OK;
-}
-
-/**
 * Returns image buffer X-size in pixels.
 * Required by the MM::Camera API.
 */

--- a/DeviceAdapters/SimpleCam/CameraFrontend.h
+++ b/DeviceAdapters/SimpleCam/CameraFrontend.h
@@ -79,7 +79,6 @@ public:
    const unsigned char* GetImageBuffer();
    const unsigned int* GetImageBufferAsRGB32();
    unsigned GetNumberOfComponents() const;
-   int GetComponentName(unsigned int channel, char* name);
    unsigned GetImageWidth() const;
    unsigned GetImageHeight() const;
    unsigned GetImageBytesPerPixel() const;

--- a/DeviceAdapters/Spot/SpotCamera.cpp
+++ b/DeviceAdapters/Spot/SpotCamera.cpp
@@ -761,36 +761,6 @@ unsigned int SpotCamera::GetNumberOfComponents() const
 }
 
 
-int SpotCamera::GetComponentName(unsigned channel, char* name)
-{
-	bool bColor = (pImplementation_->CanDoColor() && (1 == pImplementation_->BinSize()));
-  if (!bColor && (channel > 0))  return DEVICE_NONEXISTENT_CHANNEL;      
-  
-  switch (channel)
-  {
-  case 0:      
-    if (!bColor) 
-      CDeviceUtils::CopyLimitedString(name, "Grayscale");
-    else 
-      CDeviceUtils::CopyLimitedString(name, "B");
-    break;
-
-  case 1:
-    CDeviceUtils::CopyLimitedString(name, "G");
-    break;
-
-  case 2:
-    CDeviceUtils::CopyLimitedString(name, "R");
-    break;
-
-  default:
-    return DEVICE_NONEXISTENT_CHANNEL;
-    break;
-  }
-  return DEVICE_OK;
-}
- 
-
 /**
  * Returns image buffer X-size in pixels.
  * Required by the MM::Camera API.

--- a/DeviceAdapters/Spot/SpotCamera.h
+++ b/DeviceAdapters/Spot/SpotCamera.h
@@ -72,7 +72,6 @@ public:
    const unsigned char* GetImageBuffer();
    const unsigned int* GetImageBufferAsRGB32();
    unsigned int GetNumberOfComponents() const;
-   int GetComponentName(unsigned channel, char* name);
          
    unsigned GetImageWidth() const;
    unsigned GetImageHeight() const;

--- a/DeviceAdapters/TwainCamera/TwainCamera.cpp
+++ b/DeviceAdapters/TwainCamera/TwainCamera.cpp
@@ -446,22 +446,6 @@ unsigned int TwainCamera::GetNumberOfComponents() const
    return n;
 }
 
-int TwainCamera::GetComponentName(unsigned int channel, char* name)
-{
-   int ret=DEVICE_ERR;
-   if(channel == 0)
-   {
-      CDeviceUtils::CopyLimitedString(name, g_ChannelName);
-      ret = DEVICE_OK;
-   }
-   else
-   {
-      CDeviceUtils::CopyLimitedString(name, g_Unknown);
-      ret = DEVICE_NONEXISTENT_CHANNEL;
-   }
-   return ret;
-}
-
 
 /**
 * Shuts down (unloads) the device.

--- a/DeviceAdapters/TwainCamera/TwainCamera.h
+++ b/DeviceAdapters/TwainCamera/TwainCamera.h
@@ -82,7 +82,6 @@ public:
    const unsigned char* GetImageBuffer();
    const unsigned int* GetImageBufferAsRGB32();
    unsigned GetNumberOfComponents() const;
-   int GetComponentName(unsigned int channel, char* name);
    unsigned GetImageWidth() const;
    unsigned GetImageHeight() const;
    unsigned GetImageBytesPerPixel() const;

--- a/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
+++ b/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
@@ -646,18 +646,6 @@ unsigned BitFlowCamera::GetNumberOfChannels() const
 	//return (unsigned)img_.size();
 }
 
-
-int BitFlowCamera::GetComponentName(unsigned channel, char* name)
-{
-   if (channel < 0 || channel >= img_.size())
-      return DEVICE_NONEXISTENT_CHANNEL;
-
-   ostringstream txt;
-   txt << "Input-" << channel;
-   CDeviceUtils::CopyLimitedString(name, txt.str().c_str());
-   return DEVICE_OK;
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // BitFlowCamera Action handlers
 ///////////////////////////////////////////////////////////////////////////////

--- a/DeviceAdapters/TwoPhoton/TwoPhoton.h
+++ b/DeviceAdapters/TwoPhoton/TwoPhoton.h
@@ -79,7 +79,6 @@ public:
    int GetChannelName(unsigned channel, char* name);
 
    unsigned GetNumberOfComponents() const;
-   int GetComponentName(unsigned channel, char* name);
 
    unsigned GetImageWidth() const;
    unsigned GetImageHeight() const;

--- a/DeviceAdapters/ZWO/MyASICam2.cpp
+++ b/DeviceAdapters/ZWO/MyASICam2.cpp
@@ -867,36 +867,7 @@ long CMyASICam::GetImageBufferSize() const
 {
 	return iROIWidth*iROIHeight*iPixBytes;
 }
- /**
-       * Returns the name for each component 
-       */
-int CMyASICam::GetComponentName(unsigned component, char* name)
-{
-	if(iComponents != 1)
-	{
-		switch (component)
-		{
-		case 1:
-			strcpy(name, "red");
-			break;
-		case 2:
-			strcpy(name, "green");
-			break;
-		case 3:
-			strcpy(name, "blue");
-			break;
-		case 4:
-			strcpy(name, "0");
-			break;
-		default:
-			strcpy(name, "error");
-			break;
-		}
-	}
-	else
-		strcpy(name, "grey");
-	return DEVICE_OK;
-}
+
 /**
 * Sets the camera Region Of Interest.
 * Required by the MM::Camera API.

--- a/DeviceAdapters/ZWO/MyASICam2.h
+++ b/DeviceAdapters/ZWO/MyASICam2.h
@@ -47,7 +47,7 @@ public:
 	int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow);
 	int StopSequenceAcquisition();
 	unsigned  GetNumberOfComponents() const { return iComponents;};
-	int GetComponentName(unsigned component, char* name);
+
 	// action interface
 	// ----------------
 	int OnBinning(MM::PropertyBase* pProp, MM::ActionType eAct);

--- a/DeviceAdapters/dc1394/dc1394.cpp
+++ b/DeviceAdapters/dc1394/dc1394.cpp
@@ -1728,37 +1728,6 @@ unsigned int Cdc1394::GetNumberOfComponents() const
 }
 
 
-// EF: pretty much identical to SpotCamera.cpp
-int Cdc1394::GetComponentName(unsigned channel, char* name)
-{
-	bool bColor = IsColor();
-	if (!bColor && (channel > 0))  return DEVICE_NONEXISTENT_CHANNEL;      
-	
-	switch (channel)
-	{
-		case 0:      
-			if (!bColor) 
-				CDeviceUtils::CopyLimitedString(name, "Grayscale");
-			else 
-				CDeviceUtils::CopyLimitedString(name, "B");
-			break;
-			
-		case 1:
-			CDeviceUtils::CopyLimitedString(name, "G");
-			break;
-			
-		case 2:
-			CDeviceUtils::CopyLimitedString(name, "R");
-			break;
-			
-		default:
-			return DEVICE_NONEXISTENT_CHANNEL;
-			break;
-	}
-	return DEVICE_OK;
-}
-
-
 int Cdc1394::GetBytesPerPixel() const
 {
    if (depth_ <= 8 && integrateFrameNumber_ == 1) {

--- a/DeviceAdapters/dc1394/dc1394.h
+++ b/DeviceAdapters/dc1394/dc1394.h
@@ -138,7 +138,6 @@ public:
    unsigned GetImageHeight() const {return img_.Height();}
    unsigned GetImageBytesPerPixel() const {return img_.Depth();} 
    unsigned int GetNumberOfComponents() const;
-   int GetComponentName(unsigned channel, char* name);
    long GetImageBufferSize() const {return img_.Width() * img_.Height() * GetImageBytesPerPixel();}
    unsigned GetBitDepth() const;
    int GetBinning() const;

--- a/MMCore/Devices/CameraInstance.cpp
+++ b/MMCore/Devices/CameraInstance.cpp
@@ -30,17 +30,6 @@ const unsigned char* CameraInstance::GetImageBuffer() { RequireInitialized(__fun
 const unsigned char* CameraInstance::GetImageBuffer(unsigned channelNr) { RequireInitialized(__func__); return GetImpl()->GetImageBuffer(channelNr); }
 const unsigned int* CameraInstance::GetImageBufferAsRGB32() { RequireInitialized(__func__); return GetImpl()->GetImageBufferAsRGB32(); }
 unsigned CameraInstance::GetNumberOfComponents() const { RequireInitialized(__func__); return GetImpl()->GetNumberOfComponents(); }
-
-std::string CameraInstance::GetComponentName(unsigned component)
-{
-   RequireInitialized(__func__);
-   DeviceStringBuffer nameBuf(this, "GetComponentName");
-   int err = GetImpl()->GetComponentName(component, nameBuf.GetBuffer());
-   ThrowIfError(err, "Cannot get component name at index " +
-         ToString(component));
-   return nameBuf.Get();
-}
-
 int unsigned CameraInstance::GetNumberOfChannels() const { RequireInitialized(__func__); return GetImpl()->GetNumberOfChannels(); }
 
 std::string CameraInstance::GetChannelName(unsigned channel)

--- a/MMCore/Devices/CameraInstance.h
+++ b/MMCore/Devices/CameraInstance.h
@@ -44,7 +44,6 @@ public:
    const unsigned char* GetImageBuffer(unsigned channelNr);
    const unsigned int* GetImageBufferAsRGB32();
    unsigned GetNumberOfComponents() const;
-   std::string GetComponentName(unsigned component);
    int unsigned GetNumberOfChannels() const;
    std::string GetChannelName(unsigned channel);
    long GetImageBufferSize()const;

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1415,12 +1415,11 @@ public:
       return 1; // Default to monochrome (ie not RGB)
    }
 
-   virtual int GetComponentName(unsigned channel, char* name)
+   // To be removed (never used by MMCore); devices should not override.
+   virtual int GetComponentName(unsigned channel, char* name) final
    {
-      if (channel > 0)
-         return DEVICE_NONEXISTENT_CHANNEL;
-
-      CDeviceUtils::CopyLimitedString(name, "Grayscale");
+      (void)channel;
+      CDeviceUtils::CopyLimitedString(name, "");
       return DEVICE_OK;
    }
 

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -372,10 +372,10 @@ namespace MM {
        * This is '1' for grayscale cameras, and '4' for RGB cameras.
        */
       virtual unsigned GetNumberOfComponents() const = 0;
-      /**
-       * @brief Return the name for each component.
-       */
+
+      /** Unused; to be removed. */
       virtual int GetComponentName(unsigned component, char* name) = 0;
+
       /**
        * @brief Return the number of simultaneous channels that camera is capable of.
        *


### PR DESCRIPTION
This function is not called by MMCore and those cameras that implement it do so inconsistently (and sometimes incorrectly by confusing component with channel).

Remove overrides and support code in Core. Block future overrides by marking the default implementation final.

Prepares us for #754.