### PR TITLE
Optimize ImageFlipY for large images

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -35,8 +35,10 @@
 #include <string>
 #include <map>
 #include <algorithm>
+#include <cstring>
 #include <stdint.h>
 #include <future>
+#include <vector>
 
 //////////////////////////////////////////////////////////////////////////////
 // Error codes
@@ -967,18 +969,16 @@ public:
    template <typename PixelType>
    int Flip(PixelType* pI, unsigned int width, unsigned int height)
    {
-      PixelType tmp;
-      int ret = DEVICE_OK;
-      for( unsigned long ix = 0; ix < width ; ++ix)
+      std::vector<PixelType> rowBuf(width);
+      for (unsigned int iy = 0; iy < height / 2; ++iy)
       {
-         for( unsigned long iy = 0; iy < (height>>1); ++iy)
-         {
-            tmp = pI[ ix + iy*width];
-            pI[ ix + iy*width] = pI[ ix + (height - 1 - iy)*width];
-            pI[ ix + (height - 1 - iy)*width] = tmp;
-         }
+         PixelType* topRow = pI + iy * width;
+         PixelType* botRow = pI + (height - 1 - iy) * width;
+         std::memcpy(rowBuf.data(), topRow, width * sizeof(PixelType));
+         std::memcpy(topRow, botRow, width * sizeof(PixelType));
+         std::memcpy(botRow, rowBuf.data(), width * sizeof(PixelType));
       }
-      return ret;
+      return DEVICE_OK;
    }
 
 


### PR DESCRIPTION
## Summary

- Replace the pixel-by-pixel column-major swap in `ImageFlipY::Flip` with row-wise `memcpy` swaps using a temporary row buffer
- Add `<vector>` and `<cstring>` includes to support the new implementation

## Motivation

The previous implementation used a nested loop with the column index (`ix`) as the outer loop and the row index (`iy`) as the inner loop. This meant each pixel swap accessed two memory locations separated by `width` elements (a full row stride), causing cache misses on nearly every access. For a 2048x2048 16-bit image (8 MB), this results in millions of cache misses.

The new implementation swaps entire rows at a time using `memcpy`. Since rows are contiguous in memory, this is fully sequential and cache-friendly. Additionally, `memcpy` is SIMD-optimized on modern platforms (SSE/AVX), copying 16-64 bytes per instruction instead of one pixel at a time. The loop count drops from `width * height/2` pixel swaps to `height/2` row swaps.

## Why other image transforms are not modified

- **ImageFlipX**: Already has the correct loop order (outer loop over rows, inner loop over columns within each row), so memory access is already sequential and cache-friendly. While individual pixel swaps could theoretically be replaced with `std::reverse`, the gain is modest since the access pattern is not pathological.
- **TransposeProcessor**: Both `TransposeSquareInPlace` and `TransposeRectangleOutOfPlace` inherently require element-level reordering (every pixel moves to a different location). The standard optimization (cache-blocking/tiling) would add significant code complexity for a demo camera adapter, and there is no `memcpy`-based shortcut available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)