### PR TITLE
CI: set macOS target to 11.0

### DIFF
--- a/.github/workflows/ci-mmdevice-mmcore.yml
+++ b/.github/workflows/ci-mmdevice-mmcore.yml
@@ -101,16 +101,14 @@ jobs:
             cxx: cl
           - os: macos-15
             name: macos-arm64
-            deployment_target: "11.0"
           - os: macos-15
             name: macos-x86_64
             meson_cross_args: --cross-file=scripts/meson-cross-macos-x86_64.txt
             jdk_arch: x86_64
-            deployment_target: "10.15"
     env:
       CXX: ${{ matrix.cxx }}
       CJDK_ARCH: ${{ matrix.jdk_arch }}
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
This is just for the MMDevice/MMCore Meson CI.

Part of #772.