### PR TITLE
MMCore: fix flaky tests (destruction order)

### DIFF
--- a/MMCore/unittest/EventCallback-Tests.cpp
+++ b/MMCore/unittest/EventCallback-Tests.cpp
@@ -239,10 +239,9 @@ struct StubWithProperty : CGenericBase<StubWithProperty> {
 TEST_CASE("onPropertiesChanged from device", "[EventCallback]") {
    StubGeneric dev;
    MockAdapterWithDevices adapter{{"dev", &dev}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    dev.OnPropertiesChanged();
@@ -253,10 +252,9 @@ TEST_CASE("onPropertiesChanged from device", "[EventCallback]") {
 TEST_CASE("onPropertyChanged from device", "[EventCallback]") {
    StubWithProperty dev;
    MockAdapterWithDevices adapter{{"dev", &dev}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    dev.OnPropertyChanged("TestProp", "newValue");
@@ -272,10 +270,9 @@ TEST_CASE("onPropertyChanged from device", "[EventCallback]") {
 TEST_CASE("onStagePositionChanged from device", "[EventCallback]") {
    StubStage stage;
    MockAdapterWithDevices adapter{{"stage", &stage}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    stage.OnStagePositionChanged(42.0);
@@ -290,10 +287,9 @@ TEST_CASE("onStagePositionChanged from device", "[EventCallback]") {
 TEST_CASE("onXYStagePositionChanged from device", "[EventCallback]") {
    StubXYStage xy;
    MockAdapterWithDevices adapter{{"xy", &xy}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    xy.OnXYStagePositionChanged(1.0, 2.0);
@@ -309,10 +305,9 @@ TEST_CASE("onXYStagePositionChanged from device", "[EventCallback]") {
 TEST_CASE("onExposureChanged from device", "[EventCallback]") {
    StubCamera cam;
    MockAdapterWithDevices adapter{{"cam", &cam}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    cam.OnExposureChanged(25.0);
@@ -327,10 +322,9 @@ TEST_CASE("onExposureChanged from device", "[EventCallback]") {
 TEST_CASE("onSLMExposureChanged from device", "[EventCallback]") {
    StubSLM slm;
    MockAdapterWithDevices adapter{{"slm", &slm}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    slm.OnSLMExposureChanged(100.0);
@@ -345,10 +339,9 @@ TEST_CASE("onSLMExposureChanged from device", "[EventCallback]") {
 TEST_CASE("onShutterOpenChanged from device", "[EventCallback]") {
    StubShutter shutter;
    MockAdapterWithDevices adapter{{"shutter", &shutter}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    shutter.GetCoreCallback()->OnShutterOpenChanged(&shutter, true);
@@ -364,11 +357,10 @@ TEST_CASE("onSequenceAcquisitionStarted from device",
           "[EventCallback]") {
    StubCamera cam;
    MockAdapterWithDevices adapter{{"cam", &cam}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
    c.setCameraDevice("cam");
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    cam.PrepareForAcq();
@@ -383,11 +375,10 @@ TEST_CASE("onSequenceAcquisitionStopped from device",
           "[EventCallback]") {
    StubCamera cam;
    MockAdapterWithDevices adapter{{"cam", &cam}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
    c.setCameraDevice("cam");
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    cam.AcqFinished();
@@ -404,12 +395,11 @@ TEST_CASE("onConfigGroupChanged from device property change",
           "[EventCallback]") {
    StubWithProperty dev;
    MockAdapterWithDevices adapter{{"dev", &dev}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
 
    c.defineConfig("Group1", "Config1", "dev", "TestProp", "val1");
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    dev.OnPropertyChanged("TestProp", "val1");
@@ -425,13 +415,12 @@ TEST_CASE("onPixelSizeChanged from device property change",
           "[EventCallback]") {
    StubWithProperty dev;
    MockAdapterWithDevices adapter{{"dev", &dev}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
 
    c.definePixelSizeConfig("Res1", "dev", "TestProp", "val1");
    c.setPixelSizeUm("Res1", 0.5);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    dev.OnPropertyChanged("TestProp", "val1");
@@ -446,6 +435,7 @@ TEST_CASE("onPixelSizeAffineChanged from device property change",
           "[EventCallback]") {
    StubWithProperty dev;
    MockAdapterWithDevices adapter{{"dev", &dev}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
 
@@ -453,8 +443,6 @@ TEST_CASE("onPixelSizeAffineChanged from device property change",
    c.setPixelSizeUm("Res1", 0.5);
    std::vector<double> matrix = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
    c.setPixelSizeAffine("Res1", matrix);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    dev.OnPropertyChanged("TestProp", "val1");
@@ -474,14 +462,13 @@ TEST_CASE("onPixelSizeChanged from magnifier change",
           "[EventCallback]") {
    StubMagnifier mag;
    MockAdapterWithDevices adapter{{"mag", &mag}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
 
    c.definePixelSizeConfig("Res1");
    c.setPixelSizeUm("Res1", 0.5);
    c.setPixelSizeConfig("Res1");
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    mag.OnMagnifierChanged();
@@ -497,11 +484,10 @@ TEST_CASE("onPixelSizeChanged from magnifier change",
 TEST_CASE("onImageSnapped from snapImage", "[EventCallback]") {
    StubCamera cam;
    MockAdapterWithDevices adapter{{"cam", &cam}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
    c.setCameraDevice("cam");
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    c.snapImage();
@@ -514,10 +500,9 @@ TEST_CASE("onImageSnapped from snapImage", "[EventCallback]") {
 
 TEST_CASE("onChannelGroupChanged from setChannelGroup",
           "[EventCallback]") {
+   RecordingCallback cb;
    CMMCore c;
    c.defineConfig("Channel", "Ch1");
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    c.setChannelGroup("Channel");
@@ -532,10 +517,9 @@ TEST_CASE("onSystemConfigurationLoaded from unloadAllDevices",
           "[EventCallback]") {
    StubGeneric dev;
    MockAdapterWithDevices adapter{{"dev", &dev}};
+   RecordingCallback cb;
    CMMCore c;
    adapter.LoadIntoCore(c);
-
-   RecordingCallback cb;
    c.registerCallback(&cb);
 
    c.unloadAllDevices();
@@ -546,8 +530,8 @@ TEST_CASE("onSystemConfigurationLoaded from unloadAllDevices",
 TEST_CASE(
    "onSystemConfigurationLoaded from loadSystemConfiguration success",
    "[EventCallback]") {
-   CMMCore c;
    RecordingCallback cb;
+   CMMCore c;
    c.registerCallback(&cb);
 
    TempFile tmp("# empty config\n");
@@ -559,8 +543,8 @@ TEST_CASE(
 TEST_CASE(
    "onSystemConfigurationLoaded from loadSystemConfiguration failure",
    "[EventCallback]") {
-   CMMCore c;
    RecordingCallback cb;
+   CMMCore c;
    c.registerCallback(&cb);
 
    TempFile tmp("Device,NoSuchLabel,NoSuchAdapter,NoSuchDevice\n");
@@ -571,8 +555,8 @@ TEST_CASE(
 }
 
 TEST_CASE("onPropertyChanged from Core property", "[EventCallback]") {
-   CMMCore c;
    RecordingCallback cb;
+   CMMCore c;
    c.registerCallback(&cb);
 
    c.setProperty("Core", "AutoShutter", "0");
@@ -591,13 +575,12 @@ TEST_CASE("registerCallback throws when called from callback handler",
           "[EventCallback]") {
    StubGeneric dev;
    MockAdapterWithDevices adapter{{"dev", &dev}};
-   CMMCore c;
-   adapter.LoadIntoCore(c);
-
    std::mutex mu;
    std::condition_variable cv;
    bool threw = false;
    bool done = false;
+   CMMCore c;
+   adapter.LoadIntoCore(c);
 
    struct ReentrantCallback : MMEventCallback {
       CMMCore& core;
@@ -636,6 +619,7 @@ TEST_CASE("registerCallback throws when called from callback handler",
       REQUIRE(cv.wait_for(lk, std::chrono::milliseconds(5000),
                           [&] { return done; }));
    }
+   c.registerCallback(nullptr);
    REQUIRE(threw);
 }
 


### PR DESCRIPTION
After `c.registerCallback(cb)`, `cb` must outlive `c` unless unregistered.

C++ destroys local vars in reverse order of definition, so reorder. For 1 case (`ReentrantCallback`), explicitly unregister before destruction.