### PR TITLE
Remove doProcess flag from InsertImage() calls

### DIFF
--- a/DeviceAdapters/Andor/Andor.cpp
+++ b/DeviceAdapters/Andor/Andor.cpp
@@ -5295,8 +5295,7 @@ int AndorCamera::GetCameraAcquisitionProgress(at_32* series)
                SRRFImage_->Width(),
                SRRFImage_->Height(),
                SRRFImage_->Depth(),
-               md.Serialize(),
-               false);
+               md.Serialize());
             //oss.str("");
             //oss << "[PushImageWithSRRF] sent up an image to MMCore and returned: " << corecallbackInsertImageReturn << endl;
             //Log(oss.str().c_str());

--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -183,8 +183,7 @@ void AravisCamera::AcquisitionCallback(ArvStreamCallbackType type, ArvBuffer *cb
 					     img_buffer_height,
 					     img_buffer_bytes_per_pixel,
 					     1,
-					     md.Serialize(),
-					     FALSE);
+					     md.Serialize());
 
     arv_stream_push_buffer(arv_stream, cb_arv_buffer);
     counter += 1;

--- a/DeviceAdapters/Basler/BaslerPylonCamera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylonCamera.cpp
@@ -2145,7 +2145,7 @@ void CircularBufferInserter::OnImageGrabbed(CInstantCamera& /* camera */, const 
 			//copy to intermediate buffer
 			int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)ptrGrabResult->GetBuffer(),
 				(unsigned)ptrGrabResult->GetWidth(), (unsigned)ptrGrabResult->GetHeight(),
-				(unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize(), FALSE);
+				(unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize());
 		}
 		else if (IsByerFormat || ptrGrabResult->GetPixelType() == PixelType_RGB8packed)
 		{
@@ -2155,7 +2155,7 @@ void CircularBufferInserter::OnImageGrabbed(CInstantCamera& /* camera */, const 
 			//copy to intermediate buffer
 			int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)image.GetBuffer(),
 				(unsigned)dev_->GetImageWidth(), (unsigned)dev_->GetImageHeight(),
-				(unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize(), FALSE);
+				(unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize());
 		}
 		else if (ptrGrabResult->GetPixelType() == PixelType_BGR8packed)
 		{
@@ -2163,7 +2163,7 @@ void CircularBufferInserter::OnImageGrabbed(CInstantCamera& /* camera */, const 
 			//copy to intermediate buffer
 			int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)dev_->Buffer4ContinuesShot,
 				(unsigned)dev_->GetImageWidth(), (unsigned)dev_->GetImageHeight(),
-				(unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize(), FALSE);
+				(unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize());
 		}
 	}
 	else

--- a/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
+++ b/DeviceAdapters/DahengGalaxy/ClassGalaxy.cpp
@@ -2059,7 +2059,7 @@ void CircularBufferInserter::DoOnImageCaptured(CImageDataPointer& objImageDataPo
             //copy to intermediate buffer
             int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)objImageDataPointer->GetBuffer(),
                 (unsigned)objImageDataPointer->GetWidth(), (unsigned)objImageDataPointer->GetHeight(),
-                (unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize(), FALSE);
+                (unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize());
         }
         else if (dev_->colorCamera_)
         {
@@ -2074,7 +2074,7 @@ void CircularBufferInserter::DoOnImageCaptured(CImageDataPointer& objImageDataPo
             //copy to intermediate buffer
             int ret = dev_->GetCoreCallback()->InsertImage(dev_, (const unsigned char*)dev_->imgBuffer_,
                 (unsigned)dev_->GetImageWidth(), (unsigned)dev_->GetImageHeight(),
-                (unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize(), FALSE);
+                (unsigned)dev_->GetImageBytesPerPixel(), 1, md.Serialize());
         }
         imgCounter_++;
         if (imgCounter_ == numImages_)

--- a/DeviceAdapters/Fli/FirstLightImagingCameras.cpp
+++ b/DeviceAdapters/Fli/FirstLightImagingCameras.cpp
@@ -225,7 +225,7 @@ void FirstLightImagingCameras::imageReceived(const uint8_t* image)
 
 	MM::Core* core = GetCoreCallback();
 
-	int ret = core->InsertImage(this, image, w, h, b, 1, md.Serialize(), false);
+	int ret = core->InsertImage(this, image, w, h, b, 1, md.Serialize());
 }
 
 //---------------------------------------------------------------

--- a/DeviceAdapters/Hikrobot/HikrobotCamera.cpp
+++ b/DeviceAdapters/Hikrobot/HikrobotCamera.cpp
@@ -1547,7 +1547,7 @@ void HikrobotCamera::ImageRecvThreadProc()
 
 			nRet = GetCoreCallback()->InsertImage(this, (const unsigned char*)stConvertParam.pDstBuffer,
 				stOutFrame.stFrameInfo.nWidth,
-				stOutFrame.stFrameInfo.nHeight, GetImageBytesPerPixel(), 1, md.Serialize(), FALSE);
+				stOutFrame.stFrameInfo.nHeight, GetImageBytesPerPixel(), 1, md.Serialize());
 			if (nRet == DEVICE_OK)
 			{
 				MvWriteLog(__FILE__, __LINE__, m_chDevID, "Success InsertImage Width[%d], Height[%d], FrameNum[%d] FrameLen[%d] enPixelType[%lld]",

--- a/DeviceAdapters/MatrixVision/mvIMPACT_Acquire_Device.cpp
+++ b/DeviceAdapters/MatrixVision/mvIMPACT_Acquire_Device.cpp
@@ -978,7 +978,7 @@ int mvIMPACT_Acquire_Device::InsertImage( void )
    const unsigned int w = GetImageWidth();
    const unsigned int h = GetImageHeight();
    const unsigned int b = GetImageBytesPerPixel();
-   return GetCoreCallback()->InsertImage( this, pI, w, h, b, md.Serialize(), false );
+   return GetCoreCallback()->InsertImage( this, pI, w, h, b, md.Serialize());
 }
 
 //-----------------------------------------------------------------------------

--- a/DeviceAdapters/Pixelink/Pixelink.cpp
+++ b/DeviceAdapters/Pixelink/Pixelink.cpp
@@ -910,7 +910,7 @@ int Pixelink::InsertImage()
 	md.AddTag(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(imageCounter_));
 	md.AddTag("FrameCounter", frameCounter);
 
-	return GetCoreCallback()->InsertImage(this, pPixel, w, h, b, md.Serialize(), false);
+	return GetCoreCallback()->InsertImage(this, pPixel, w, h, b, md.Serialize());
 }
 
 

--- a/DeviceAdapters/PointGrey/PointGrey.cpp
+++ b/DeviceAdapters/PointGrey/PointGrey.cpp
@@ -1351,7 +1351,7 @@ int PointGrey::InsertImage(Image* pImg)
    {
       pData = RGBToBGRA(pImg->GetData());
    }
-   return GetCoreCallback()->InsertImage(this, pData, w, h, b, md.Serialize(), false);
+   return GetCoreCallback()->InsertImage(this, pData, w, h, b, md.Serialize());
 }
 
 

--- a/DeviceAdapters/Ximea/XIMEACamera.cpp
+++ b/DeviceAdapters/Ximea/XIMEACamera.cpp
@@ -815,7 +815,7 @@ int XimeaCamera::InsertImage()
 	unsigned int h = GetImageHeight();
 	unsigned int b = GetImageBytesPerPixel();
 
-	return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize(), false);
+	return GetCoreCallback()->InsertImage(this, pI, w, h, b, md.Serialize());
 }
 
 /***********************************************************************


### PR DESCRIPTION
Now that the device-side handling of clear-and-continue is gone, passing false is incorrect.

Part of #722.