### PR TITLE
MMDevice: remove 3 Camera functions (bumps DIV)

### DIFF
--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1422,21 +1422,9 @@ public:
     */
    virtual int StopSequenceAcquisition() = 0;
 
-   // It appears that this function was never used by MMCore and is slated for
-   // removal. Concrete cameras should not override.
-   double GetPixelSizeUm() const final { return 0.0; }
-
    virtual unsigned GetNumberOfComponents() const
    {
       return 1; // Default to monochrome (ie not RGB)
-   }
-
-   // To be removed (never used by MMCore); devices should not override.
-   virtual int GetComponentName(unsigned channel, char* name) final
-   {
-      (void)channel;
-      CDeviceUtils::CopyLimitedString(name, "");
-      return DEVICE_OK;
    }
 
    /**
@@ -1493,9 +1481,6 @@ public:
       }
       CDeviceUtils::CopyLimitedString(serializedMetadata, md.Serialize());
    }
-
-   // To be removed; devices should no longer override.
-   virtual int PrepareSequenceAcqusition() final {return DEVICE_OK;}
 
    /**
     * @brief Start sequence acquisition.

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -28,7 +28,7 @@
 // Header version
 // If any of the class definitions changes, the interface version
 // must be incremented
-#define DEVICE_INTERFACE_VERSION 74
+#define DEVICE_INTERFACE_VERSION 75
 ///////////////////////////////////////////////////////////////////////////////
 
 // N.B.
@@ -373,9 +373,6 @@ namespace MM {
        */
       virtual unsigned GetNumberOfComponents() const = 0;
 
-      /** Unused; to be removed. */
-      virtual int GetComponentName(unsigned component, char* name) = 0;
-
       /**
        * @brief Return the number of simultaneous channels that camera is capable of.
        *
@@ -422,10 +419,6 @@ namespace MM {
        * Required by the MM::Camera API.
        */
       virtual unsigned GetBitDepth() const = 0;
-      /**
-       * @brief Unused and slated for removal. Implemented in DeviceBase.h.
-       */
-      virtual double GetPixelSizeUm() const = 0;
       /**
        * @brief Return the current binning factor.
        */
@@ -488,10 +481,6 @@ namespace MM {
        * @brief Stop an ongoing sequence acquisition.
        */
       virtual int StopSequenceAcquisition() = 0;
-      /**
-       * @brief Set up the camera so that Sequence acquisition can start without delay.
-       */
-      virtual int PrepareSequenceAcqusition() = 0;
       /**
        * @brief Indicate whether sequence acquisition is currently running.
        *


### PR DESCRIPTION
Closes #596
Closes #754
Closes #595

These have already been made `final` recently to prevent override.
`GetPixelSizeUm()` - never called from Core, intent unclear
`GetComponentName()` - never called from Core, inconsistent impls
`PrepareSequenceAcqusition()` - inconsistent impls, seldom of value, typo in name