### PR TITLE
Enable digital-output shutter control without camera synchronization using the NIDAQ adapter + Fix Labels in NDIAQ adapter

### DIFF
--- a/DeviceAdapters/NIDAQ/NIDAQ.h
+++ b/DeviceAdapters/NIDAQ/NIDAQ.h
@@ -470,7 +470,6 @@ public:
 
     // Gate (shutter) interface
     int SetGateOpen(bool open);
-    int GetGateOpen(bool& open);
 
     // action interface
     // ----------------
@@ -499,7 +498,6 @@ private:
     bool sequenceRunning_;
     bool blanking_;
     bool blankOnLow_;
-    bool open_;
     long pos_;
     long numPos_;
     long highestLabeledPos_;

--- a/DeviceAdapters/NIDAQ/NIDAQ.h
+++ b/DeviceAdapters/NIDAQ/NIDAQ.h
@@ -422,7 +422,51 @@ public:
     virtual void GetName(char* name) const;
     virtual bool Busy() { return false; }
 
-    virtual unsigned long GetNumberOfPositions()const { return numPos_; } // replace with numPos_ once API allows not creating Labels
+    // For 8-bit ports, all states are enumerable. For wider ports, only
+    // enumerate positions that have been explicitly labeled (e.g. via config
+    // file). This prevents MMCore from iterating billions of states.
+    // The State property limits still allow the full value range.
+    static const long maxEnumerablePositions_ = 65536;
+    virtual unsigned long GetNumberOfPositions()const {
+       if (numPos_ <= 255)
+          return numPos_ + 1;
+       return (highestLabeledPos_ >= 0 && highestLabeledPos_ < maxEnumerablePositions_)
+          ? (unsigned long)(highestLabeledPos_ + 1) : 0;
+    }
+
+    // Return the numeric string as default when no explicit label exists.
+    // This prevents errors when the Label property is read for unlabeled states.
+    virtual int GetPositionLabel(long pos, char* label) const
+    {
+       int ret = CStateDeviceBase<DigitalOutputPort>::GetPositionLabel(pos, label);
+       if (ret != DEVICE_OK)
+       {
+          CDeviceUtils::CopyLimitedString(label, std::to_string(pos).c_str());
+          return DEVICE_OK;
+       }
+       return ret;
+    }
+
+    // Override to fill in default labels for gaps when labels are added
+    // beyond the auto-generated range (e.g. from config file on wide ports).
+    virtual int SetPositionLabel(long pos, const char* label)
+    {
+       // Fill in default labels for any positions below pos that have no label
+       if (pos > highestLabeledPos_ && pos < maxEnumerablePositions_)
+       {
+          char buf[MM::MaxStrLength];
+          for (long i = highestLabeledPos_ + 1; i < pos; i++)
+          {
+             // Only fill if no label exists yet
+             if (CStateDeviceBase<DigitalOutputPort>::GetPositionLabel(i, buf) != DEVICE_OK)
+             {
+                CStateDeviceBase<DigitalOutputPort>::SetPositionLabel(i, std::to_string(i).c_str());
+             }
+          }
+          highestLabeledPos_ = pos;
+       }
+       return CStateDeviceBase<DigitalOutputPort>::SetPositionLabel(pos, label);
+    }
 
     // Gate (shutter) interface
     int SetGateOpen(bool open);
@@ -458,6 +502,7 @@ private:
     bool open_;
     long pos_;
     long numPos_;
+    long highestLabeledPos_;
     uInt32 portWidth_;
     long inputLine_;
     long firstStateSlider_;

--- a/DeviceAdapters/NIDAQ/NIDAQ.h
+++ b/DeviceAdapters/NIDAQ/NIDAQ.h
@@ -424,6 +424,10 @@ public:
 
     virtual unsigned long GetNumberOfPositions()const { return numPos_; } // replace with numPos_ once API allows not creating Labels
 
+    // Gate (shutter) interface
+    int SetGateOpen(bool open);
+    int GetGateOpen(bool& open);
+
     // action interface
     // ----------------
     int OnState(MM::PropertyBase* pProp, MM::ActionType eAct);

--- a/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
@@ -35,6 +35,7 @@ DigitalOutputPort::DigitalOutputPort(const std::string& port) :
    open_(true),
    pos_(0),
    numPos_(0),
+   highestLabeledPos_(-1),
    portWidth_(0),
    nrOfStateSliders_(4),
    inputLine_(8),
@@ -142,12 +143,26 @@ int DigitalOutputPort::Initialize()
    }
    else
    {
-      numPos_ = (1 << portWidth_) - 1;
+      numPos_ = (portWidth_ >= 32) ? 0x7FFFFFFF : (1L << portWidth_) - 1;
    }
 
    pAct = new CPropertyAction(this, &DigitalOutputPort::OnState);
    CreateIntegerProperty("State", 0, false, pAct);
    SetPropertyLimits("State", 0, numPos_);
+
+   pAct = new CPropertyAction(this, &CStateBase::OnLabel);
+   CreateProperty(MM::g_Keyword_Label, "", MM::String, false, pAct);
+
+   // For 8-bit ports, pre-populate labels for all states.
+   // For wider ports, labels are only created when explicitly set
+   // (e.g. via config file). The SetPositionLabel override fills gaps.
+   if (numPos_ <= 255)
+   {
+      for (long i = 0; i <= numPos_; i++)
+      {
+         SetPositionLabel(i, std::to_string(i).c_str());
+      }
+   }
 
    // In case someone left some pins high:
    SetState(0);

--- a/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
@@ -211,6 +211,38 @@ void DigitalOutputPort::GetName(char* name) const
 }
 
 
+int DigitalOutputPort::SetGateOpen(bool open)
+{
+   if (open == open_)
+      return DEVICE_OK;
+
+   open_ = open;
+
+   // When a hardware-timed task (blanking/sequencing) is active,
+   // just update the flag — hardware controls the outputs.
+   if (blanking_ || sequenceRunning_)
+      return DEVICE_OK;
+
+   if (open)
+   {
+      return SetState(pos_);
+   }
+   else
+   {
+      long closedPosition;
+      GetProperty(MM::g_Keyword_Closed_Position, closedPosition);
+      return SetState(closedPosition);
+   }
+}
+
+
+int DigitalOutputPort::GetGateOpen(bool& open)
+{
+   open = open_;
+   return DEVICE_OK;
+}
+
+
 int DigitalOutputPort::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
@@ -229,9 +261,20 @@ int DigitalOutputPort::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
       if ((pos == pos_) && (open_ == gateOpen))
          return DEVICE_OK;
 
-      long closed_state;
-      GetProperty(MM::g_Keyword_Closed_Position, closed_state);
-      long newState = gateOpen ? pos : closed_state;
+      // When blanking is active, hardware controls on/off via the trigger
+      // input, so always use the requested state. Gate only applies in
+      // software-timed mode (blanking off).
+      long newState;
+      if (blanking_)
+      {
+         newState = pos;
+      }
+      else
+      {
+         long closed_state;
+         GetProperty(MM::g_Keyword_Closed_Position, closed_state);
+         newState = gateOpen ? pos : closed_state;
+      }
 
       // pause blanking, otherwise most cards will error
       int err;

--- a/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
+++ b/DeviceAdapters/NIDAQ/NIDigitalOutputPort.cpp
@@ -32,7 +32,6 @@ DigitalOutputPort::DigitalOutputPort(const std::string& port) :
    sequenceRunning_(false),
    blanking_(false),
    blankOnLow_(true),
-   open_(true),
    pos_(0),
    numPos_(0),
    highestLabeledPos_(-1),
@@ -169,7 +168,6 @@ int DigitalOutputPort::Initialize()
 
    // Gate Closed Position
    CreateProperty(MM::g_Keyword_Closed_Position, "0", MM::Integer, false);
-   GetGateOpen(open_);
 
    if (supportsBlankingAndSequencing_ && (uint32_t) nrOfStateSliders_ >= portWidth_) {
       nrOfStateSliders_ = portWidth_ - 1;
@@ -228,33 +226,18 @@ void DigitalOutputPort::GetName(char* name) const
 
 int DigitalOutputPort::SetGateOpen(bool open)
 {
-   if (open == open_)
+   // During blanking/sequencing, hardware controls the outputs via
+   // the trigger input. We cannot delegate to the base class because
+   // it calls SetPosition -> OnState, which rejects changes during
+   // sequencing. Just record the gate state for when we return to
+   // software-timed mode.
+   if (sequenceRunning_)
       return DEVICE_OK;
 
-   open_ = open;
-
-   // When a hardware-timed task (blanking/sequencing) is active,
-   // just update the flag — hardware controls the outputs.
-   if (blanking_ || sequenceRunning_)
-      return DEVICE_OK;
-
-   if (open)
-   {
-      return SetState(pos_);
-   }
-   else
-   {
-      long closedPosition;
-      GetProperty(MM::g_Keyword_Closed_Position, closedPosition);
-      return SetState(closedPosition);
-   }
-}
-
-
-int DigitalOutputPort::GetGateOpen(bool& open)
-{
-   open = open_;
-   return DEVICE_OK;
+   // Delegate to base class, which updates gateOpen_ and calls
+   // SetPosition -> OnState. OnState handles the blanking vs
+   // software-timed distinction.
+   return CStateDeviceBase<DigitalOutputPort>::SetGateOpen(open);
 }
 
 
@@ -269,12 +252,10 @@ int DigitalOutputPort::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
       if (sequenceRunning_)
          return ERR_SEQUENCE_RUNNING;
 
-      bool gateOpen;
-      GetGateOpen(gateOpen);
       long pos;
       pProp->Get(pos);
-      if ((pos == pos_) && (open_ == gateOpen))
-         return DEVICE_OK;
+      bool gateOpen;
+      GetGateOpen(gateOpen);
 
       // When blanking is active, hardware controls on/off via the trigger
       // input, so always use the requested state. Gate only applies in
@@ -306,7 +287,6 @@ int DigitalOutputPort::OnState(MM::PropertyBase* pProp, MM::ActionType eAct)
       if (err == DEVICE_OK)
       {
          pos_ = pos;
-         open_ = gateOpen;
       }
       else
       {

--- a/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
@@ -5716,11 +5716,17 @@ int Universal::abortAcquisitionInternal()
             {
                 pollingThd_->setStop(true);
                 pollingThd_->wait();
+                // Notify the core that acquisition has finished so that
+                // AutoShutter can close the shutter.
+                GetCoreCallback()->AcqFinished(this, nRet);
             }
         }
         else
         {
             acqThd_->Pause();
+            // Notify the core that acquisition has finished so that
+            // AutoShutter can close the shutter.
+            GetCoreCallback()->AcqFinished(this, nRet);
         }
 
         customDiskWriter_->Stop();

--- a/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
@@ -5716,9 +5716,7 @@ int Universal::abortAcquisitionInternal()
             {
                 pollingThd_->setStop(true);
                 pollingThd_->wait();
-                // Notify the core that acquisition has finished so that
-                // AutoShutter can close the shutter.
-                GetCoreCallback()->AcqFinished(this, nRet);
+                // AcqFinished() is already called by PollingThreadExiting()
             }
         }
         else


### PR DESCRIPTION
There are situations in which a triggerable light source must be used without a camera synchronization signal, for example, when the camera does not provide a sync output, in legacy setups, or when synchronization becomes impractical due to additional hardware such as a DMD. In these cases, hardware blanking must be disabled and the light source controlled directly via a digital output (you may ask why in this case go over hardware TTL control instead of software on / off control => hardware control is much faster and much more reliable, especially for old Lumencor Spectra's)

Previously, the NIDAQ adapter did not function correctly when hardware blanking was set to off. Opening or closing the shutter failed to drive the digital output back to 0 because the internal logic implicitly relied on blanking. With these two commits, hardware blanking can now be disabled explicitly, and the configured digital output port is used to directly enable or disable the light source. When live mode is exited, the output is reliably reset to 0, ensuring that the light source is switched off.

To support this behavior, the DigitalOutputPort class was extended with explicit gate (shutter) control. New SetGateOpen and GetGateOpen methods manage the internal gate state and apply it to the hardware as appropriate. The OnState logic was refined to distinguish between hardware-timed (blanking) and software-timed operation, ensuring that gate state changes are only applied in software-timed mode and do not interfere with hardware blanking.

During testing, this workflow behaved correctly with an Andor Zyla camera, which properly manages shutter control, but not with Teledyne PVCAM-based cameras. To address this discrepancy, the PVCAM adapter was updated to allow explicitly switching off the light source. In addition, abortAcquisitionInternal in PVCAMUniversal.cpp now notifies the core system when an acquisition finishes, allowing the AutoShutter to close the shutter automatically and restoring consistent shutdown behavior across camera backends.

Edit: Latest commit adds labels of NIDAQ devices to property browser (you can set-up labels during the hardware setup, but they weren't shown in the property browser during runtime) => fixed. 