### PR TITLE
Add script to extract device adapter properties from C++ source files

### DIFF
--- a/tools/parse_device_properties.py
+++ b/tools/parse_device_properties.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = ["tree-sitter", "tree-sitter-cpp"]
 # ///
 """Extract device adapter properties from C++ source files.
@@ -365,27 +365,38 @@ def find_device_classes(files: list[ParsedFile]) -> list[dict]:
             if name_node is None:
                 continue
             class_name = _text(name_node, source)
-            for child in node.children:
-                if child.type != "base_class_clause":
-                    continue
-                for base_child in _walk(child):
-                    if base_child.type == "template_type":
-                        type_node = base_child.child_by_field_name("name")
-                        base_name = _text(type_node, source) if type_node else None
-                    elif base_child.type == "type_identifier":
-                        base_name = _text(base_child, source)
-                    else:
-                        continue
-                    if base_name in BASE_CLASS_TO_TYPE:
-                        classes.append(
-                            {
-                                "class_name": class_name,
-                                "base_class": base_name,
-                                "device_type": BASE_CLASS_TO_TYPE[base_name],
-                                "file": path,
-                            }
-                        )
+            base_name = _find_base_class(node, source)
+            if base_name:
+                classes.append(
+                    {
+                        "class_name": class_name,
+                        "base_class": base_name,
+                        "device_type": BASE_CLASS_TO_TYPE[base_name],
+                        "file": path,
+                    }
+                )
     return classes
+
+
+def _find_base_class(class_node: Any, source: bytes) -> str | None:
+    """Find a known device base class in a class's inheritance list."""
+    for child in class_node.children:
+        if child.type != "base_class_clause":
+            continue
+        for base_child in _walk(child):
+            if base_child.type == "template_type":
+                type_node = base_child.child_by_field_name("name")
+                base_name = _text(type_node, source) if type_node else None
+                if base_name and base_name in BASE_CLASS_TO_TYPE:
+                    return base_name
+            elif base_child.type == "type_identifier":
+                # Skip if parent is template_type (already checked above)
+                if base_child.parent and base_child.parent.type == "template_type":
+                    continue
+                base_name = _text(base_child, source)
+                if base_name in BASE_CLASS_TO_TYPE:
+                    return base_name
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1304,6 +1315,20 @@ def main():
                 all_devices.extend(process_adapter_dir(subdir, mm_keywords))
             except Exception as e:
                 print(f"Warning: error processing {subdir.name}: {e}", file=sys.stderr)
+
+    # Deduplicate by (library, device), keeping the entry with more properties
+    seen: dict[tuple[str, str], int] = {}
+    deduped: list[dict] = []
+    for d in all_devices:
+        key = (d["library"], d["device"])
+        if key in seen:
+            idx = seen[key]
+            if len(d["properties"]) > len(deduped[idx]["properties"]):
+                deduped[idx] = d
+        else:
+            seen[key] = len(deduped)
+            deduped.append(d)
+    all_devices = deduped
 
     print(
         f"Found {len(all_devices)} devices across {', '.join(p.name for p in adapter_roots)}",


### PR DESCRIPTION
This is a somewhat handy script that uses `tree-sitter` (and a lot of additional claude-assisted hacks) to statically parse all of the DeviceAdapters to create a JSON output containing all Devices and Properties in the source code. 

you can run it with 

```sh
uv run tools/parse_device_properties.py -o props.json --stats 
```

and it will create a very large `props.json` file containing, device details that look like this:

<details>

```json
  {
    "library": "DemoCamera",
    "device": "DCam",
    "description": "Demo Camera Device Adapter",
    "device_type": "Camera",
    "type": "object",
    "properties": {
      "<unresolved:propName>": {
        "type": "number",
        "default": 0.0,
        "minimum": "<unresolved:lowerLimit>",
        "maximum": "<unresolved:upperLimit>"
      },
      "AllowMultiROI": {
        "type": "boolean",
        "default": false
      },
      "AsyncPropertyDelayMS": {
        "type": "integer",
        "default": 2000
      },
      "AsyncPropertyFollower": {
        "type": "string",
        "readOnly": true,
        "default": "init"
      },
      "AsyncPropertyLeader": {
        "type": "string",
        "default": "init"
      },
      "BeadBlurRate": {
        "type": "number",
        "minimum": 0.1,
        "maximum": 1.0
      },
      "BeadBrightness": {
        "type": "number",
        "minimum": 0.125,
        "maximum": 8.0
      },
      "BeadDensity": {
        "type": "integer",
        "minimum": 10,
        "maximum": 500
      },
      "BeadSize": {
        "type": "number",
        "minimum": 1.0,
        "maximum": 10.0
      },
      "Binning": {
        "type": "integer",
        "default": 1,
        "enum": [
          1,
          2,
          4,
          8
        ]
      },
      "BitDepth": {
        "type": "integer",
        "default": 8,
        "enum": [
          8,
          10,
          11,
          12,
          14,
          16,
          32
        ]
      },
      "CCDTemperature": {
        "type": "number",
        "default": 0,
        "minimum": -100,
        "maximum": 10
      },
      "CCDTemperature RO": {
        "type": "number",
        "readOnly": true,
        "default": 0
      },
      "CameraID": {
        "type": "string",
        "readOnly": true,
        "default": "V1.0"
      },
      "CameraName": {
        "type": "string",
        "readOnly": true,
        "default": "DemoCamera-MultiMode"
      },
      "Description": {
        "type": "string",
        "readOnly": true,
        "default": "Demo Camera Device Adapter"
      },
      "DisplayImageNumber": {
        "type": "boolean",
        "default": false
      },
      "DropPixels": {
        "type": "boolean",
        "default": false
      },
      "Exposure": {
        "type": "number",
        "default": 10.0,
        "minimum": 0.0,
        "maximum": "<unresolved:exposureMaximum_>"
      },
      "FastImage": {
        "type": "boolean",
        "default": false
      },
      "FractionOfPixelsToDropOrSaturate": {
        "type": "number",
        "default": 0.002,
        "minimum": 0.0,
        "maximum": 0.1
      },
      "Gain": {
        "type": "integer",
        "default": 0,
        "minimum": -5,
        "maximum": 8
      },
      "MaximumExposureMs": {
        "type": "number",
        "preInit": true
      },
      "Mode": {
        "type": "string",
        "default": "Artificial Waves",
        "enum": [
          "Artificial Waves",
          "Color Test Pattern",
          "Fluorescent Beads",
          "Noise"
        ]
      },
      "MultiROIFillValue": {
        "type": "integer",
        "default": 0,
        "minimum": 0,
        "maximum": 65536
      },
      "Name": {
        "type": "string",
        "readOnly": true,
        "default": "DCam"
      },
      "Offset": {
        "type": "integer",
        "default": 0
      },
      "OnCameraCCDXSize": {
        "type": "integer",
        "default": 512
      },
      "OnCameraCCDYSize": {
        "type": "integer",
        "default": 512
      },
      "Photon Conversion Factor": {
        "type": "number",
        "minimum": 0.01,
        "maximum": 10.0
      },
      "Photon Flux": {
        "type": "number",
        "minimum": 2.0,
        "maximum": 5000.0
      },
      "PixelType": {
        "type": "string",
        "default": "8bit",
        "enum": [
          "16bit",
          "32bit",
          "32bitRGB",
          "64bitRGB",
          "8bit"
        ]
      },
      "ReadNoise (electrons)": {
        "type": "number",
        "minimum": 0.25,
        "maximum": 50.0
      },
      "ReadoutTime": {
        "type": "number",
        "default": 0
      },
      "RotateImages": {
        "type": "boolean",
        "default": false
      },
      "SaturatePixels": {
        "type": "boolean",
        "default": false
      },
      "ScanMode": {
        "type": "integer",
        "default": 1,
        "enum": [
          1,
          2,
          3
        ]
      },
      "SimulateCrash": {
        "type": "string",
        "default": "",
        "enum": [
          "",
          "Dereference Null Pointer",
          "Divide by Zero"
        ]
      },
      "StripeWidth": {
        "type": "number",
        "default": 0,
        "minimum": 0,
        "maximum": 10
      },
      "TriggerDevice": {
        "type": "string",
        "default": ""
      },
      "UseExposureSequences": {
        "type": "string",
        "default": "No",
        "enum": [
          "No",
          "Yes"
        ]
      }
    }
  },
```

</details>

here's how well it's currently doing:

```
Found 725 devices across DeviceAdapters, SecretDeviceAdapters

--- Extraction Stats ---
Time:                          5.6s
Libraries:                     261
Devices:                       725
Resolved device names:         704/725 (97%)
Devices with properties:       710/725 (98%)
Unresolved property names:     233/6283 (4%)
Unresolved property values:    647/17515 (4%)

By device type:
  StateDevice          147
  Shutter              139
  Generic              97
  Stage                92
  Camera               66
  XYStage              56
  Hub                  51
  SignalIO             26
  AutoFocus            18
  Magnifier            8
  Galvo                7
  ImageProcessor       5
  SLM                  4
  Serial               4
  VolumetricPump       3
  PressurePump         2
```

and errors include:

<details>

```
Unresolved device names (21):
  ASITiger                       <unresolved:CClocked::GetName>
  AlliedVisionCamera             <unresolved:m_cameraName.c_str()>
  Aravis                         <unresolved:arv_cam_name>
  IntegratedLaserEngine          <unresolved:GetDeviceName().c_str()>
  MCCDAQ                         <unresolved:name_.c_str()>
  MCCDAQ                         <unresolved:CDTOLSwitch::GetName>
  MatrixVision                   <unresolved:pDev_->serial.read().c_str()>
  Pixelink                       <unresolved:deviceName_.c_str()>
  PointGrey                      <unresolved:deviceName_.c_str()>
  SequenceTester                 <unresolved:TesterCamera::GetName>
  SequenceTester                 <unresolved:TesterShutter::GetName>
  SequenceTester                 <unresolved:TesterXYStage::GetName>
  SequenceTester                 <unresolved:TesterAutofocus::GetName>
  SequenceTester                 <unresolved:TesterSwitcher::GetName>
  SerialManager                  <unresolved:portName_.c_str()>
  Spinnaker                      <unresolved:m_SN.c_str()>
  SpinnakerC                     <unresolved:m_serialNumber.c_str()>
  TCPIPPort                      <unresolved:GetStringName().c_str()>
  TUCam                          <unresolved:DemoHub::GetName>
  USB_Viper_QPL                  <unresolved:CDTOLSwitch::GetName>
  pgFocus                        <unresolved:pgFocusAxis::GetName>

Devices with 0 properties (15):
  AmScope                        DHub
  MCCDAQ                         <unresolved:CDTOLSwitch::GetName>
  MoticMicroscope                g_devlist[MoticHub][0]
  OxxiusCombiner                 LCX laser source 1
  PlayerOne                      DHub
  PriorPureFocus                 PureFocusOffset
  SequenceTester                 THub
  SequenceTester                 <unresolved:TesterCamera::GetName>
  SequenceTester                 <unresolved:TesterShutter::GetName>
  SequenceTester                 <unresolved:TesterXYStage::GetName>
  SequenceTester                 <unresolved:TesterAutofocus::GetName>
  SequenceTester                 <unresolved:TesterSwitcher::GetName>
  TUCam                          <unresolved:DemoHub::GetName>
  USB_Viper_QPL                  <unresolved:CDTOLSwitch::GetName>
  pgFocus                        <unresolved:pgFocusAxis::GetName>
```

</details>