### PR TITLE
MMCore: Avoid manual memory management in `Metadata`

### DIFF
--- a/MMCore/unittest/ImageMetadata-Tests.cpp
+++ b/MMCore/unittest/ImageMetadata-Tests.cpp
@@ -31,6 +31,14 @@ TEST_CASE("Metadata serialize via PutImageTag three tags", "[Metadata]") {
        "s\nX\n_\n1\n1.5\n");
 }
 
+TEST_CASE("Metadata PutImageTag overwrites previous value", "[Metadata]") {
+   Metadata md;
+   md.PutImageTag("Exposure", "10.0");
+   md.PutImageTag("Exposure", "20.0");
+   CHECK(md.GetKeys().size() == 1);
+   CHECK(md.GetSingleTag("Exposure").GetValue() == "20.0");
+}
+
 // --- CameraImageMetadata to Metadata restore ---
 
 TEST_CASE("CameraImageMetadata to Metadata restore empty", "[Metadata]") {
@@ -109,6 +117,16 @@ TEST_CASE("CameraImageMetadata to Metadata restore three tags",
    CHECK(tag3.GetName() == "X");
    CHECK(tag3.GetDevice() == "_");
    CHECK(tag3.GetValue() == "1.5");
+}
+
+TEST_CASE("Metadata Restore with duplicate tags keeps last", "[Metadata]") {
+   Metadata md;
+   REQUIRE(md.Restore(
+       "2\n"
+       "s\nExposure\n_\n1\n10.0\n"
+       "s\nExposure\n_\n1\n20.0\n"));
+   CHECK(md.GetKeys().size() == 1);
+   CHECK(md.GetSingleTag("Exposure").GetValue() == "20.0");
 }
 
 // --- Metadata PutImageTag() and CameraImageMetadata equivalence ---

--- a/MMDevice/CameraImageMetadata.h
+++ b/MMDevice/CameraImageMetadata.h
@@ -103,8 +103,8 @@ public:
       // (The '_' device-label field is always "_".)
       // (The '1' indicates "read-only"; no actual meaning.)
       //
-      // Tags must have unique keys as of DIV 74 (otherwise memory may leak on
-      // deserialization by Metadata::Restore())
+      // Tags must have unique keys up to DIV 74. In DIV 75+, the last
+      // occurrence of duplicate tags wins.
 
       serialized_.clear();
       serialized_ = std::to_string(tags_.size());


### PR DESCRIPTION
- Avoid manual new/delete
- This fixed a memory leak in `Put[Image]Tag()` for an existing tag
- Use range-based for loops
- Add tests for last-tag-wins

This slightly widens the allowed format for serialized metadata, in that the serialized form may contain duplicate tags (the last one wins). The writing side (MMDevice) cannot take advantage of this under the current Device Interface Version, but it will be able to under the next.

To be merged before #861 so that DIV 75 allows duplicate tags in serialized metadata.