### PR TITLE
MMCore: simplify notificationQueueMutex_

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -7769,7 +7769,7 @@ void CMMCore::registerCallback(MMEventCallback* cb) MMCORE_LEGACY_THROW(CMMError
    if (cb) {
       if (!notificationQueue_) {
          auto queue = std::make_shared<mmi::NotificationQueue>();
-         std::unique_lock<std::shared_mutex> lock(notificationQueueMutex_);
+         std::lock_guard<std::mutex> lock(notificationQueueMutex_);
          notificationQueue_ = queue;
       }
 
@@ -7786,7 +7786,7 @@ void CMMCore::registerCallback(MMEventCallback* cb) MMCORE_LEGACY_THROW(CMMError
          }
       });
    } else {
-      std::unique_lock<std::shared_mutex> lock(notificationQueueMutex_);
+      std::lock_guard<std::mutex> lock(notificationQueueMutex_);
       notificationQueue_.reset();
    }
 }
@@ -7794,9 +7794,13 @@ void CMMCore::registerCallback(MMEventCallback* cb) MMCORE_LEGACY_THROW(CMMError
 
 void CMMCore::postNotification(mmi::Notification notification)
 {
-   std::shared_lock<std::shared_mutex> lock(notificationQueueMutex_);
-   if (notificationQueue_)
-      notificationQueue_->Push(std::move(notification));
+   std::shared_ptr<mmi::NotificationQueue> q;
+   {
+      std::lock_guard<std::mutex> lock(notificationQueueMutex_);
+      q = notificationQueue_;
+   }
+   if (q)
+      q->Push(std::move(notification));
 }
 
 

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -62,7 +62,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -738,7 +737,7 @@ private:
    bool isLoadingSystemConfiguration_ = false;
 
    std::mutex callbackMutex_; // Serializes registerCallback() calls
-   std::shared_mutex notificationQueueMutex_; // Protects notificationQueue_
+   std::mutex notificationQueueMutex_; // Protects notificationQueue_
    std::shared_ptr<mmcore::internal::NotificationQueue>
       notificationQueue_;
    std::thread notificationDeliveryThread_;


### PR DESCRIPTION
Minor cleanup/simplification.

- Switch from std::shared_mutex to plain std::mutex, because this uncontended and briefly held mutex is unlikely to benefit from a read-write lock (if anything, shared_mutex may have more overhead)

- In postNotification(), only hold notificationQueueMutex_ while making a copy of the shared_ptr to the queue, and perform the push outside it. This is safe because:
  - If the queue doesn't exist, no behavior change (no push)
  - If the queue exists and a callback swap is happening concurrently, the queue is not swapped so no notifications are lost
  - If the queue exists and a callback unregister is happening concurrently, we have a slight increase in concurrency but no behavioral change because the queue is dropped after joining the delivery thread; the concurrently posted notifications are dropped in either case and this is not a problem