### PR TITLE
ASIStage: CRISP improvements, reduce serial traffic when setting the "CRISP State" property

### DIFF
--- a/DeviceAdapters/ASIStage/ASICRISP.cpp
+++ b/DeviceAdapters/ASIStage/ASICRISP.cpp
@@ -11,6 +11,7 @@ namespace {
 namespace Properties {
 
 // Always read
+constexpr char SignalNoiseRatio[] = "Signal Noise Ratio";
 constexpr char Sum[] = "Sum";
 constexpr char DitherError[] = "Dither Error";
 
@@ -254,15 +255,13 @@ int CRISP::Initialize()
 		CreateProperty(os.str().c_str(), "", MM::String, true, pActEx);
 	}
 
-	pAct = new CPropertyAction(this, &CRISP::OnSNR);
-	CreateProperty("Signal Noise Ratio", "", MM::Float, true, pAct);
-
 	pAct = new CPropertyAction(this, &CRISP::OnLogAmpAGC);
 	CreateProperty("LogAmpAGC", "", MM::Integer, true, pAct);
 
 	// Read-only Properties
 
 	// Always read, not cached
+	CreateSNRProperty();
 	CreateSumProperty();
 	CreateDitherErrorProperty();
 
@@ -322,7 +321,7 @@ int CRISP::UpdateFocusState() {
 
 	// Requests single char lock state description
 	std::string answer;
-	if (const int ret = QueryCommand("LK X?", answer); ret != DEVICE_OK) {
+	if (const int result = QueryCommand("LK X?", answer); result != DEVICE_OK) {
 		return ERR_UNRECOGNIZED_ANSWER;
 	}
 
@@ -914,21 +913,6 @@ int CRISP::OnAxis(MM::PropertyBase* pProp, MM::ActionType eAct)
 	return DEVICE_OK;
 }
 
-int CRISP::OnSNR(MM::PropertyBase* pProp, MM::ActionType eAct)
-{
-	if (eAct == MM::BeforeGet)
-	{
-		double snr{};
-		int ret = GetValue("EXTRA Y?", snr);
-		if (ret != DEVICE_OK)
-		{
-			return ret;
-		}
-		pProp->Set(snr);
-	}
-	return DEVICE_OK;
-}
-
 int CRISP::OnLogAmpAGC(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
 	if (eAct == MM::BeforeGet) {
@@ -1038,6 +1022,32 @@ int CRISP::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 }
 
 // Read-only Properties
+
+// Always read, not cached
+void CRISP::CreateSNRProperty() {
+	const bool isNewFirmware = (version_ >= Version(9, 5, 3));
+	const std::string command = isNewFirmware ? "EX Y?" : "EXTRA Y?";
+
+	if (isNewFirmware) {
+		LogMessage("CRISP: firmware >= 9.53; using shortcut 'EX Y?' for SNR.", true);
+	} else {
+		LogMessage("CRISP: firmware < 9.53; using full command 'EXTRA Y?' for SNR.", true);
+	}
+
+	CreateFloatProperty(
+		Props::SignalNoiseRatio, 0.0, true,
+		new MM::ActionLambda([this, command](MM::PropertyBase* pProp, MM::ActionType eAct) {
+			if (eAct == MM::BeforeGet) {
+				double snr{};
+				if (const int result = GetValue(command.c_str(), snr); result != DEVICE_OK) {
+					return result;
+				}
+				pProp->Set(snr);
+			}
+			return DEVICE_OK;
+		})
+	);
+}
 
 // Always read, not cached
 void CRISP::CreateSumProperty() {

--- a/DeviceAdapters/ASIStage/ASICRISP.h
+++ b/DeviceAdapters/ASIStage/ASICRISP.h
@@ -10,7 +10,7 @@
 
 #include "ASIBase.h"
 
-// CRISP reflection based autofocusing unit (Nico, Nov 2011)
+// CRISP Autofocus (Nico, Nov 2011)
 class CRISP : public CAutoFocusBase<CRISP>, public ASIBase {
 public:
 	CRISP();
@@ -57,7 +57,6 @@ public:
 	int GetGainMultiplier(long& gainMult);
 	int OnFocusCurve(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnFocusCurveData(MM::PropertyBase* pProp, MM::ActionType eAct, long index);
-	int OnSNR(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnLogAmpAGC(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnNumSkips(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int GetNumSkips(long& updateRate);
@@ -74,6 +73,7 @@ private:
 	int SetCommand(const std::string& command);
 
 	// Properties
+	void CreateSNRProperty();
 	void CreateSumProperty();
 	void CreateDitherErrorProperty();
 	void CreateSetLogAmpAGCProperty();
@@ -82,6 +82,7 @@ private:
 	std::string axisLetter_;
 	std::string focusState_;
 	long waitAfterLock_;
+
 	int answerTimeoutMs_;
 
 	// cached properties


### PR DESCRIPTION
We no longer query the focus state 2x with `GetFocusState()` before setting the `"CRISP State"`.

CRISP Advanced properties `"Set LogAmpAGC (Advanced Users Only)"` and `"Set Lock Offset (Advanced Users Only)"` are `MM::Integer` properties and should use `long` not `double`. Sends `"LK M=1"` instead of `"LK M=1.000000"`.

Change CRISP `GetFocusState()` to `UpdateFocusState()` which uses the same logic as `ASITiger` to update the `focusState_` member variable.

If firmware >= 9.53 is detected, use the shortcut `"EX Y?" instead of `"EXTRA Y?"` for the `"Signal Noise Ratio"` property.

Use `static_cast<long>` to convert double to long.  LogAmpAGC returns `":A X=1.000000"` and Offset uses `GetOffset(double& offset)`.

`GetCurrentFocusScore()` matches CRISP semantics. `"LK Y?"` returns the current focus score, so we alias `GetLastFocusScore()` to `GetCurrentFocusScore()` instead of the other way around.