### PR TITLE
MMCore: Avoid GetName calls and store device name

### DIFF
--- a/MMCore/Devices/DeviceInstance.cpp
+++ b/MMCore/Devices/DeviceInstance.cpp
@@ -58,20 +58,22 @@ DeviceInstance::DeviceInstance(CMMCore* core,
    pImpl_(pDevice),
    core_(core),
    adapter_(adapter),
+   name_(name),
    label_(label),
    deleteFunction_(deleteFunction),
    deviceLogger_(deviceLogger),
    coreLogger_(coreLogger)
 {
-   const std::string actualName = GetName();
+   // MM::Device::GetName() is not used any more outside of peripheral
+   // discovery, but we still have it for legacy reasons. For what it's worth,
+   // log a warning if GetName() doesn't return the expected name.
+   DeviceStringBuffer nameBuf(this, "GetName");
+   pImpl_->GetName(nameBuf.GetBuffer());
+   const std::string actualName = nameBuf.Get();
    if (actualName != name)
    {
       LOG_WARNING(Logger()) << "Requested device named \"" << name <<
          "\" but the actual device is named \"" << actualName << "\"";
-
-      // TODO This should ideally be an error, but currently it breaks some
-      // device adapters. Probably best to remove GetName() from MM::Device
-      // entirely and handle it solely in the Core.
    }
 
    pImpl_->SetLabel(label_.c_str());
@@ -398,14 +400,6 @@ DeviceInstance::Shutdown()
 MM::DeviceType
 DeviceInstance::GetType() const
 { return pImpl_->GetType(); }
-
-std::string
-DeviceInstance::GetName() const
-{
-   DeviceStringBuffer nameBuf(this, "GetName");
-   pImpl_->GetName(nameBuf.GetBuffer());
-   return nameBuf.Get();
-}
 
 void
 DeviceInstance::SetCallback(MM::Core* callback) { 

--- a/MMCore/Devices/DeviceInstance.h
+++ b/MMCore/Devices/DeviceInstance.h
@@ -73,6 +73,7 @@ protected:
 private:
    CMMCore* core_; // Weak reference
    std::shared_ptr<LoadedDeviceAdapter> adapter_;
+   const std::string name_;
    const std::string label_;
    std::string description_;
    DeleteDeviceFunction deleteFunction_;
@@ -86,6 +87,7 @@ public:
    DeviceInstance& operator=(const DeviceInstance&) = delete;
 
    std::shared_ptr<LoadedDeviceAdapter> GetAdapterModule() const /* final */ { return adapter_; }
+   std::string GetName() const /* final */ { return name_; }
    std::string GetLabel() const /* final */ { return label_; }
    std::string GetDescription() const /* final */ { return description_; }
    void SetDescription(const std::string& description) /* final */ { description_ = description; }
@@ -221,7 +223,6 @@ public:
    void Initialize();
    void Shutdown();
    MM::DeviceType GetType() const; // TODO Make private (can use RTTI)
-   std::string GetName() const;
    void SetCallback(MM::Core* callback);
    bool SupportsDeviceDetection();
    MM::DeviceDetectionStatus DetectDevice();

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -108,7 +108,7 @@ namespace notif = mmcore::internal::notification;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 12, MMCore_versionMinor = 2, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 12, MMCore_versionMinor = 2, MMCore_versionPatch = 1;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/unittest/MockDeviceAdapter-Tests.cpp
+++ b/MMCore/unittest/MockDeviceAdapter-Tests.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Register and load a mock device")
    c.loadDevice("mylabel", "myadapter", "mydevice");
    c.initializeDevice("mylabel");
    c.waitForDevice("mylabel");
-   CHECK(c.getDeviceName("mylabel") == "name-returned-by-device");
+   CHECK(c.getDeviceName("mylabel") == "mydevice");
    c.unloadDevice("mylabel");
 }
 

--- a/MMCore/unittest/StubDevices-Tests.cpp
+++ b/MMCore/unittest/StubDevices-Tests.cpp
@@ -61,88 +61,88 @@ TEST_CASE("StubGalvo can be default-constructed") {
 
 TEST_CASE("StubGeneric can be loaded into CMMCore") {
    StubGeneric dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubGeneric", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubGeneric");
+   CHECK(c.getDeviceName("StubGeneric") == "StubGeneric");
 }
 
 TEST_CASE("StubCamera can be loaded into CMMCore") {
    StubCamera dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubCamera", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubCamera");
+   CHECK(c.getDeviceName("StubCamera") == "StubCamera");
 }
 
 TEST_CASE("StubStage can be loaded into CMMCore") {
    StubStage dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubStage", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubStage");
+   CHECK(c.getDeviceName("StubStage") == "StubStage");
 }
 
 TEST_CASE("StubXYStage can be loaded into CMMCore") {
    StubXYStage dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubXYStage", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubXYStage");
+   CHECK(c.getDeviceName("StubXYStage") == "StubXYStage");
 }
 
 TEST_CASE("StubStateDevice can be loaded into CMMCore") {
    StubStateDevice dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubStateDevice", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubStateDevice");
+   CHECK(c.getDeviceName("StubStateDevice") == "StubStateDevice");
 }
 
 TEST_CASE("StubShutter can be loaded into CMMCore") {
    StubShutter dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubShutter", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubShutter");
+   CHECK(c.getDeviceName("StubShutter") == "StubShutter");
 }
 
 TEST_CASE("StubMagnifier can be loaded into CMMCore") {
    StubMagnifier dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubMagnifier", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubMagnifier");
+   CHECK(c.getDeviceName("StubMagnifier") == "StubMagnifier");
 }
 
 TEST_CASE("StubAutoFocus can be loaded into CMMCore") {
    StubAutoFocus dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubAutoFocus", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubAutoFocus");
+   CHECK(c.getDeviceName("StubAutoFocus") == "StubAutoFocus");
 }
 
 TEST_CASE("StubImageProcessor can be loaded into CMMCore") {
    StubImageProcessor dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubImageProcessor", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubImageProcessor");
+   CHECK(c.getDeviceName("StubImageProcessor") == "StubImageProcessor");
 }
 
 TEST_CASE("StubSLM can be loaded into CMMCore") {
    StubSLM dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubSLM", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubSLM");
+   CHECK(c.getDeviceName("StubSLM") == "StubSLM");
 }
 
 TEST_CASE("StubGalvo can be loaded into CMMCore") {
    StubGalvo dev;
-   MockAdapterWithDevices adapter{{"dev", &dev}};
+   MockAdapterWithDevices adapter{{"StubGalvo", &dev}};
    CMMCore c;
    adapter.LoadIntoCore(c);
-   CHECK(c.getDeviceName("dev") == "StubGalvo");
+   CHECK(c.getDeviceName("StubGalvo") == "StubGalvo");
 }

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.micro-manager.mmcorej</groupId>
     <artifactId>MMCoreJ</artifactId>
-    <version>12.2.0</version>
+    <version>12.2.1</version>
 
     <name>MMCore Java API</name>
     <description>Java bindings for MMCore, the device abstraction layer of Micro-Manager, the microscope control and acquisition platform.</description>


### PR DESCRIPTION
Closes #897.

Avoid ever calling a device's GetName(), except in the case of peripheral detection for hub devices (which we cannot change without a device interface break).

This means that CMMCore::getDeviceName(label) always returns the correct device name that is used to load the device, instead of leaving it up to the device's potentially buggy implementation. And one step toward removing GetName() entirely from the device interface.

(This issue came up again in a pymmcore-widgets (hardware wizard) context.)