### PR TITLE
MMCore: post notifications for shutter open/close

### DIFF
--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -297,13 +297,14 @@ int CoreCallback::AcqFinished(const MM::Device* caller, int /*statusCode*/)
       {
          // We need to lock the shutter's module for thread safety, but there's
          // a case where deadlock would result.
+         int sret = DEVICE_ERR;
          if (camera->GetAdapterModule() == shutter->GetAdapterModule())
          {
             // This is a nasty hack to allow the case where the shutter and
             // camera live in the same module. It is not safe, but this is how
             // _all_ cases used to be implemented, and I can't immediately
             // think of a fully safe fix that is reasonably simple.
-            shutter->SetOpen(false);
+            sret = shutter->SetOpen(false);
          }
          else if (currentCamera && currentCamera->GetAdapterModule() ==
                shutter->GetAdapterModule())
@@ -315,14 +316,14 @@ int CoreCallback::AcqFinished(const MM::Device* caller, int /*statusCode*/)
             // This is an even nastier hack in that it ignores the possibility
             // of StopSequenceAcquisition() being called on a camera other than
             // currentCamera, but such cases are rare.
-            shutter->SetOpen(false);
+            sret = shutter->SetOpen(false);
          }
          else
          {
             // If the shutter is in a different device adapter, it is safe to
             // lock that adapter.
             DeviceModuleLockGuard g(shutter);
-            shutter->SetOpen(false);
+            sret = shutter->SetOpen(false);
 
             // We could wait for the shutter to close here, but the
             // implementation has always returned without waiting. The camera
@@ -330,6 +331,9 @@ int CoreCallback::AcqFinished(const MM::Device* caller, int /*statusCode*/)
             // stopSequenceAcquisition() does not wait for the shutter before
             // returning.
          }
+         if (sret == DEVICE_OK)
+            core_->postNotification(notif::ShutterOpenChanged{
+               shutter->GetLabel(), false});
       }
    }
 
@@ -347,10 +351,14 @@ int CoreCallback::PrepareForAcq(const MM::Device* caller)
          core_->currentShutterDevice_.lock();
       if (shutter)
       {
+         int sret;
          {
             DeviceModuleLockGuard g(shutter);
-            shutter->SetOpen(true);
+            sret = shutter->SetOpen(true);
          }
+         if (sret == DEVICE_OK)
+            core_->postNotification(notif::ShutterOpenChanged{
+               shutter->GetLabel(), true});
          core_->waitForDevice(shutter);
       }
    }

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -108,7 +108,7 @@ namespace notif = mmcore::internal::notification;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 12, MMCore_versionMinor = 1, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 12, MMCore_versionMinor = 2, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2585,6 +2585,8 @@ void CMMCore::snapImage() MMCORE_LEGACY_THROW(CMMError)
                logError("CMMCore::snapImage", getDeviceErrorText(sret, shutter).c_str());
                throw CMMError(getDeviceErrorText(sret, shutter).c_str(), MMERR_DEVICE_GENERIC);
             }
+            postNotification(notif::ShutterOpenChanged{
+               shutter->GetLabel(), true});
             waitForDevice(shutter);
          }
 
@@ -2610,6 +2612,8 @@ void CMMCore::snapImage() MMCORE_LEGACY_THROW(CMMError)
                logError("CMMCore::snapImage", getDeviceErrorText(sret, shutter).c_str());
                throw CMMError(getDeviceErrorText(sret, shutter).c_str(), MMERR_DEVICE_GENERIC);
             }
+            postNotification(notif::ShutterOpenChanged{
+               shutter->GetLabel(), false});
             waitForDevice(shutter);
          }
          postNotification(notif::ImageSnapped{camera->GetLabel()});
@@ -2672,6 +2676,8 @@ void CMMCore::setShutterOpen(const char* shutterLabel, bool state) MMCORE_LEGACY
          logError("CMMCore::setShutterOpen()", getDeviceErrorText(ret, pShutter).c_str());
          throw CMMError(getDeviceErrorText(ret, pShutter).c_str(), MMERR_DEVICE_GENERIC);
       }
+
+      postNotification(notif::ShutterOpenChanged{shutterLabel, state});
 
       if (pShutter->HasProperty(MM::g_Keyword_State))
       {

--- a/MMCore/unittest/EventCallback-Tests.cpp
+++ b/MMCore/unittest/EventCallback-Tests.cpp
@@ -481,6 +481,89 @@ TEST_CASE("onPixelSizeChanged from magnifier change",
 
 // --- Core-originated callback tests ---
 
+TEST_CASE("onShutterOpenChanged from setShutterOpen", "[EventCallback]") {
+   StubShutter shutter;
+   MockAdapterWithDevices adapter{{"shutter", &shutter}};
+   RecordingCallback cb;
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.registerCallback(&cb);
+
+   c.setShutterOpen("shutter", true);
+
+   REQUIRE(cb.waitFor(CBType::ShutterOpenChanged));
+   auto recs = cb.records(CBType::ShutterOpenChanged);
+   REQUIRE(recs.size() >= 1);
+   CHECK(recs[0].s1 == "shutter");
+   CHECK(recs[0].b1 == true);
+}
+
+TEST_CASE("onShutterOpenChanged from snapImage with auto-shutter",
+          "[EventCallback]") {
+   StubCamera cam;
+   StubShutter shutter;
+   MockAdapterWithDevices adapter{{"cam", &cam}, {"shutter", &shutter}};
+   RecordingCallback cb;
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("cam");
+   c.setShutterDevice("shutter");
+   c.setAutoShutter(true);
+   c.registerCallback(&cb);
+
+   c.snapImage();
+
+   REQUIRE(cb.waitForCount(CBType::ShutterOpenChanged, 2));
+   auto recs = cb.records(CBType::ShutterOpenChanged);
+   REQUIRE(recs.size() >= 2);
+   CHECK(recs[0].s1 == "shutter");
+   CHECK(recs[0].b1 == true);
+   CHECK(recs[1].s1 == "shutter");
+   CHECK(recs[1].b1 == false);
+}
+
+TEST_CASE("onShutterOpenChanged from AcqFinished", "[EventCallback]") {
+   StubCamera cam;
+   StubShutter shutter;
+   MockAdapterWithDevices adapter{{"cam", &cam}, {"shutter", &shutter}};
+   RecordingCallback cb;
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("cam");
+   c.setShutterDevice("shutter");
+   c.setAutoShutter(true);
+   c.registerCallback(&cb);
+
+   cam.AcqFinished();
+
+   REQUIRE(cb.waitFor(CBType::ShutterOpenChanged));
+   auto recs = cb.records(CBType::ShutterOpenChanged);
+   REQUIRE(recs.size() >= 1);
+   CHECK(recs[0].s1 == "shutter");
+   CHECK(recs[0].b1 == false);
+}
+
+TEST_CASE("onShutterOpenChanged from PrepareForAcq", "[EventCallback]") {
+   StubCamera cam;
+   StubShutter shutter;
+   MockAdapterWithDevices adapter{{"cam", &cam}, {"shutter", &shutter}};
+   RecordingCallback cb;
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("cam");
+   c.setShutterDevice("shutter");
+   c.setAutoShutter(true);
+   c.registerCallback(&cb);
+
+   cam.PrepareForAcq();
+
+   REQUIRE(cb.waitFor(CBType::ShutterOpenChanged));
+   auto recs = cb.records(CBType::ShutterOpenChanged);
+   REQUIRE(recs.size() >= 1);
+   CHECK(recs[0].s1 == "shutter");
+   CHECK(recs[0].b1 == true);
+}
+
 TEST_CASE("onImageSnapped from snapImage", "[EventCallback]") {
    StubCamera cam;
    MockAdapterWithDevices adapter{{"cam", &cam}};

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.micro-manager.mmcorej</groupId>
     <artifactId>MMCoreJ</artifactId>
-    <version>12.1.0</version>
+    <version>12.2.0</version>
 
     <name>MMCore Java API</name>
     <description>Java bindings for MMCore, the device abstraction layer of Micro-Manager, the microscope control and acquisition platform.</description>


### PR DESCRIPTION
Closes #887.

@tlambert03 Is this (together with the `onPropertyChanged("Core", "Autoshutter", f)` from #881) enough for #887?

I left out updating the system state cache because that requires mapping to a particular shutter's `State` property. Probably doable but better if we have the guarantee that the shutter in fact has a canonical `State` property.