### PR TITLE
MMCore logging: add log rotation, full log level/source support

### DIFF
--- a/MMCore/Devices/DeviceInstance.cpp
+++ b/MMCore/Devices/DeviceInstance.cpp
@@ -35,8 +35,8 @@ namespace mmcore {
 namespace internal {
 
 using mmcore::internal::logging::Logger;
-using mmcore::internal::logging::LogLevelDebug;
-using mmcore::internal::logging::LogLevelInfo;
+using mmcore::LogLevelDebug;
+using mmcore::LogLevelInfo;
 
 int
 DeviceInstance::LogMessage(const char* msg, bool debugOnly)

--- a/MMCore/LogLevel.h
+++ b/MMCore/LogLevel.h
@@ -9,7 +9,7 @@ enum LogLevel
    LogLevelInfo,
    LogLevelWarning,
    LogLevelError,
-   LogLevelFatal,
+   LogLevelCritical,
 };
 
 } // namespace mmcore

--- a/MMCore/LogLevel.h
+++ b/MMCore/LogLevel.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace mmcore {
+
+enum LogLevel
+{
+   LogLevelTrace,
+   LogLevelDebug,
+   LogLevelInfo,
+   LogLevelWarning,
+   LogLevelError,
+   LogLevelFatal,
+};
+
+} // namespace mmcore

--- a/MMCore/LogManager.cpp
+++ b/MMCore/LogManager.cpp
@@ -14,16 +14,16 @@ namespace internal {
 namespace
 {
 
-const char* StringForLogLevel(logging::LogLevel level)
+const char* StringForLogLevel(LogLevel level)
 {
    switch (level)
    {
-      case logging::LogLevelTrace: return "trace";
-      case logging::LogLevelDebug: return "debug";
-      case logging::LogLevelInfo: return "info";
-      case logging::LogLevelWarning: return "warning";
-      case logging::LogLevelError: return "error";
-      case logging::LogLevelFatal: return "fatal";
+      case LogLevelTrace: return "trace";
+      case LogLevelDebug: return "debug";
+      case LogLevelInfo: return "info";
+      case LogLevelWarning: return "warning";
+      case LogLevelError: return "error";
+      case LogLevelFatal: return "fatal";
       default: return "(unknown)";
    }
 }
@@ -35,7 +35,7 @@ const logging::SinkMode LogManager::PrimarySinkMode = logging::SinkModeAsynchron
 LogManager::LogManager() :
    loggingCore_(std::make_shared<logging::LoggingCore>()),
    internalLogger_(loggingCore_->NewLogger("LogManager")),
-   primaryLogLevel_(logging::LogLevelInfo),
+   primaryLogLevel_(LogLevelInfo),
    usingStdErr_(false),
    primaryMaxFileSize_(0),
    primaryMaxBackupFiles_(0),
@@ -208,14 +208,14 @@ LogManager::SetPrimaryLogRotation(std::size_t maxFileSize, int maxBackupFiles)
 
 
 void
-LogManager::SetPrimaryLogLevel(logging::LogLevel level)
+LogManager::SetPrimaryLogLevel(LogLevel level)
 {
    std::lock_guard<std::mutex> lock(mutex_);
 
    if (level == primaryLogLevel_)
       return;
 
-   logging::LogLevel oldLevel = primaryLogLevel_;
+   LogLevel oldLevel = primaryLogLevel_;
    primaryLogLevel_ = level;
 
    LOG_INFO(internalLogger_) << "Switching primary log level from " <<
@@ -250,7 +250,7 @@ LogManager::SetPrimaryLogLevel(logging::LogLevel level)
 }
 
 
-logging::LogLevel
+LogLevel
 LogManager::GetPrimaryLogLevel() const
 {
    std::lock_guard<std::mutex> lock(mutex_);
@@ -259,7 +259,7 @@ LogManager::GetPrimaryLogLevel() const
 
 
 LogManager::LogFileHandle
-LogManager::AddSecondaryLogFile(logging::LogLevel level,
+LogManager::AddSecondaryLogFile(LogLevel level,
       const std::string& filename, bool truncate, logging::SinkMode mode)
 {
    std::lock_guard<std::mutex> lock(mutex_);

--- a/MMCore/LogManager.cpp
+++ b/MMCore/LogManager.cpp
@@ -37,6 +37,8 @@ LogManager::LogManager() :
    internalLogger_(loggingCore_->NewLogger("LogManager")),
    primaryLogLevel_(logging::LogLevelInfo),
    usingStdErr_(false),
+   primaryMaxFileSize_(0),
+   primaryMaxBackupFiles_(0),
    nextSecondaryHandle_(0)
 {}
 
@@ -103,7 +105,8 @@ LogManager::SetPrimaryLogFilename(const std::string& filename, bool truncate)
    std::shared_ptr<logging::LogSink> newSink;
    try
    {
-      newSink = std::make_shared<logging::FileLogSink>(primaryFilename_, !truncate);
+      newSink = std::make_shared<logging::FileLogSink>(primaryFilename_,
+            !truncate, primaryMaxFileSize_, primaryMaxBackupFiles_);
    }
    catch (const logging::CannotOpenFileException&)
    {
@@ -163,6 +166,44 @@ LogManager::IsUsingPrimaryLogFile() const
 {
    std::lock_guard<std::mutex> lock(mutex_);
    return !primaryFilename_.empty();
+}
+
+
+void
+LogManager::SetPrimaryLogRotation(std::size_t maxFileSize, int maxBackupFiles)
+{
+   std::lock_guard<std::mutex> lock(mutex_);
+
+   primaryMaxFileSize_ = maxFileSize;
+   primaryMaxBackupFiles_ = maxBackupFiles;
+
+   if (!primaryFileSink_)
+      return;
+
+   std::shared_ptr<logging::LogSink> newSink;
+   try
+   {
+      newSink = std::make_shared<logging::FileLogSink>(primaryFilename_,
+            true, primaryMaxFileSize_, primaryMaxBackupFiles_);
+   }
+   catch (const logging::CannotOpenFileException&)
+   {
+      LOG_ERROR(internalLogger_) << "Failed to reopen file " <<
+         primaryFilename_ << " while updating rotation settings";
+      return;
+   }
+
+   newSink->SetFilter(std::make_shared<logging::LevelFilter>(primaryLogLevel_));
+
+   LOG_INFO(internalLogger_) << "Updating primary log file rotation settings";
+   std::vector<std::pair<std::shared_ptr<logging::LogSink>, logging::SinkMode>> toRemove;
+   std::vector<std::pair<std::shared_ptr<logging::LogSink>, logging::SinkMode>> toAdd;
+   toRemove.push_back(std::make_pair(primaryFileSink_, PrimarySinkMode));
+   toAdd.push_back(std::make_pair(newSink, PrimarySinkMode));
+
+   loggingCore_->AtomicSwapSinks(toRemove.begin(), toRemove.end(),
+         toAdd.begin(), toAdd.end());
+   primaryFileSink_ = newSink;
 }
 
 

--- a/MMCore/LogManager.cpp
+++ b/MMCore/LogManager.cpp
@@ -23,7 +23,7 @@ const char* StringForLogLevel(LogLevel level)
       case LogLevelInfo: return "info";
       case LogLevelWarning: return "warning";
       case LogLevelError: return "error";
-      case LogLevelFatal: return "fatal";
+      case LogLevelCritical: return "critical";
       default: return "(unknown)";
    }
 }

--- a/MMCore/LogManager.h
+++ b/MMCore/LogManager.h
@@ -23,7 +23,7 @@ private:
 
    mutable std::mutex mutex_;
 
-   logging::LogLevel primaryLogLevel_;
+   LogLevel primaryLogLevel_;
 
    bool usingStdErr_;
    std::shared_ptr<logging::LogSink> stdErrSink_;
@@ -64,10 +64,10 @@ public:
 
    void SetPrimaryLogRotation(std::size_t maxFileSize, int maxBackupFiles);
 
-   void SetPrimaryLogLevel(logging::LogLevel level);
-   logging::LogLevel GetPrimaryLogLevel() const;
+   void SetPrimaryLogLevel(LogLevel level);
+   LogLevel GetPrimaryLogLevel() const;
 
-   LogFileHandle AddSecondaryLogFile(logging::LogLevel level,
+   LogFileHandle AddSecondaryLogFile(LogLevel level,
          const std::string& filename, bool truncate = true,
          logging::SinkMode mode = logging::SinkModeAsynchronous);
    void RemoveSecondaryLogFile(LogFileHandle handle);

--- a/MMCore/LogManager.h
+++ b/MMCore/LogManager.h
@@ -30,6 +30,8 @@ private:
 
    std::string primaryFilename_;
    std::shared_ptr<logging::LogSink> primaryFileSink_;
+   std::size_t primaryMaxFileSize_;
+   int primaryMaxBackupFiles_;
 
    LogFileHandle nextSecondaryHandle_;
    struct LogFileInfo
@@ -59,6 +61,8 @@ public:
    void SetPrimaryLogFilename(const std::string& filename, bool truncate);
    std::string GetPrimaryLogFilename() const;
    bool IsUsingPrimaryLogFile() const;
+
+   void SetPrimaryLogRotation(std::size_t maxFileSize, int maxBackupFiles);
 
    void SetPrimaryLogLevel(logging::LogLevel level);
    logging::LogLevel GetPrimaryLogLevel() const;

--- a/MMCore/Logging/FileRotation.cpp
+++ b/MMCore/Logging/FileRotation.cpp
@@ -1,0 +1,136 @@
+#include "FileRotation.h"
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace mmcore {
+namespace internal {
+namespace logging {
+
+namespace {
+
+// Split filename into (stem, extension) where extension includes the dot.
+// "CoreLog.log" -> ("CoreLog", ".log")
+// "CoreLog" -> ("CoreLog", "")
+// "/path/to/CoreLog.log" -> ("/path/to/CoreLog", ".log")
+std::pair<std::string, std::string>
+SplitFilename(const std::string& filename)
+{
+   namespace fs = std::filesystem;
+   fs::path p(filename);
+   std::string ext = p.extension().string();
+   std::string stem = filename.substr(0, filename.size() - ext.size());
+   return {stem, ext};
+}
+
+std::string FormatLocalTimeForFilename()
+{
+   auto now = std::chrono::system_clock::now();
+   auto secs = std::chrono::duration_cast<std::chrono::seconds>(
+         now.time_since_epoch());
+
+   std::time_t t(secs.count());
+   std::tm* ptm;
+#ifdef _WIN32
+   ptm = std::localtime(&t);
+#else
+   std::tm tmstruct;
+   ptm = localtime_r(&t, &tmstruct);
+#endif
+
+   char buf[32];
+   std::strftime(buf, sizeof(buf), "%Y%m%dT%H%M%S", ptm);
+   return buf;
+}
+
+bool IsRotatedFile(const std::string& name, const std::string& stem,
+      const std::string& ext)
+{
+   // Expected: {stem}_{YYYYMMDD}T{HHMMSS}{ext}
+   // The timestamp portion is exactly 15 characters: 8 date + T + 6 time
+   const std::size_t timestampLen = 15;
+   const std::size_t expectedLen =
+         stem.size() + 1 + timestampLen + ext.size(); // +1 for underscore
+   if (name.size() != expectedLen)
+      return false;
+   if (name.compare(0, stem.size(), stem) != 0)
+      return false;
+   if (name[stem.size()] != '_')
+      return false;
+   // Verify timestamp portion is digits and 'T'
+   std::size_t tsStart = stem.size() + 1;
+   for (std::size_t i = 0; i < timestampLen; ++i)
+   {
+      char c = name[tsStart + i];
+      if (i == 8) // Position of 'T'
+      {
+         if (c != 'T')
+            return false;
+      }
+      else
+      {
+         if (c < '0' || c > '9')
+            return false;
+      }
+   }
+   if (!ext.empty() &&
+         name.compare(tsStart + timestampLen, ext.size(), ext) != 0)
+      return false;
+   return true;
+}
+
+} // anonymous namespace
+
+std::string
+MakeRotatedFilename(const std::string& filename)
+{
+   auto [stem, ext] = SplitFilename(filename);
+   return stem + "_" + FormatLocalTimeForFilename() + ext;
+}
+
+void
+DeleteExcessRotatedFiles(const std::string& filename, int maxBackupFiles)
+{
+   namespace fs = std::filesystem;
+
+   if (maxBackupFiles <= 0)
+      return;
+
+   fs::path filePath(filename);
+   fs::path dir = filePath.parent_path();
+   if (dir.empty())
+      dir = ".";
+
+   auto [stem, ext] = SplitFilename(filePath.filename().string());
+
+   std::vector<std::string> rotatedFiles;
+   std::error_code ec;
+   for (const auto& entry : fs::directory_iterator(dir, ec))
+   {
+      if (!entry.is_regular_file(ec))
+         continue;
+      std::string name = entry.path().filename().string();
+      if (IsRotatedFile(name, stem, ext))
+         rotatedFiles.push_back(name);
+   }
+
+   if (static_cast<int>(rotatedFiles.size()) <= maxBackupFiles)
+      return;
+
+   // Sort ascending by name (chronological due to fixed-width timestamp)
+   std::sort(rotatedFiles.begin(), rotatedFiles.end());
+
+   int toDelete = static_cast<int>(rotatedFiles.size()) - maxBackupFiles;
+   for (int i = 0; i < toDelete; ++i)
+   {
+      fs::remove(dir / rotatedFiles[i], ec);
+   }
+}
+
+} // namespace logging
+} // namespace internal
+} // namespace mmcore

--- a/MMCore/Logging/FileRotation.h
+++ b/MMCore/Logging/FileRotation.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace mmcore {
+namespace internal {
+namespace logging {
+
+std::string MakeRotatedFilename(const std::string& filename);
+
+void DeleteExcessRotatedFiles(const std::string& filename,
+      int maxBackupFiles);
+
+} // namespace logging
+} // namespace internal
+} // namespace mmcore

--- a/MMCore/Logging/GenericStreamSink.h
+++ b/MMCore/Logging/GenericStreamSink.h
@@ -16,11 +16,14 @@
 
 #pragma once
 
+#include "FileRotation.h"
 #include "GenericSink.h"
 
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <streambuf>
 
 
 namespace mmcore {
@@ -36,6 +39,49 @@ public:
 
 
 namespace internal {
+
+
+class CountingStreambuf : public std::streambuf
+{
+   std::streambuf* wrapped_;
+   std::size_t count_;
+
+public:
+   explicit CountingStreambuf(std::streambuf* wrapped) :
+      wrapped_(wrapped),
+      count_(0)
+   {}
+
+   std::size_t Count() const { return count_; }
+   void ResetCount() { count_ = 0; }
+
+   void SetWrapped(std::streambuf* wrapped) { wrapped_ = wrapped; }
+
+protected:
+   int_type overflow(int_type c) override
+   {
+      if (!traits_type::eq_int_type(c, traits_type::eof()))
+      {
+         auto result = wrapped_->sputc(traits_type::to_char_type(c));
+         if (!traits_type::eq_int_type(result, traits_type::eof()))
+            ++count_;
+         return result;
+      }
+      return traits_type::not_eof(c);
+   }
+
+   std::streamsize xsputn(const char_type* s, std::streamsize n) override
+   {
+      auto written = wrapped_->sputn(s, n);
+      count_ += static_cast<std::size_t>(written);
+      return written;
+   }
+
+   int sync() override
+   {
+      return wrapped_->pubsync();
+   }
+};
 
 
 template <class TFormatter, class UMetadata, typename VPacketIter>
@@ -122,7 +168,12 @@ class GenericFileLogSink : public GenericSink<TMetadata>
 {
    std::string filename_;
    std::ofstream fileStream_;
+   CountingStreambuf countingBuf_;
+   std::ostream countingStream_;
    bool hadError_;
+   std::size_t maxFileSize_;
+   int maxBackupFiles_;
+   std::size_t initialFileSize_;
 
 public:
    typedef GenericSink<TMetadata> Super;
@@ -131,9 +182,15 @@ public:
    GenericFileLogSink(const GenericFileLogSink&) = delete;
    GenericFileLogSink& operator=(const GenericFileLogSink&) = delete;
 
-   GenericFileLogSink(const std::string& filename, bool append = false) :
+   GenericFileLogSink(const std::string& filename, bool append = false,
+         std::size_t maxFileSize = 0, int maxBackupFiles = 0) :
       filename_(filename),
-      hadError_(false)
+      countingBuf_(nullptr),
+      countingStream_(nullptr),
+      hadError_(false),
+      maxFileSize_(maxFileSize),
+      maxBackupFiles_(maxBackupFiles),
+      initialFileSize_(0)
    {
       std::ios_base::openmode mode = std::ios_base::out;
       mode |= (append ? std::ios_base::app : std::ios_base::trunc);
@@ -141,17 +198,27 @@ public:
       fileStream_.open(filename_.c_str(), mode);
       if (!fileStream_)
          throw CannotOpenFileException();
+
+      if (append)
+      {
+         auto pos = fileStream_.tellp();
+         if (pos > 0)
+            initialFileSize_ = static_cast<std::size_t>(pos);
+      }
+
+      countingBuf_.SetWrapped(fileStream_.rdbuf());
+      countingStream_.rdbuf(&countingBuf_);
    }
 
    virtual void Consume(const PacketArrayType& packets)
    {
-      fileStream_.clear();
-      WritePacketsToStream<UFormatter>(fileStream_,
+      countingStream_.clear();
+      WritePacketsToStream<UFormatter>(countingStream_,
             packets.Begin(), packets.End(), this->GetFilter());
-      fileStream_.flush();
-      if (fileStream_.fail())
+      countingStream_.flush();
+      if (countingStream_.fail())
       {
-         fileStream_.clear();
+         countingStream_.clear();
          if (!hadError_)
          {
             hadError_ = true;
@@ -161,6 +228,49 @@ public:
       else
       {
          hadError_ = false;
+      }
+
+      if (maxFileSize_ > 0 &&
+            initialFileSize_ + countingBuf_.Count() > maxFileSize_)
+      {
+         RotateFile();
+      }
+   }
+
+private:
+   void RotateFile()
+   {
+      countingStream_.flush();
+      fileStream_.close();
+
+      std::string rotatedName = MakeRotatedFilename(filename_);
+      if (std::rename(filename_.c_str(), rotatedName.c_str()) != 0)
+      {
+         if (!hadError_)
+         {
+            hadError_ = true;
+            std::cerr << "Logging: cannot rotate file " << filename_ << '\n';
+         }
+         fileStream_.open(filename_.c_str(),
+               std::ios_base::out | std::ios_base::app);
+         return;
+      }
+
+      DeleteExcessRotatedFiles(filename_, maxBackupFiles_);
+
+      fileStream_.open(filename_.c_str(),
+            std::ios_base::out | std::ios_base::trunc);
+      if (fileStream_)
+      {
+         countingBuf_.SetWrapped(fileStream_.rdbuf());
+         countingBuf_.ResetCount();
+         initialFileSize_ = 0;
+         hadError_ = false;
+      }
+      else
+      {
+         std::cerr << "Logging: cannot reopen file " << filename_
+               << " after rotation\n";
       }
    }
 };

--- a/MMCore/Logging/Logger.h
+++ b/MMCore/Logging/Logger.h
@@ -59,4 +59,4 @@ typedef internal::GenericLogStream<Logger> LogStream;
 #define LOG_INFO(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelInfo)
 #define LOG_WARNING(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelWarning)
 #define LOG_ERROR(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelError)
-#define LOG_FATAL(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelFatal)
+#define LOG_CRITICAL(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelCritical)

--- a/MMCore/Logging/Logger.h
+++ b/MMCore/Logging/Logger.h
@@ -54,9 +54,9 @@ typedef internal::GenericLogStream<Logger> LogStream;
          !strm.Used(); strm.MarkUsed()) \
       strm
 
-#define LOG_TRACE(logger) LOG_WITH_LEVEL((logger), ::mmcore::internal::logging::LogLevelTrace)
-#define LOG_DEBUG(logger) LOG_WITH_LEVEL((logger), ::mmcore::internal::logging::LogLevelDebug)
-#define LOG_INFO(logger) LOG_WITH_LEVEL((logger), ::mmcore::internal::logging::LogLevelInfo)
-#define LOG_WARNING(logger) LOG_WITH_LEVEL((logger), ::mmcore::internal::logging::LogLevelWarning)
-#define LOG_ERROR(logger) LOG_WITH_LEVEL((logger), ::mmcore::internal::logging::LogLevelError)
-#define LOG_FATAL(logger) LOG_WITH_LEVEL((logger), ::mmcore::internal::logging::LogLevelFatal)
+#define LOG_TRACE(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelTrace)
+#define LOG_DEBUG(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelDebug)
+#define LOG_INFO(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelInfo)
+#define LOG_WARNING(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelWarning)
+#define LOG_ERROR(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelError)
+#define LOG_FATAL(logger) LOG_WITH_LEVEL((logger), ::mmcore::LogLevelFatal)

--- a/MMCore/Logging/Logging.h
+++ b/MMCore/Logging/Logging.h
@@ -24,6 +24,7 @@
 #include "Logger.h"
 #include "Metadata.h"
 #include "MetadataFormatter.h"
+#include "StderrColor.h"
 
 
 namespace mmcore {
@@ -34,7 +35,14 @@ namespace logging {
 typedef internal::GenericLoggingCore<Metadata> LoggingCore;
 
 typedef internal::GenericSink<Metadata> LogSink;
-typedef internal::GenericStdErrLogSink<Metadata, internal::MetadataFormatter>
+namespace internal {
+class StderrMetadataFormatter : public MetadataFormatter {
+public:
+   StderrMetadataFormatter() : MetadataFormatter(ShouldColorStderr()) {}
+};
+} // namespace internal
+
+typedef internal::GenericStdErrLogSink<Metadata, internal::StderrMetadataFormatter>
    StdErrLogSink;
 typedef internal::GenericFileLogSink<Metadata, internal::MetadataFormatter>
    FileLogSink;

--- a/MMCore/Logging/Metadata.h
+++ b/MMCore/Logging/Metadata.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "../LogLevel.h"
 #include "GenericMetadata.h"
 
 #ifdef _WIN32
@@ -54,17 +55,6 @@ GetTid() { return ::pthread_self(); }
 
 
 } // namespace internal
-
-
-enum LogLevel
-{
-   LogLevelTrace,
-   LogLevelDebug,
-   LogLevelInfo,
-   LogLevelWarning,
-   LogLevelError,
-   LogLevelFatal,
-};
 
 
 class EntryData

--- a/MMCore/Logging/MetadataFormatter.h
+++ b/MMCore/Logging/MetadataFormatter.h
@@ -42,7 +42,7 @@ LevelString(LogLevel logLevel)
       case LogLevelInfo: return "IFO";
       case LogLevelWarning: return "WRN";
       case LogLevelError: return "ERR";
-      case LogLevelFatal: return "FTL";
+      case LogLevelCritical: return "CRT";
       default: return "???";
    }
 }

--- a/MMCore/Logging/MetadataFormatter.h
+++ b/MMCore/Logging/MetadataFormatter.h
@@ -48,6 +48,33 @@ LevelString(LogLevel logLevel)
 }
 
 
+inline const char*
+LevelColorCode(LogLevel level)
+{
+   switch (level)
+   {
+      case LogLevelTrace: return "\033[2m";
+      case LogLevelDebug: return "\033[2m";
+      case LogLevelInfo: return "";
+      case LogLevelWarning: return "\033[33m";
+      case LogLevelError: return "\033[31m";
+      case LogLevelCritical: return "\033[1;31m";
+      default: return "";
+   }
+}
+
+
+inline const char*
+LevelColorReset(LogLevel level)
+{
+   switch (level)
+   {
+      case LogLevelInfo: return "";
+      default: return "\033[m";
+   }
+}
+
+
 // A stateful formatter for the metadata prefix and corresponding
 // continuation-line prefix. Intended for single-threaded use only.
 class MetadataFormatter
@@ -57,15 +84,21 @@ class MetadataFormatter
    std::ostringstream sstrm_;
    size_t openBracketCol_;
    size_t closeBracketCol_;
+   bool useColor_;
 
 public:
-   MetadataFormatter() : openBracketCol_(0), closeBracketCol_(0) {}
+   MetadataFormatter() : openBracketCol_(0), closeBracketCol_(0),
+      useColor_(false) {}
 
    // Format the line prefix for the first line of an entry
    void FormatLinePrefix(std::ostream& stream, const Metadata& metadata);
 
    // Format the line prefix for subsequent lines of an entry
    void FormatContinuationPrefix(std::ostream& stream);
+
+protected:
+   explicit MetadataFormatter(bool useColor) :
+      openBracketCol_(0), closeBracketCol_(0), useColor_(useColor) {}
 };
 
 
@@ -115,11 +148,20 @@ MetadataFormatter::FormatLinePrefix(std::ostream& stream,
    openBracketCol_ = buf_.size();
    buf_ += '[';
 
-   buf_ += LevelString(metadata.GetEntryData().GetLevel());
+   const auto level = metadata.GetEntryData().GetLevel();
+   const char* levelStr = LevelString(level);
+   if (useColor_)
+      buf_ += LevelColorCode(level);
+   buf_ += levelStr;
+   if (useColor_)
+      buf_ += LevelColorReset(level);
    buf_ += ',';
-   buf_ += metadata.GetLoggerData().GetComponentLabel();
 
-   closeBracketCol_ = buf_.size();
+   const char* label = metadata.GetLoggerData().GetComponentLabel();
+   buf_ += label;
+
+   closeBracketCol_ = openBracketCol_ + 1 +
+      std::strlen(levelStr) + 1 + std::strlen(label);
    buf_ += ']';
 
    stream << buf_;

--- a/MMCore/Logging/StderrColor.h
+++ b/MMCore/Logging/StderrColor.h
@@ -1,0 +1,83 @@
+// COPYRIGHT:     2026 Board of Regents of the University of Wisconsin System
+//
+// LICENSE:       This file is distributed under the "Lesser GPL" (LGPL) license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// AUTHOR:        Mark Tsuchida
+
+#pragma once
+
+#include <cstdlib>
+#include <cstring>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+
+namespace mmcore {
+namespace internal {
+namespace logging {
+namespace internal {
+
+
+namespace {
+
+inline bool
+DetectStderrColor()
+{
+   if (std::getenv("NO_COLOR") != nullptr)
+      return false;
+
+   const char* term = std::getenv("TERM");
+   if (term != nullptr && std::strcmp(term, "dumb") == 0)
+      return false;
+
+#ifdef _WIN32
+   if (!_isatty(_fileno(stderr)))
+      return false;
+
+   HANDLE h = GetStdHandle(STD_ERROR_HANDLE);
+   if (h == INVALID_HANDLE_VALUE)
+      return false;
+
+   DWORD mode = 0;
+   if (!GetConsoleMode(h, &mode))
+      return false;
+
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+   return (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0;
+#else
+   return isatty(STDERR_FILENO) != 0;
+#endif
+}
+
+} // anonymous namespace
+
+
+inline bool
+ShouldColorStderr()
+{
+   static const bool result = DetectStderrColor();
+   return result;
+}
+
+
+} // namespace internal
+} // namespace logging
+} // namespace internal
+} // namespace mmcore

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -272,7 +272,7 @@ void CMMCore::setPrimaryLogFileRotation(long long maxFileSize, int maxBackupCoun
  */
 void CMMCore::logMessage(const char* msg)
 {
-   appLogger_(mmi::logging::LogLevelInfo, msg);
+   appLogger_(mmcore::LogLevelInfo, msg);
 }
 
 
@@ -281,8 +281,49 @@ void CMMCore::logMessage(const char* msg)
  */
 void CMMCore::logMessage(const char* msg, bool debugOnly)
 {
-   appLogger_(debugOnly ? mmi::logging::LogLevelDebug :
-         mmi::logging::LogLevelInfo, msg);
+   appLogger_(debugOnly ? mmcore::LogLevelDebug :
+         mmcore::LogLevelInfo, msg);
+}
+
+
+/**
+ * Record text message in the log file at the specified level.
+ */
+void CMMCore::log(const char* msg, mmcore::LogLevel level)
+{
+   appLogger_(level, msg);
+}
+
+
+/**
+ * Record text message in the log file at the specified level, with a
+ * caller-specified logger name as the component label.
+ */
+void CMMCore::log(const char* msg, mmcore::LogLevel level,
+      const char* loggerName)
+{
+   logManager_->NewLogger(loggerName)(level, msg);
+}
+
+
+/**
+ * Set the primary log level.
+ *
+ * Messages below this level will not be recorded in the primary log file or
+ * stderr output.
+ */
+void CMMCore::setPrimaryLogLevel(mmcore::LogLevel level)
+{
+   logManager_->SetPrimaryLogLevel(level);
+}
+
+
+/**
+ * Return the current primary log level.
+ */
+mmcore::LogLevel CMMCore::getPrimaryLogLevel()
+{
+   return logManager_->GetPrimaryLogLevel();
 }
 
 
@@ -292,8 +333,8 @@ void CMMCore::logMessage(const char* msg, bool debugOnly)
  */
 void CMMCore::enableDebugLog(bool enable)
 {
-   logManager_->SetPrimaryLogLevel(enable ? mmi::logging::LogLevelTrace :
-         mmi::logging::LogLevelInfo);
+   logManager_->SetPrimaryLogLevel(enable ? mmcore::LogLevelTrace :
+         mmcore::LogLevelInfo);
 }
 
 /**
@@ -301,7 +342,7 @@ void CMMCore::enableDebugLog(bool enable)
  */
 bool CMMCore::debugLogEnabled()
 {
-   return (logManager_->GetPrimaryLogLevel() < mmi::logging::LogLevelInfo);
+   return (logManager_->GetPrimaryLogLevel() < mmcore::LogLevelInfo);
 }
 
 /**
@@ -345,7 +386,7 @@ int CMMCore::startSecondaryLogFile(const char* filename, bool enableDebug,
    typedef mmi::LogManager::LogFileHandle LogFileHandle;
 
    LogFileHandle handle = logManager_->AddSecondaryLogFile(
-            (enableDebug ? LogLevelTrace : LogLevelInfo),
+            (enableDebug ? mmcore::LogLevelTrace : mmcore::LogLevelInfo),
             filename, truncate,
             (synchronous ? SinkModeSynchronous : SinkModeAsynchronous));
    return static_cast<int>(handle);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -108,7 +108,7 @@ namespace notif = mmcore::internal::notification;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 12, MMCore_versionMinor = 2, MMCore_versionPatch = 2;
+const int MMCore_versionMajor = 12, MMCore_versionMinor = 3, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -253,6 +253,21 @@ std::string CMMCore::getPrimaryLogFile() const
 }
 
 /**
+ * Set log rotation for the primary Core log file.
+ *
+ * @param maxFileSize Maximum file size in bytes before rotation. 0 disables
+ * rotation.
+ * @param maxBackupCount Maximum number of rotated files to keep. 0 means
+ * unlimited. Oldest files are deleted first.
+ */
+void CMMCore::setPrimaryLogFileRotation(long long maxFileSize, int maxBackupCount)
+{
+   logManager_->SetPrimaryLogRotation(
+         maxFileSize > 0 ? static_cast<std::size_t>(maxFileSize) : 0,
+         maxBackupCount);
+}
+
+/**
  * Record text message in the log file.
  */
 void CMMCore::logMessage(const char* msg)

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -186,6 +186,7 @@ public:
    ///@{
    void setPrimaryLogFile(const char* filename, bool truncate = false) MMCORE_LEGACY_THROW(CMMError);
    std::string getPrimaryLogFile() const;
+   void setPrimaryLogFileRotation(long long maxFileSize, int maxBackupCount);
 
    void logMessage(const char* msg);
    void logMessage(const char* msg, bool debugOnly);

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -49,6 +49,7 @@
 #include "Configuration.h"
 #include "Error.h"
 #include "ErrorCodes.h"
+#include "LogLevel.h"
 #include "Logging/Logger.h"
 #include "MockDeviceAdapter.h"
 #include "Notification.h"
@@ -190,6 +191,11 @@ public:
 
    void logMessage(const char* msg);
    void logMessage(const char* msg, bool debugOnly);
+   void log(const char* msg, mmcore::LogLevel level);
+   void log(const char* msg, mmcore::LogLevel level,
+         const char* loggerName);
+   void setPrimaryLogLevel(mmcore::LogLevel level);
+   mmcore::LogLevel getPrimaryLogLevel();
    void enableDebugLog(bool enable);
    bool debugLogEnabled();
    void enableStderrLog(bool enable);

--- a/MMCore/MMCore.vcxproj
+++ b/MMCore/MMCore.vcxproj
@@ -170,6 +170,7 @@
     <ClInclude Include="Logging\GenericStreamSink.h" />
     <ClInclude Include="Logging\Logger.h" />
     <ClInclude Include="Logging\Logging.h" />
+    <ClInclude Include="Logging\StderrColor.h" />
     <ClInclude Include="Logging\Metadata.h" />
     <ClInclude Include="Logging\MetadataFormatter.h" />
     <ClInclude Include="LogLevel.h" />

--- a/MMCore/MMCore.vcxproj
+++ b/MMCore/MMCore.vcxproj
@@ -172,6 +172,7 @@
     <ClInclude Include="Logging\Logging.h" />
     <ClInclude Include="Logging\Metadata.h" />
     <ClInclude Include="Logging\MetadataFormatter.h" />
+    <ClInclude Include="LogLevel.h" />
     <ClInclude Include="LogManager.h" />
     <ClInclude Include="MMCore.h" />
     <ClInclude Include="MMEventCallback.h" />

--- a/MMCore/MMCore.vcxproj
+++ b/MMCore/MMCore.vcxproj
@@ -107,6 +107,7 @@
     <ClCompile Include="LoadableModules\LoadedDeviceAdapterImplRegular.cpp" />
     <ClCompile Include="LoadableModules\LoadedModule.cpp" />
     <ClCompile Include="LoadableModules\LoadedModuleImpl.cpp" />
+    <ClCompile Include="Logging\FileRotation.cpp" />
     <ClCompile Include="Logging\Metadata.cpp" />
     <ClCompile Include="LogManager.cpp" />
     <ClCompile Include="MMCore.cpp" />
@@ -157,6 +158,7 @@
     <ClInclude Include="LoadableModules\LoadedDeviceAdapterImplRegular.h" />
     <ClInclude Include="LoadableModules\LoadedModule.h" />
     <ClInclude Include="LoadableModules\LoadedModuleImpl.h" />
+    <ClInclude Include="Logging\FileRotation.h" />
     <ClInclude Include="Logging\GenericEntryFilter.h" />
     <ClInclude Include="Logging\GenericLinePacket.h" />
     <ClInclude Include="Logging\GenericLogger.h" />

--- a/MMCore/MMCore.vcxproj.filters
+++ b/MMCore/MMCore.vcxproj.filters
@@ -260,6 +260,9 @@
     <ClInclude Include="LibraryInfo\LibraryPaths.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="LogLevel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="LogManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/MMCore/MMCore.vcxproj.filters
+++ b/MMCore/MMCore.vcxproj.filters
@@ -299,6 +299,9 @@
     <ClInclude Include="Logging\Logging.h">
       <Filter>Header Files\Logging</Filter>
     </ClInclude>
+    <ClInclude Include="Logging\StderrColor.h">
+      <Filter>Header Files\Logging</Filter>
+    </ClInclude>
     <ClInclude Include="Logging\Metadata.h">
       <Filter>Header Files\Logging</Filter>
     </ClInclude>

--- a/MMCore/MMCore.vcxproj.filters
+++ b/MMCore/MMCore.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="DeviceManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Logging\FileRotation.cpp">
+      <Filter>Source Files\Logging</Filter>
+    </ClCompile>
     <ClCompile Include="Logging\Metadata.cpp">
       <Filter>Source Files\Logging</Filter>
     </ClCompile>
@@ -262,6 +265,9 @@
     </ClInclude>
     <ClInclude Include="DeviceManager.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Logging\FileRotation.h">
+      <Filter>Header Files\Logging</Filter>
     </ClInclude>
     <ClInclude Include="Logging\GenericEntryFilter.h">
       <Filter>Header Files\Logging</Filter>

--- a/MMCore/Makefile.am
+++ b/MMCore/Makefile.am
@@ -81,6 +81,8 @@ libMMCore_la_SOURCES = \
 	LoadableModules/LoadedModuleImpl.h \
 	LogManager.cpp \
 	LogManager.h \
+	Logging/FileRotation.cpp \
+	Logging/FileRotation.h \
 	Logging/GenericStreamSink.h \
 	Logging/GenericEntryFilter.h \
 	Logging/GenericLinePacket.h \

--- a/MMCore/Makefile.am
+++ b/MMCore/Makefile.am
@@ -95,6 +95,7 @@ libMMCore_la_SOURCES = \
 	Logging/GenericSink.h \
 	Logging/Logger.h \
 	Logging/Logging.h \
+	Logging/StderrColor.h \
 	Logging/Metadata.cpp \
 	Logging/Metadata.h \
 	Logging/MetadataFormatter.h \

--- a/MMCore/Makefile.am
+++ b/MMCore/Makefile.am
@@ -81,6 +81,7 @@ libMMCore_la_SOURCES = \
 	LoadableModules/LoadedModuleImpl.h \
 	LogManager.cpp \
 	LogManager.h \
+	LogLevel.h \
 	Logging/FileRotation.cpp \
 	Logging/FileRotation.h \
 	Logging/GenericStreamSink.h \

--- a/MMCore/meson.build
+++ b/MMCore/meson.build
@@ -58,6 +58,7 @@ mmcore_sources = files(
     'LoadableModules/LoadedDeviceAdapterImplRegular.cpp',
     'LoadableModules/LoadedModule.cpp',
     'LoadableModules/LoadedModuleImpl.cpp',
+    'Logging/FileRotation.cpp',
     'Logging/Metadata.cpp',
     'LogManager.cpp',
     'MMCore.cpp',

--- a/MMCore/meson.build
+++ b/MMCore/meson.build
@@ -78,6 +78,7 @@ mmcore_public_headers = files(
     'Error.h',
     'ErrorCodes.h',
     'ImageMetadata.h',
+    'LogLevel.h',
     'Logging/GenericLogger.h',
     'Logging/Logger.h',
     'Logging/Metadata.h',

--- a/MMCore/unittest/LoggingStreamSink-Tests.cpp
+++ b/MMCore/unittest/LoggingStreamSink-Tests.cpp
@@ -2,13 +2,18 @@
 
 #include "Logging/Logging.h"
 
+#include "Logging/FileRotation.h"
+
+#include <algorithm>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <random>
+#include <regex>
 #include <sstream>
 #include <streambuf>
 #include <string>
+#include <vector>
 
 namespace mmcore {
 namespace internal {
@@ -201,6 +206,190 @@ TEST_CASE("stream error recovery pattern", "[LoggingStreamSink]")
       consume("fail2");
       REQUIRE(hadError);
    }
+}
+
+
+class TempDir
+{
+   std::filesystem::path path_;
+
+public:
+   TempDir()
+   {
+      std::random_device rd;
+      auto dir = std::filesystem::temp_directory_path();
+      for (;;)
+      {
+         auto p = dir / ("mmcore-test-" + std::to_string(rd()));
+         if (!std::filesystem::exists(p))
+         {
+            std::filesystem::create_directory(p);
+            path_ = p;
+            break;
+         }
+      }
+   }
+
+   ~TempDir() { std::filesystem::remove_all(path_); }
+
+   std::string Path() const { return path_.string(); }
+
+   std::string FilePath(const std::string& name) const
+   {
+      return (path_ / name).string();
+   }
+
+   std::vector<std::string> ListFiles() const
+   {
+      std::vector<std::string> result;
+      for (const auto& entry : std::filesystem::directory_iterator(path_))
+         result.push_back(entry.path().filename().string());
+      std::sort(result.begin(), result.end());
+      return result;
+   }
+};
+
+
+TEST_CASE("MakeRotatedFilename format with extension",
+      "[LoggingStreamSink][rotation]")
+{
+   std::string rotated = MakeRotatedFilename("/tmp/CoreLog.log");
+   std::string filename = std::filesystem::path(rotated).filename().string();
+
+   // Should match CoreLog_YYYYMMDDTHHMMSS.log
+   std::regex pattern(R"(CoreLog_\d{8}T\d{6}\.log)");
+   REQUIRE(std::regex_match(filename, pattern));
+}
+
+
+TEST_CASE("MakeRotatedFilename format without extension",
+      "[LoggingStreamSink][rotation]")
+{
+   std::string rotated = MakeRotatedFilename("/tmp/CoreLog");
+   std::string filename = std::filesystem::path(rotated).filename().string();
+
+   std::regex pattern(R"(CoreLog_\d{8}T\d{6})");
+   REQUIRE(std::regex_match(filename, pattern));
+}
+
+
+TEST_CASE("rotation triggers at size threshold",
+      "[LoggingStreamSink][rotation]")
+{
+   TempDir dir;
+   std::string logPath = dir.FilePath("test.log");
+
+   auto core = std::make_shared<LoggingCore>();
+   auto sink = std::make_shared<FileLogSink>(logPath, false, 200, 0);
+   core->AddSink(sink, SinkModeSynchronous);
+
+   Logger lgr = core->NewLogger("test");
+
+   // Write enough entries to exceed 200 bytes
+   for (int i = 0; i < 20; ++i)
+      lgr(LogLevelInfo, "This is a log entry for rotation testing");
+
+   auto files = dir.ListFiles();
+
+   // Should have the current log file and at least one rotated file
+   REQUIRE(files.size() >= 2);
+
+   // Current file should still exist
+   bool hasCurrentFile = std::find(files.begin(), files.end(), "test.log")
+         != files.end();
+   REQUIRE(hasCurrentFile);
+
+   // Rotated files should match the pattern
+   std::regex pattern(R"(test_\d{8}T\d{6}\.log)");
+   int rotatedCount = 0;
+   for (const auto& f : files)
+   {
+      if (f != "test.log")
+      {
+         REQUIRE(std::regex_match(f, pattern));
+         ++rotatedCount;
+      }
+   }
+   REQUIRE(rotatedCount >= 1);
+}
+
+
+TEST_CASE("excess rotated files are deleted",
+      "[LoggingStreamSink][rotation]")
+{
+   TempDir dir;
+   std::string logPath = dir.FilePath("test.log");
+
+   // Pre-create some "old" rotated files
+   {
+      std::ofstream(dir.FilePath("test_20240101T000000.log")) << "old1";
+      std::ofstream(dir.FilePath("test_20240102T000000.log")) << "old2";
+      std::ofstream(dir.FilePath("test_20240103T000000.log")) << "old3";
+   }
+
+   auto core = std::make_shared<LoggingCore>();
+   auto sink = std::make_shared<FileLogSink>(logPath, false, 200, 2);
+   core->AddSink(sink, SinkModeSynchronous);
+
+   Logger lgr = core->NewLogger("test");
+
+   // Write enough to trigger rotation
+   for (int i = 0; i < 20; ++i)
+      lgr(LogLevelInfo, "This is a log entry for rotation testing");
+
+   auto files = dir.ListFiles();
+
+   // Count rotated files (everything except test.log)
+   int rotatedCount = 0;
+   for (const auto& f : files)
+   {
+      if (f != "test.log")
+         ++rotatedCount;
+   }
+   REQUIRE(rotatedCount <= 2);
+}
+
+
+TEST_CASE("no rotation when disabled", "[LoggingStreamSink][rotation]")
+{
+   TempDir dir;
+   std::string logPath = dir.FilePath("test.log");
+
+   auto core = std::make_shared<LoggingCore>();
+   auto sink = std::make_shared<FileLogSink>(logPath, false, 0, 0);
+   core->AddSink(sink, SinkModeSynchronous);
+
+   Logger lgr = core->NewLogger("test");
+
+   for (int i = 0; i < 20; ++i)
+      lgr(LogLevelInfo, "This is a log entry that should not trigger rotation");
+
+   auto files = dir.ListFiles();
+
+   // Should only have the one log file
+   REQUIRE(files.size() == 1);
+   REQUIRE(files[0] == "test.log");
+}
+
+
+TEST_CASE("DeleteExcessRotatedFiles removes oldest",
+      "[LoggingStreamSink][rotation]")
+{
+   TempDir dir;
+   std::string logPath = dir.FilePath("app.log");
+
+   // Create rotated files
+   std::ofstream(dir.FilePath("app_20240101T000000.log")) << "a";
+   std::ofstream(dir.FilePath("app_20240201T000000.log")) << "b";
+   std::ofstream(dir.FilePath("app_20240301T000000.log")) << "c";
+   std::ofstream(dir.FilePath("app_20240401T000000.log")) << "d";
+
+   DeleteExcessRotatedFiles(logPath, 2);
+
+   auto files = dir.ListFiles();
+   REQUIRE(files.size() == 2);
+   REQUIRE(files[0] == "app_20240301T000000.log");
+   REQUIRE(files[1] == "app_20240401T000000.log");
 }
 
 

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -925,6 +925,7 @@ namespace std {
 
 %import "CoreDeclHelpers.h"
 
+%include "LogLevel.h"
 %include "MMDeviceConstants.h"
 %include "Error.h"
 %include "Configuration.h"

--- a/MMCoreJ_wrap/meson.build
+++ b/MMCoreJ_wrap/meson.build
@@ -66,6 +66,7 @@ swig_gen_java_source_names = [
     'DeviceType.java',
     'DoubleVector.java',
     'FocusDirection.java',
+    'LogLevel.java',
     'LongVector.java',
     'Metadata.java',
     'MetadataArrayTag.java',

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.micro-manager.mmcorej</groupId>
     <artifactId>MMCoreJ</artifactId>
-    <version>12.2.2</version>
+    <version>12.3.0</version>
 
     <name>MMCore Java API</name>
     <description>Java bindings for MMCore, the device abstraction layer of Micro-Manager, the microscope control and acquisition platform.</description>


### PR DESCRIPTION
The goal here is to make MMCore's logging usable as a destination for logging from Python or SLF4J. The main motivation is for pymmcore-plus (https://github.com/pymmcore-plus/pymmcore-plus/issues/385).

This is the opposite direction to what I proposed in #498. But given that the MMCore logging is already non-blocking and (relatively) high-performance, it makes more sense to send logging to MMCore in order to get unified logging. (Sending MMCore logging to Python logging would require processing every log entry with the Python GIL held.)

APIs added here:

- `mmcore::LogLevel` enum (`Trace, Debug, Info, Warning, Error, Critical`, which is the union of SLF4J and Python logging)
- `setPrimaryLogFileRotation(long long maxFileSize, int maxBackupCount)` (disabled by default for compatibility)
- `log(const char* msg, mmcore::LogLevel level)`
- `log(const char* msg, mmcore::LogLevel level, const char* loggerName)`
- `setPrimaryLogLevel(mmcore::LogLevel level)`
- `getPrimaryLogLevel() -> mmcore::LogLevel`

Probably should be tested in Java/Python a bit before merging.