### PR TITLE
MMCore: avoid raw new/delete

### DIFF
--- a/MMCore/FrameBuffer.cpp
+++ b/MMCore/FrameBuffer.cpp
@@ -25,25 +25,21 @@ namespace mmcore {
 namespace internal {
 
 ImgBuffer::ImgBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth) :
-   pixels_(0), width_(xSize), height_(ySize), pixDepth_(pixDepth)
+   pixels_(new unsigned char[xSize * ySize * pixDepth]()),
+   width_(xSize), height_(ySize), pixDepth_(pixDepth)
 {
-   pixels_ = new unsigned char[xSize * ySize * pixDepth];
-   memset(pixels_, 0, xSize * ySize * pixDepth);
 }
 
-ImgBuffer::~ImgBuffer()
-{
-   delete[] pixels_;
-}
+ImgBuffer::~ImgBuffer() = default;
 
 const unsigned char* ImgBuffer::GetPixels() const
 {
-   return pixels_;
+   return pixels_.get();
 }
 
 void ImgBuffer::SetPixels(const void* pix)
 {
-   memcpy((void*)pixels_, pix, width_ * height_ * pixDepth_);
+   memcpy((void*)pixels_.get(), pix, width_ * height_ * pixDepth_);
 }
 
 void ImgBuffer::Resize(unsigned xSize, unsigned ySize, unsigned pixDepth)
@@ -51,8 +47,7 @@ void ImgBuffer::Resize(unsigned xSize, unsigned ySize, unsigned pixDepth)
    // re-allocate internal buffer if it is not big enough
    if (width_ * height_ * pixDepth_ < xSize * ySize * pixDepth)
    {
-      delete[] pixels_;
-      pixels_ = new unsigned char [xSize * ySize * pixDepth];
+      pixels_.reset(new unsigned char[xSize * ySize * pixDepth]);
    }
 
    width_ = xSize;
@@ -65,14 +60,13 @@ void ImgBuffer::Resize(unsigned xSize, unsigned ySize)
    // re-allocate internal buffer if it is not big enough
    if (width_ * height_ < xSize * ySize)
    {
-      delete[] pixels_;
-      pixels_ = new unsigned char[xSize * ySize * pixDepth_];
+      pixels_.reset(new unsigned char[xSize * ySize * pixDepth_]);
    }
 
    width_ = xSize;
    height_ = ySize;
 
-   memset(pixels_, 0, width_ * height_ * pixDepth_);
+   memset(pixels_.get(), 0, width_ * height_ * pixDepth_);
 }
 
 void ImgBuffer::SetMetadata(const Metadata& md)

--- a/MMCore/FrameBuffer.h
+++ b/MMCore/FrameBuffer.h
@@ -27,7 +27,7 @@ namespace internal {
 
 class ImgBuffer
 {
-   unsigned char* pixels_;
+   std::unique_ptr<unsigned char[]> pixels_;
    unsigned int width_;
    unsigned int height_;
    unsigned int pixDepth_;

--- a/MMCore/LoadableModules/LoadedModule.cpp
+++ b/MMCore/LoadableModules/LoadedModule.cpp
@@ -42,10 +42,7 @@ LoadedModule::LoadedModule(const std::string& filename) :
 }
 
 
-LoadedModule::~LoadedModule()
-{
-   delete pImpl_;
-}
+LoadedModule::~LoadedModule() = default;
 
 
 void

--- a/MMCore/LoadableModules/LoadedModule.h
+++ b/MMCore/LoadableModules/LoadedModule.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 namespace mmcore {
@@ -41,7 +42,7 @@ public:
    void* GetFunction(const char* funcName);
 
 private:
-   LoadedModuleImpl* pImpl_;
+   std::unique_ptr<LoadedModuleImpl> pImpl_;
    const std::string filename_;
 };
 

--- a/MMCore/LoadableModules/LoadedModuleImpl.cpp
+++ b/MMCore/LoadableModules/LoadedModuleImpl.cpp
@@ -33,10 +33,10 @@ typedef LoadedModuleImplWindows PlatformLoadedModuleImpl;
 typedef LoadedModuleImplUnix PlatformLoadedModuleImpl;
 #endif
 
-LoadedModuleImpl*
+std::unique_ptr<LoadedModuleImpl>
 LoadedModuleImpl::NewPlatformImpl(const std::string& filename)
 {
-   return new PlatformLoadedModuleImpl(filename);
+   return std::make_unique<PlatformLoadedModuleImpl>(filename);
 }
 
 } // namespace internal

--- a/MMCore/LoadableModules/LoadedModuleImpl.h
+++ b/MMCore/LoadableModules/LoadedModuleImpl.h
@@ -24,6 +24,8 @@
 
 #include "LoadedModule.h"
 
+#include <memory>
+
 namespace mmcore {
 namespace internal {
 
@@ -33,7 +35,7 @@ public:
    LoadedModuleImpl(const LoadedModuleImpl&) = delete;
    LoadedModuleImpl& operator=(const LoadedModuleImpl&) = delete;
 
-   static LoadedModuleImpl* NewPlatformImpl(const std::string& filename);
+   static std::unique_ptr<LoadedModuleImpl> NewPlatformImpl(const std::string& filename);
 
    virtual ~LoadedModuleImpl() {}
 

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -121,37 +121,24 @@ const int MMCore_versionMajor = 12, MMCore_versionMinor = 2, MMCore_versionPatch
  * devices at this point.
  */
 CMMCore::CMMCore() :
-   logManager_(new mmi::LogManager()),
+   logManager_(std::make_shared<mmi::LogManager>()),
    appLogger_(logManager_->NewLogger("App")),
    coreLogger_(logManager_->NewLogger("Core")),
    everSnapped_(false),
    pollingIntervalMs_(10),
    timeoutMs_(5000),
    autoShutter_(true),
-   callback_(0),
-   configGroups_(0),
-   properties_(0),
-   pixelSizeGroup_(0),
-   cbuf_(0),
-   pluginManager_(new mmi::CPluginManager()),
-   deviceManager_(new mmi::DeviceManager()),
+   nullAffine_(6, 0.0),
+   configGroups_(std::make_unique<mmi::ConfigGroupCollection>()),
+   pixelSizeGroup_(std::make_unique<PixelSizeConfigGroup>()),
+   cbuf_(std::make_unique<mmi::CircularBuffer>(
+      (sizeof(void*) > 4) ? 250u : 25u)),
+   callback_(std::make_unique<mmi::CoreCallback>(this)),
+   pluginManager_(std::make_shared<mmi::CPluginManager>()),
+   deviceManager_(std::make_shared<mmi::DeviceManager>()),
    stateCache_(std::make_unique<SynchronizedConfiguration>())
 {
-   configGroups_ = new mmi::ConfigGroupCollection();
-   pixelSizeGroup_ = new PixelSizeConfigGroup();
-
    InitializeErrorMessages();
-
-   callback_ = new mmi::CoreCallback(this);
-
-   const unsigned seqBufMegabytes = (sizeof(void*) > 4) ? 250 : 25;
-   cbuf_ = new mmi::CircularBuffer(seqBufMegabytes);
-
-   nullAffine_ = new std::vector<double>(6);
-   for (int i = 0; i < 6; i++) {
-      nullAffine_->at(i) = 0.0;
-   }
-
    CreateCoreProperties();
 }
 
@@ -182,12 +169,6 @@ CMMCore::~CMMCore()
    {
       LOG_ERROR(coreLogger_) << "Exception caught in CMMCore destructor.";
    }
-
-   delete callback_;
-   delete configGroups_;
-   delete properties_;
-   delete cbuf_;
-   delete pixelSizeGroup_;
 
    LOG_INFO(coreLogger_) << "Core session ended";
 }
@@ -712,7 +693,7 @@ void CMMCore::loadDevice(const char* label, const char* moduleName, const char* 
    std::shared_ptr<mmi::DeviceInstance> pDevice =
       deviceManager_->LoadDevice(module, deviceName, label, this,
             deviceLogger, coreLogger);
-   pDevice->SetCallback(callback_);
+   pDevice->SetCallback(callback_.get());
 
    LOG_INFO(coreLogger_) << "Did load device " << deviceName <<
       " from " << moduleName << "; label = " << label;
@@ -3251,12 +3232,11 @@ void CMMCore::clearCircularBuffer() MMCORE_LEGACY_THROW(CMMError)
 void CMMCore::setCircularBufferMemoryFootprint(unsigned sizeMB ///< n megabytes
                                                ) MMCORE_LEGACY_THROW(CMMError)
 {
-   delete cbuf_; // discard old buffer
    LOG_DEBUG(coreLogger_) << "Will set circular buffer size to " <<
       sizeMB << " MB";
 	try
 	{
-		cbuf_ = new mmi::CircularBuffer(sizeMB);
+		cbuf_ = std::make_unique<mmi::CircularBuffer>(sizeMB);
 	}
 	catch (std::bad_alloc& ex)
 	{
@@ -3265,7 +3245,6 @@ void CMMCore::setCircularBufferMemoryFootprint(unsigned sizeMB ///< n megabytes
 		messs << getCoreErrorText(MMERR_OutOfMemory).c_str() << " " << ex.what() << '\n';
 		throw CMMError(messs.str().c_str() , MMERR_OutOfMemory);
 	}
-	if (NULL == cbuf_) throw CMMError(getCoreErrorText(MMERR_OutOfMemory).c_str(), MMERR_OutOfMemory);
 
 
 	try
@@ -5815,7 +5794,7 @@ std::vector<double> CMMCore::getPixelSizeAffine(bool cached) MMCORE_LEGACY_THROW
    else
    {
       // no config found, return a matrix with all 0.0s
-      return *nullAffine_;
+      return nullAffine_;
    }
 }
 
@@ -7612,13 +7591,12 @@ void CMMCore::loadSystemConfigurationImpl(const char* fileName) MMCORE_LEGACY_TH
                //
                if (tokens.size() == 8)
                {
-                  std::vector<double> *affineT = new std::vector<double>(6);
+                  std::vector<double> affineT(6);
                   for (int i = 0; i < 6; i++)
                   {
-                     affineT->at(i) = atof(tokens[i + 2].c_str());
+                     affineT[i] = std::atof(tokens[i + 2].c_str());
                   }
-                  setPixelSizeAffine(tokens[1].c_str(), *affineT);
-                  delete affineT;
+                  setPixelSizeAffine(tokens[1].c_str(), affineT);
                }
                else
                   throw CMMError(getCoreErrorText(MMERR_InvalidCFGEntry) + " (" +
@@ -8218,7 +8196,7 @@ void CMMCore::initializeInternal(bool init)
 
 void CMMCore::CreateCoreProperties()
 {
-   properties_ = new mmi::CorePropertyCollection(this);
+   properties_ = std::make_unique<mmi::CorePropertyCollection>(this);
 
    auto deviceRoleProp = [this](const char* keyword, MM::DeviceType devType,
          std::function<std::string()> getter,

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -713,12 +713,12 @@ private:
    long timeoutMs_;
    bool autoShutter_;
    bool initialized_ = false;
-   std::vector<double> *nullAffine_;
-   MM::Core* callback_;                 // core services for devices
-   mmcore::internal::ConfigGroupCollection* configGroups_;
-   mmcore::internal::CorePropertyCollection* properties_;
-   PixelSizeConfigGroup* pixelSizeGroup_;
-   mmcore::internal::CircularBuffer* cbuf_;
+   std::vector<double> nullAffine_;
+   std::unique_ptr<mmcore::internal::ConfigGroupCollection> configGroups_;
+   std::unique_ptr<PixelSizeConfigGroup> pixelSizeGroup_;
+   std::unique_ptr<mmcore::internal::CorePropertyCollection> properties_;
+   std::unique_ptr<mmcore::internal::CircularBuffer> cbuf_;
+   std::unique_ptr<MM::Core> callback_;
 
    std::shared_ptr<mmcore::internal::CPluginManager> pluginManager_;
    std::shared_ptr<mmcore::internal::DeviceManager> deviceManager_;

--- a/MMCore/TaskSet.cpp
+++ b/MMCore/TaskSet.cpp
@@ -35,11 +35,7 @@ TaskSet::TaskSet(std::shared_ptr<ThreadPool> pool)
     assert(pool);
 }
 
-TaskSet::~TaskSet()
-{
-    for (Task* task : tasks_)
-        delete task;
-}
+TaskSet::~TaskSet() = default;
 
 size_t TaskSet::GetUsedTaskCount() const
 {
@@ -48,7 +44,11 @@ size_t TaskSet::GetUsedTaskCount() const
 
 void TaskSet::Execute()
 {
-   pool_->Execute(std::vector<Task*>(tasks_.begin(), tasks_.begin() + usedTaskCount_));
+   std::vector<Task*> rawTasks;
+   rawTasks.reserve(usedTaskCount_);
+   for (size_t i = 0; i < usedTaskCount_; ++i)
+      rawTasks.push_back(tasks_[i].get());
+   pool_->Execute(rawTasks);
 }
 
 void TaskSet::Wait()

--- a/MMCore/TaskSet.h
+++ b/MMCore/TaskSet.h
@@ -60,7 +60,7 @@ protected:
             Task* task = new(std::nothrow) T(semaphore_, n, taskCount);
             if (!task)
                 continue;
-            tasks_.push_back(task);
+            tasks_.push_back(std::unique_ptr<Task>(task));
         }
         usedTaskCount_ = tasks_.size();
     }
@@ -68,7 +68,7 @@ protected:
 protected:
     const std::shared_ptr<ThreadPool> pool_;
     const std::shared_ptr<Semaphore> semaphore_;
-    std::vector<Task*> tasks_{};
+    std::vector<std::unique_ptr<Task>> tasks_{};
     size_t usedTaskCount_{ 0 };
 };
 

--- a/MMCore/TaskSet_CopyMemory.cpp
+++ b/MMCore/TaskSet_CopyMemory.cpp
@@ -81,8 +81,8 @@ void TaskSet_CopyMemory::SetUp(void* dst, const void* src, size_t bytes)
         return;
     }
 
-    for (Task* task : tasks_)
-        static_cast<ATask*>(task)->SetUp(dst, src, bytes, usedTaskCount_);
+    for (auto& task : tasks_)
+        static_cast<ATask*>(task.get())->SetUp(dst, src, bytes, usedTaskCount_);
 }
 
 void TaskSet_CopyMemory::Execute()


### PR DESCRIPTION
Use `unique_ptr` or plain member as appropriate.

Also tweak `CMMCore` member order (destruction happens in reverse order, although it shouldn't actually matter at present) and clean up its constructor.

(Did not touch `MetadataTag::Clone()` return type because it is part of API.)