### PR TITLE
MMCore: separate level setting for stderr and primary log file

### DIFF
--- a/MMCore/LogManager.cpp
+++ b/MMCore/LogManager.cpp
@@ -36,6 +36,7 @@ LogManager::LogManager() :
    loggingCore_(std::make_shared<logging::LoggingCore>()),
    internalLogger_(loggingCore_->NewLogger("LogManager")),
    primaryLogLevel_(LogLevelInfo),
+   stderrLogLevel_(LogLevelInfo),
    usingStdErr_(false),
    primaryMaxFileSize_(0),
    primaryMaxBackupFiles_(0),
@@ -55,11 +56,9 @@ LogManager::SetUseStdErr(bool flag)
    if (flag)
    {
       if (!stdErrSink_)
-      {
          stdErrSink_ = std::make_shared<logging::StdErrLogSink>();
-         stdErrSink_->SetFilter(
-               std::make_shared<logging::LevelFilter>(primaryLogLevel_));
-      }
+      stdErrSink_->SetFilter(
+            std::make_shared<logging::LevelFilter>(stderrLogLevel_));
       loggingCore_->AddSink(stdErrSink_, PrimarySinkMode);
 
       LOG_INFO(internalLogger_) << "Enabled logging to stderr";
@@ -218,34 +217,28 @@ LogManager::SetPrimaryLogLevel(LogLevel level)
    LogLevel oldLevel = primaryLogLevel_;
    primaryLogLevel_ = level;
 
-   LOG_INFO(internalLogger_) << "Switching primary log level from " <<
+   LOG_INFO(internalLogger_) << "Switching primary log file level from " <<
       StringForLogLevel(oldLevel) << " to " << StringForLogLevel(level);
 
-   std::shared_ptr<logging::EntryFilter> filter =
-      std::make_shared<logging::LevelFilter>(level);
-
-   std::vector<
-      std::pair<
-         std::pair<std::shared_ptr<logging::LogSink>, logging::SinkMode>,
-         std::shared_ptr<logging::EntryFilter>
-      >
-   > changes;
-   if (stdErrSink_)
-   {
-      changes.push_back(
-            std::make_pair(std::make_pair(stdErrSink_, PrimarySinkMode),
-               filter));
-   }
    if (primaryFileSink_)
    {
+      std::shared_ptr<logging::EntryFilter> filter =
+         std::make_shared<logging::LevelFilter>(level);
+
+      std::vector<
+         std::pair<
+            std::pair<std::shared_ptr<logging::LogSink>, logging::SinkMode>,
+            std::shared_ptr<logging::EntryFilter>
+         >
+      > changes;
       changes.push_back(
             std::make_pair(std::make_pair(primaryFileSink_, PrimarySinkMode),
                filter));
+
+      loggingCore_->AtomicSetSinkFilters(changes.begin(), changes.end());
    }
 
-   loggingCore_->AtomicSetSinkFilters(changes.begin(), changes.end());
-
-   LOG_INFO(internalLogger_) << "Switched primary log level from " <<
+   LOG_INFO(internalLogger_) << "Switched primary log file level from " <<
       StringForLogLevel(oldLevel) << " to " << StringForLogLevel(level);
 }
 
@@ -255,6 +248,51 @@ LogManager::GetPrimaryLogLevel() const
 {
    std::lock_guard<std::mutex> lock(mutex_);
    return primaryLogLevel_;
+}
+
+
+void
+LogManager::SetStderrLogLevel(LogLevel level)
+{
+   std::lock_guard<std::mutex> lock(mutex_);
+
+   if (level == stderrLogLevel_)
+      return;
+
+   LogLevel oldLevel = stderrLogLevel_;
+   stderrLogLevel_ = level;
+
+   LOG_INFO(internalLogger_) << "Switching stderr log level from " <<
+      StringForLogLevel(oldLevel) << " to " << StringForLogLevel(level);
+
+   if (stdErrSink_ && usingStdErr_)
+   {
+      std::shared_ptr<logging::EntryFilter> filter =
+         std::make_shared<logging::LevelFilter>(level);
+
+      std::vector<
+         std::pair<
+            std::pair<std::shared_ptr<logging::LogSink>, logging::SinkMode>,
+            std::shared_ptr<logging::EntryFilter>
+         >
+      > changes;
+      changes.push_back(
+            std::make_pair(std::make_pair(stdErrSink_, PrimarySinkMode),
+               filter));
+
+      loggingCore_->AtomicSetSinkFilters(changes.begin(), changes.end());
+   }
+
+   LOG_INFO(internalLogger_) << "Switched stderr log level from " <<
+      StringForLogLevel(oldLevel) << " to " << StringForLogLevel(level);
+}
+
+
+LogLevel
+LogManager::GetStderrLogLevel() const
+{
+   std::lock_guard<std::mutex> lock(mutex_);
+   return stderrLogLevel_;
 }
 
 

--- a/MMCore/LogManager.cpp
+++ b/MMCore/LogManager.cpp
@@ -207,39 +207,65 @@ LogManager::SetPrimaryLogRotation(std::size_t maxFileSize, int maxBackupFiles)
 
 
 void
-LogManager::SetPrimaryLogLevel(LogLevel level)
+LogManager::SetLogLevels(LogLevel level, bool setPrimary, bool setStderr)
 {
    std::lock_guard<std::mutex> lock(mutex_);
 
-   if (level == primaryLogLevel_)
+   bool primaryChanged = setPrimary && level != primaryLogLevel_;
+   bool stderrChanged = setStderr && level != stderrLogLevel_;
+   if (!primaryChanged && !stderrChanged)
       return;
 
-   LogLevel oldLevel = primaryLogLevel_;
-   primaryLogLevel_ = level;
-
-   LOG_INFO(internalLogger_) << "Switching primary log file level from " <<
-      StringForLogLevel(oldLevel) << " to " << StringForLogLevel(level);
-
-   if (primaryFileSink_)
+   if (primaryChanged)
    {
-      std::shared_ptr<logging::EntryFilter> filter =
-         std::make_shared<logging::LevelFilter>(level);
+      LOG_INFO(internalLogger_) << "Switching primary log file level from " <<
+         StringForLogLevel(primaryLogLevel_) << " to " <<
+         StringForLogLevel(level);
+      primaryLogLevel_ = level;
+   }
+   if (stderrChanged)
+   {
+      LOG_INFO(internalLogger_) << "Switching stderr log level from " <<
+         StringForLogLevel(stderrLogLevel_) << " to " <<
+         StringForLogLevel(level);
+      stderrLogLevel_ = level;
+   }
 
-      std::vector<
-         std::pair<
-            std::pair<std::shared_ptr<logging::LogSink>, logging::SinkMode>,
-            std::shared_ptr<logging::EntryFilter>
-         >
-      > changes;
+   std::shared_ptr<logging::EntryFilter> filter =
+      std::make_shared<logging::LevelFilter>(level);
+
+   std::vector<
+      std::pair<
+         std::pair<std::shared_ptr<logging::LogSink>, logging::SinkMode>,
+         std::shared_ptr<logging::EntryFilter>
+      >
+   > changes;
+   if (primaryChanged && primaryFileSink_)
+   {
       changes.push_back(
             std::make_pair(std::make_pair(primaryFileSink_, PrimarySinkMode),
                filter));
-
-      loggingCore_->AtomicSetSinkFilters(changes.begin(), changes.end());
+   }
+   if (stderrChanged && stdErrSink_ && usingStdErr_)
+   {
+      changes.push_back(
+            std::make_pair(std::make_pair(stdErrSink_, PrimarySinkMode),
+               filter));
    }
 
-   LOG_INFO(internalLogger_) << "Switched primary log file level from " <<
-      StringForLogLevel(oldLevel) << " to " << StringForLogLevel(level);
+   if (!changes.empty())
+      loggingCore_->AtomicSetSinkFilters(changes.begin(), changes.end());
+
+   if (primaryChanged)
+   {
+      LOG_INFO(internalLogger_) << "Switched primary log file level to " <<
+         StringForLogLevel(level);
+   }
+   if (stderrChanged)
+   {
+      LOG_INFO(internalLogger_) << "Switched stderr log level to " <<
+         StringForLogLevel(level);
+   }
 }
 
 
@@ -248,43 +274,6 @@ LogManager::GetPrimaryLogLevel() const
 {
    std::lock_guard<std::mutex> lock(mutex_);
    return primaryLogLevel_;
-}
-
-
-void
-LogManager::SetStderrLogLevel(LogLevel level)
-{
-   std::lock_guard<std::mutex> lock(mutex_);
-
-   if (level == stderrLogLevel_)
-      return;
-
-   LogLevel oldLevel = stderrLogLevel_;
-   stderrLogLevel_ = level;
-
-   LOG_INFO(internalLogger_) << "Switching stderr log level from " <<
-      StringForLogLevel(oldLevel) << " to " << StringForLogLevel(level);
-
-   if (stdErrSink_ && usingStdErr_)
-   {
-      std::shared_ptr<logging::EntryFilter> filter =
-         std::make_shared<logging::LevelFilter>(level);
-
-      std::vector<
-         std::pair<
-            std::pair<std::shared_ptr<logging::LogSink>, logging::SinkMode>,
-            std::shared_ptr<logging::EntryFilter>
-         >
-      > changes;
-      changes.push_back(
-            std::make_pair(std::make_pair(stdErrSink_, PrimarySinkMode),
-               filter));
-
-      loggingCore_->AtomicSetSinkFilters(changes.begin(), changes.end());
-   }
-
-   LOG_INFO(internalLogger_) << "Switched stderr log level from " <<
-      StringForLogLevel(oldLevel) << " to " << StringForLogLevel(level);
 }
 
 

--- a/MMCore/LogManager.h
+++ b/MMCore/LogManager.h
@@ -65,10 +65,8 @@ public:
 
    void SetPrimaryLogRotation(std::size_t maxFileSize, int maxBackupFiles);
 
-   void SetPrimaryLogLevel(LogLevel level);
+   void SetLogLevels(LogLevel level, bool setPrimary, bool setStderr);
    LogLevel GetPrimaryLogLevel() const;
-
-   void SetStderrLogLevel(LogLevel level);
    LogLevel GetStderrLogLevel() const;
 
    LogFileHandle AddSecondaryLogFile(LogLevel level,

--- a/MMCore/LogManager.h
+++ b/MMCore/LogManager.h
@@ -24,6 +24,7 @@ private:
    mutable std::mutex mutex_;
 
    LogLevel primaryLogLevel_;
+   LogLevel stderrLogLevel_;
 
    bool usingStdErr_;
    std::shared_ptr<logging::LogSink> stdErrSink_;
@@ -66,6 +67,9 @@ public:
 
    void SetPrimaryLogLevel(LogLevel level);
    LogLevel GetPrimaryLogLevel() const;
+
+   void SetStderrLogLevel(LogLevel level);
+   LogLevel GetStderrLogLevel() const;
 
    LogFileHandle AddSecondaryLogFile(LogLevel level,
          const std::string& filename, bool truncate = true,

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -108,7 +108,7 @@ namespace notif = mmcore::internal::notification;
  * (Keep the 3 numbers on one line to make it easier to look at diffs when
  * merging/rebasing.)
  */
-const int MMCore_versionMajor = 12, MMCore_versionMinor = 3, MMCore_versionPatch = 0;
+const int MMCore_versionMajor = 12, MMCore_versionMinor = 4, MMCore_versionPatch = 0;
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -307,10 +307,12 @@ void CMMCore::log(const char* msg, mmcore::LogLevel level,
 
 
 /**
- * Set the primary log level.
+ * Set the log level for the primary log file.
  *
- * Messages below this level will not be recorded in the primary log file or
- * stderr output.
+ * Messages below this level will not be recorded in the primary log file.
+ * 
+ * It is not recommended to mix use of this function with enableDebugLog() and
+ * debugLogEnabled().
  */
 void CMMCore::setPrimaryLogLevel(mmcore::LogLevel level)
 {
@@ -319,7 +321,7 @@ void CMMCore::setPrimaryLogLevel(mmcore::LogLevel level)
 
 
 /**
- * Return the current primary log level.
+ * Return the current primary log file level.
  */
 mmcore::LogLevel CMMCore::getPrimaryLogLevel()
 {
@@ -329,20 +331,33 @@ mmcore::LogLevel CMMCore::getPrimaryLogLevel()
 
 /**
  * Enable or disable logging of debug messages.
- * @param enable   if set to true, debug messages will be recorded in the log file
+ *
+ * When enabled, sets both the primary log file level and the stderr log level
+ * to trace. When disabled, sets both to info.
+ * 
+ * It is not recommended to mix use of this function with setPrimaryLogLevel()
+ * and setStderrLogLevel().
+ *
+ * @param enable   if set to true, debug messages will be recorded
  */
 void CMMCore::enableDebugLog(bool enable)
 {
-   logManager_->SetPrimaryLogLevel(enable ? mmcore::LogLevelTrace :
-         mmcore::LogLevelInfo);
+   mmcore::LogLevel level = enable ? mmcore::LogLevelTrace :
+         mmcore::LogLevelInfo;
+   logManager_->SetPrimaryLogLevel(level);
+   logManager_->SetStderrLogLevel(level);
 }
 
 /**
- * Indicates if logging of debug messages is enabled
+ * Indicates if logging of debug messages is enabled.
+ *
+ * Returns true if both the primary log file and stderr log levels are at
+ * debug level or below.
  */
 bool CMMCore::debugLogEnabled()
 {
-   return (logManager_->GetPrimaryLogLevel() < mmcore::LogLevelInfo);
+   return (logManager_->GetPrimaryLogLevel() < mmcore::LogLevelInfo) &&
+          (logManager_->GetStderrLogLevel() < mmcore::LogLevelInfo);
 }
 
 /**
@@ -360,6 +375,28 @@ void CMMCore::enableStderrLog(bool enable)
 bool CMMCore::stderrLogEnabled()
 {
    return logManager_->IsUsingStdErr();
+}
+
+/**
+ * Set the stderr log level.
+ *
+ * Messages below this level will not be displayed on stderr.
+ * 
+ * It is not recommended to mix use of this function with enableDebugLog() and
+ * debugLogEnabled().
+ */
+void CMMCore::setStderrLogLevel(mmcore::LogLevel level)
+{
+   logManager_->SetStderrLogLevel(level);
+}
+
+
+/**
+ * Return the current stderr log level.
+ */
+mmcore::LogLevel CMMCore::getStderrLogLevel()
+{
+   return logManager_->GetStderrLogLevel();
 }
 
 

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -316,7 +316,7 @@ void CMMCore::log(const char* msg, mmcore::LogLevel level,
  */
 void CMMCore::setPrimaryLogLevel(mmcore::LogLevel level)
 {
-   logManager_->SetPrimaryLogLevel(level);
+   logManager_->SetLogLevels(level, true, false);
 }
 
 
@@ -334,7 +334,7 @@ mmcore::LogLevel CMMCore::getPrimaryLogLevel()
  *
  * When enabled, sets both the primary log file level and the stderr log level
  * to trace. When disabled, sets both to info.
- * 
+ *
  * It is not recommended to mix use of this function with setPrimaryLogLevel()
  * and setStderrLogLevel().
  *
@@ -342,10 +342,8 @@ mmcore::LogLevel CMMCore::getPrimaryLogLevel()
  */
 void CMMCore::enableDebugLog(bool enable)
 {
-   mmcore::LogLevel level = enable ? mmcore::LogLevelTrace :
-         mmcore::LogLevelInfo;
-   logManager_->SetPrimaryLogLevel(level);
-   logManager_->SetStderrLogLevel(level);
+   logManager_->SetLogLevels(enable ? mmcore::LogLevelTrace :
+         mmcore::LogLevelInfo, true, true);
 }
 
 /**
@@ -387,7 +385,7 @@ bool CMMCore::stderrLogEnabled()
  */
 void CMMCore::setStderrLogLevel(mmcore::LogLevel level)
 {
-   logManager_->SetStderrLogLevel(level);
+   logManager_->SetLogLevels(level, false, true);
 }
 
 

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -200,6 +200,8 @@ public:
    bool debugLogEnabled();
    void enableStderrLog(bool enable);
    bool stderrLogEnabled();
+   void setStderrLogLevel(mmcore::LogLevel level);
+   mmcore::LogLevel getStderrLogLevel();
 
    int startSecondaryLogFile(const char* filename, bool enableDebug,
          bool truncate = true, bool synchronous = false) MMCORE_LEGACY_THROW(CMMError);

--- a/MMCore/unittest/LogManager-Tests.cpp
+++ b/MMCore/unittest/LogManager-Tests.cpp
@@ -1,0 +1,128 @@
+#include <catch2/catch_all.hpp>
+
+#include "LogManager.h"
+
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <string>
+
+namespace mmcore {
+namespace internal {
+
+static std::string ReadFileContents(const std::string& path)
+{
+   std::ifstream in(path);
+   return std::string(std::istreambuf_iterator<char>(in),
+                      std::istreambuf_iterator<char>());
+}
+
+
+class TempFile
+{
+   std::string path_;
+
+public:
+   TempFile()
+   {
+      std::random_device rd;
+      auto dir = std::filesystem::temp_directory_path();
+      for (;;)
+      {
+         auto p = dir / ("mmcore-test-" + std::to_string(rd()));
+         if (!std::filesystem::exists(p))
+         {
+            path_ = p.string();
+            std::ofstream ofs(path_);
+            break;
+         }
+      }
+   }
+
+   ~TempFile() { std::filesystem::remove(path_); }
+
+   const std::string& Path() const { return path_; }
+};
+
+
+TEST_CASE("SetLogLevels independence", "[LogManager]")
+{
+   SECTION("setting primary does not affect stderr")
+   {
+      LogManager mgr;
+      mgr.SetLogLevels(LogLevelWarning, true, false);
+      REQUIRE(mgr.GetPrimaryLogLevel() == LogLevelWarning);
+      REQUIRE(mgr.GetStderrLogLevel() == LogLevelInfo);
+   }
+
+   SECTION("setting stderr does not affect primary")
+   {
+      LogManager mgr;
+      mgr.SetLogLevels(LogLevelError, false, true);
+      REQUIRE(mgr.GetStderrLogLevel() == LogLevelError);
+      REQUIRE(mgr.GetPrimaryLogLevel() == LogLevelInfo);
+   }
+
+   SECTION("setting both updates both")
+   {
+      LogManager mgr;
+      mgr.SetLogLevels(LogLevelTrace, true, true);
+      REQUIRE(mgr.GetPrimaryLogLevel() == LogLevelTrace);
+      REQUIRE(mgr.GetStderrLogLevel() == LogLevelTrace);
+   }
+}
+
+
+TEST_CASE("level filtering on primary log file", "[LogManager]")
+{
+   TempFile tmp;
+   std::string contents;
+
+   {
+      LogManager mgr;
+      mgr.SetPrimaryLogFilename(tmp.Path(), true);
+      mgr.SetLogLevels(LogLevelWarning, true, false);
+
+      logging::Logger lgr = mgr.NewLogger("test");
+      lgr(LogLevelTrace, "msg-trace");
+      lgr(LogLevelDebug, "msg-debug");
+      lgr(LogLevelInfo, "msg-info");
+      lgr(LogLevelWarning, "msg-warning");
+      lgr(LogLevelError, "msg-error");
+      lgr(LogLevelCritical, "msg-critical");
+   }
+
+   contents = ReadFileContents(tmp.Path());
+
+   REQUIRE(contents.find("msg-trace") == std::string::npos);
+   REQUIRE(contents.find("msg-debug") == std::string::npos);
+   REQUIRE(contents.find("msg-info") == std::string::npos);
+   REQUIRE(contents.find("msg-warning") != std::string::npos);
+   REQUIRE(contents.find("msg-error") != std::string::npos);
+   REQUIRE(contents.find("msg-critical") != std::string::npos);
+}
+
+
+TEST_CASE("stderr level persists across disable/enable", "[LogManager]")
+{
+   SECTION("level set while enabled persists through disable/enable")
+   {
+      LogManager mgr;
+      mgr.SetUseStdErr(true);
+      mgr.SetLogLevels(LogLevelError, false, true);
+      mgr.SetUseStdErr(false);
+      mgr.SetUseStdErr(true);
+      REQUIRE(mgr.GetStderrLogLevel() == LogLevelError);
+   }
+
+   SECTION("level set while disabled takes effect on enable")
+   {
+      LogManager mgr;
+      mgr.SetLogLevels(LogLevelError, false, true);
+      mgr.SetUseStdErr(true);
+      REQUIRE(mgr.GetStderrLogLevel() == LogLevelError);
+   }
+}
+
+} // namespace internal
+} // namespace mmcore

--- a/MMCore/unittest/meson.build
+++ b/MMCore/unittest/meson.build
@@ -17,6 +17,7 @@ mmcore_test_sources = files(
     'EventCallback-Tests.cpp',
     'ImageMetadata-Tests.cpp',
     'ImageMetadataTags-Tests.cpp',
+    'LogManager-Tests.cpp',
     'Logger-Tests.cpp',
     'LoggingSplitEntryIntoLines-Tests.cpp',
     'LoggingStreamSink-Tests.cpp',

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.micro-manager.mmcorej</groupId>
     <artifactId>MMCoreJ</artifactId>
-    <version>12.3.0</version>
+    <version>12.4.0</version>
 
     <name>MMCore Java API</name>
     <description>Java bindings for MMCore, the device abstraction layer of Micro-Manager, the microscope control and acquisition platform.</description>


### PR DESCRIPTION
This is a follow-up to #906.

Instead of stderr using the same log level as `setPrimaryLogLevel()` (#906), use a separate settings. This gives full control of the log level for every log sink (primary, secondaries, stderr) via the `CMMCore` API.

Existing code using `enableDebugLog()` is unaffected and the level switches for stderr and the primary file together atomically (as it always has).

Changes behavior of `setPrimaryLogLevel()` (just added in #906) but only bumping minor version because I consider it a bug fix (stderr should not be affected by "primary" log level).