### PR TITLE
Trigger GUI Events on all Waveform Parameters

### DIFF
--- a/DeviceAdapters/iSIMWaveforms/iSIMWaveforms.h
+++ b/DeviceAdapters/iSIMWaveforms/iSIMWaveforms.h
@@ -157,6 +157,8 @@ public:
 	int OnReadoutTimeConvToMs(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnReadoutTimeMs(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnCurrentReadoutTimeMs(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnCurrentExposureTimeMs(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnCameraPulseWidthMs(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
 	// Helper methods
@@ -187,6 +189,8 @@ private:
 	int GetNumEnabledModInChannels() const;
 	int ValidateWaveformParameters() const;
 	double ComputeMinFrameIntervalMs() const;
+	double ComputeCameraPulseWidthMs() const;
+	void NotifyTimingChanged();
 
 	// Interleaved waveform construction
 	int BuildAndWriteAlignmentWaveforms();


### PR DESCRIPTION
This should be the last major change that I need to make to the iSIMWaveforms device adapter to have it interface with the plugin.

I'll begin microscope alignment this week so everything will be put to the test shortly.

- Call OnPropertyChanged() on all waveform parameters so that their changes are reflected in the GUI
- Add camera pulse width and exposure time properties
- Change property names `AOTF MOD IN N Voltage` to `AOTF MOD IN N (V)` for consistency
- Extend mutex in iSIM Illumination Selector to cover calls on the main device adapter