### PR TITLE
Ordinary cameras should not name their channel

### DIFF
--- a/DeviceAdapters/FLICamera/FLICamera.cpp
+++ b/DeviceAdapters/FLICamera/FLICamera.cpp
@@ -392,11 +392,6 @@ const unsigned char* CFLICamera::GetImageBuffer()
 	return img_.GetPixels();
 }
 
-unsigned CFLICamera::GetNumberOfChannels() const 
-{
-  return 1;
-}
-
 unsigned CFLICamera::GetNumberOfComponents() const 
 {
   return 1;

--- a/DeviceAdapters/FLICamera/FLICamera.h
+++ b/DeviceAdapters/FLICamera/FLICamera.h
@@ -61,7 +61,6 @@ class CFLICamera : public CLegacyCameraBase<CFLICamera>
 		int GetBinning() const;
 		int SetBinning(int binSize);
 		int IsExposureSequenceable(bool& seq) const {seq = false; return DEVICE_OK;}
-		unsigned GetNumberOfChannels() const;
 		unsigned GetNumberOfComponents() const;
 
     // action interface

--- a/DeviceAdapters/JAI/JAI.cpp
+++ b/DeviceAdapters/JAI/JAI.cpp
@@ -713,22 +713,6 @@ unsigned JAICamera::GetNumberOfComponents() const
 	return 4;
 }
 
-unsigned JAICamera::GetNumberOfChannels() const
-{
-   return 1;
-}
-
-int JAICamera::GetChannelName(unsigned channel, char* name)
-{
-   // TODO: multichannel
-
-   if (channel != 0)
-      return ERR_INVALID_CHANNEL_INDEX;
-   
-   strncpy(name, "Channel-0", MM::MaxStrLength);
-   return DEVICE_OK;
-}
-
 /**
  * Snaps a single image, blocks at least until exposure is finished 
  */

--- a/DeviceAdapters/JAI/JAI.h
+++ b/DeviceAdapters/JAI/JAI.h
@@ -152,8 +152,6 @@ public:
    const unsigned char* GetImageBuffer();
 
    unsigned GetNumberOfComponents() const;
-   unsigned GetNumberOfChannels() const;
-   int GetChannelName(unsigned channel, char* name);
 
    unsigned GetImageWidth() const {return img.Width();}
    unsigned GetImageHeight() const {return img.Height();}

--- a/DeviceAdapters/Motic/MoticCamera.h
+++ b/DeviceAdapters/Motic/MoticCamera.h
@@ -98,39 +98,6 @@ public:
     return 4;
   }
 
-//    unsigned GetNumberOfChannels() const 
-//    {
-//       return 3;
-//    }
-// 
-//    virtual int GetChannelName(unsigned  channel , char* name)
-//    {
-//      if(channel == 0)
-//      {
-//        CDeviceUtils::CopyLimitedString(name, "Blue");
-//      }
-//      else if(channel == 1)
-//      {
-//        CDeviceUtils::CopyLimitedString(name, "Green");
-//      }
-//      else if(channel == 2)
-//      {
-//        CDeviceUtils::CopyLimitedString(name, "Red");
-//      }
-//      else
-//      {
-//        return DEVICE_NONEXISTENT_CHANNEL;
-//      }
-//      return DEVICE_OK;      
-//    }
-// 
-//    virtual const unsigned char* GetImageBuffer(unsigned /* channelNr */)
-//    {
-//       if (GetNumberOfChannels() == 1)
-//          return GetImageBuffer();
-//       return 0;
-//    }
-
    const unsigned int* GetImageBufferAsRGB32()
    {
       return (unsigned int*)m_img.GetPixels();

--- a/DeviceAdapters/TSI/TSI3Cam.cpp
+++ b/DeviceAdapters/TSI/TSI3Cam.cpp
@@ -578,11 +578,6 @@ unsigned Tsi3Cam::GetNumberOfComponents() const
 	return numComp;
 }
 
-unsigned Tsi3Cam::GetNumberOfChannels() const
-{
-   return 1;
-}
-
 unsigned Tsi3Cam::GetImageBytesPerPixel() const
 {
 	//ostringstream os;
@@ -590,16 +585,6 @@ unsigned Tsi3Cam::GetImageBytesPerPixel() const
 	//LogMessage(os.str(), true);
 	return img.Depth();
 } 
-
-
-int Tsi3Cam::GetChannelName(unsigned channel, char* name)
-{
-   if (channel != 0)
-      return ERR_INVALID_CHANNEL_INDEX;
-   
-   strncpy(name, "Channel-0", MM::MaxStrLength);
-   return DEVICE_OK;
-}
 
 /**
  * Snaps a single image, blocks at least until exposure is finished 

--- a/DeviceAdapters/TSI/TSI3Cam.h
+++ b/DeviceAdapters/TSI/TSI3Cam.h
@@ -122,8 +122,6 @@ public:
    const unsigned char* GetImageBuffer();
 
    unsigned GetNumberOfComponents() const;
-   unsigned GetNumberOfChannels() const;
-   int GetChannelName(unsigned channel, char* name);
 
    unsigned GetImageWidth() const {return img.Width();}
    unsigned GetImageHeight() const {return img.Height();}

--- a/DeviceAdapters/TSI/TSICam.cpp
+++ b/DeviceAdapters/TSI/TSICam.cpp
@@ -508,28 +508,10 @@ const unsigned int* TsiCam::GetImageBufferAsRGB32()
 }
 unsigned TsiCam::GetNumberOfComponents() const
 {
-   // TODO: multichannel
    if (color)
       return 4;
    else
       return 1;
-}
-
-unsigned TsiCam::GetNumberOfChannels() const
-{
-   // TODO: multichannel
-   return 1;
-}
-
-int TsiCam::GetChannelName(unsigned channel, char* name)
-{
-   // TODO: multichannel
-
-   if (channel != 0)
-      return ERR_INVALID_CHANNEL_INDEX;
-   
-   strncpy(name, "Channel-0", MM::MaxStrLength);
-   return DEVICE_OK;
 }
 
 /**

--- a/DeviceAdapters/TSI/TSICam.h
+++ b/DeviceAdapters/TSI/TSICam.h
@@ -91,8 +91,6 @@ public:
    const unsigned char* GetImageBuffer();
 
    unsigned GetNumberOfComponents() const;
-   unsigned GetNumberOfChannels() const;
-   int GetChannelName(unsigned channel, char* name);
 
    unsigned GetImageWidth() const {return img.Width();}
    unsigned GetImageHeight() const {return img.Height();}


### PR DESCRIPTION
Ordinary cameras need not override GetNumberOfChannels() (default returns 1) or GetChannelName() (default returns empty string).

The actual changes here are only to JAI and TSI, which were only assigning a channel name of `Channel-0`, which is not helpful.

Remove a redundant override from FLICamera. Remove commented code that confused channels with components from MoticCamera.