### PR TITLE
SWIG 2 doesn't like double closing angle bracket

### DIFF
--- a/MMCore/ImageMetadata.h
+++ b/MMCore/ImageMetadata.h
@@ -470,5 +470,5 @@ private:
          throw MetadataKeyError(key);
    }
 
-   std::map<std::string, std::unique_ptr<MetadataTag>> tags_;
+   std::map<std::string, std::unique_ptr<MetadataTag> > tags_;
 };


### PR DESCRIPTION
We should update our Windows build to SWIG 3 (already used for macOS build), but in the meantime we need this fix.