### PR TITLE
add ImageAddedToBuffer notification

### DIFF
--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -243,9 +243,15 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
             ip->Process(const_cast<unsigned char*>(buf), width, height, bytesPerPixel);
          }
       if (core_->cbuf_->InsertImage(buf, width, height, bytesPerPixel, nComponents, &md))
-         return DEVICE_OK;
+      {
+        std::string label;
+        if(md.HasTag(MM::g_Keyword_Metadata_CameraLabel))
+            label = md.GetSingleTag(MM::g_Keyword_Metadata_CameraLabel).GetValue();
+        core_->postNotification(notif::ImageAddedToBuffer{label});
+        return DEVICE_OK;
+      }
       else
-         return DEVICE_BUFFER_OVERFLOW;
+        return DEVICE_BUFFER_OVERFLOW;
    }
    catch (CMMError& /*e*/)
    {

--- a/MMCore/MMEventCallback.h
+++ b/MMCore/MMEventCallback.h
@@ -112,4 +112,9 @@ public:
       std::cout << "onSequenceAcquisitionStopped() " << cameraLabel << '\n';
    }
 
+   virtual void onImageAddedToBuffer(const char* cameraLabel)
+   {
+      std::cout << "onImageAddedToBuffer() " << cameraLabel << '\n';
+   }
+
 };

--- a/MMCore/Notification.h
+++ b/MMCore/Notification.h
@@ -65,6 +65,9 @@ struct SystemConfigurationLoaded {};
 struct ChannelGroupChanged {
    std::string channelGroupName;
 };
+struct ImageAddedToBuffer {
+   std::string cameraLabel;
+};
 
 } // namespace notification
 
@@ -83,7 +86,8 @@ using Notification = std::variant<
    notification::SequenceAcquisitionStarted,
    notification::SequenceAcquisitionStopped,
    notification::SystemConfigurationLoaded,
-   notification::ChannelGroupChanged
+   notification::ChannelGroupChanged,
+   notification::ImageAddedToBuffer
 >;
 
 namespace detail {
@@ -142,6 +146,9 @@ inline void DispatchNotification(const Notification& notification,
       },
       [&](const notification::ChannelGroupChanged& n) {
          cb.onChannelGroupChanged(n.channelGroupName.c_str());
+      },
+      [&](const notification::ImageAddedToBuffer& n) {
+         cb.onImageAddedToBuffer(n.cameraLabel.c_str());
       },
    }, notification);
 }

--- a/MMCore/unittest/Notification-Tests.cpp
+++ b/MMCore/unittest/Notification-Tests.cpp
@@ -2,8 +2,10 @@
 
 #include "MMCore.h"
 #include "MMEventCallback.h"
+#include "MockDeviceUtils.h"
 #include "Notification.h"
 #include "NotificationQueue.h"
+#include "StubDevices.h"
 
 #include <atomic>
 #include <chrono>
@@ -201,6 +203,10 @@ public:
       calls.push_back(
          {"onChannelGroupChanged", {newChannelGroupName}, {}, false});
    }
+   void onImageAddedToBuffer(const char* cameraLabel) override {
+      calls.push_back(
+         {"onImageAddedToBuffer", {cameraLabel}, {}, false});
+   }
 };
 
 TEST_CASE("Dispatch PropertiesChanged", "[Notification][Dispatch]")
@@ -351,6 +357,14 @@ TEST_CASE("Dispatch ChannelGroupChanged", "[Notification][Dispatch]")
    REQUIRE(cb.calls.size() == 1);
    CHECK(cb.calls[0].method == "onChannelGroupChanged");
    CHECK(cb.calls[0].stringArgs[0] == "DAPI");
+}
+TEST_CASE("Dispatch ImageAddedToBuffer", "[Notification][Dispatch]")
+{
+   RecordingCallback cb;
+   mmi::DispatchNotification(notif::ImageAddedToBuffer{"Camera"}, cb);
+   REQUIRE(cb.calls.size() == 1);
+   CHECK(cb.calls[0].method == "onImageAddedToBuffer");
+   CHECK(cb.calls[0].stringArgs[0] == "Camera");
 }
 
 // --- Integration: registerCallback + postNotification ---

--- a/MMCore/unittest/SequenceAcquisition-Tests.cpp
+++ b/MMCore/unittest/SequenceAcquisition-Tests.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
+#include <set>
 #include <thread>
 #include <vector>
 
@@ -259,6 +260,41 @@ public:
       std::unique_lock<std::mutex> lock(mutex);
       return cv.wait_for(lock, timeout,
          [this] { return _receivedCalls == _expectedCalls; });
+   }
+};
+
+
+// A callback that pops images from the circular buffer as each image arrives.
+// Declare instances of this class BEFORE the CMMCore instance in tests so that
+// the callback object outlives core. The notification delivery thread holds a
+// raw pointer to this callback; it must be joined (via registerCallback(nullptr)
+// or CMMCore's destructor) before this object is destroyed.
+class RotatingBufferCallback : public MMEventCallback {
+public:
+   CMMCore* core_ = nullptr;
+   std::mutex mutex_;
+   std::condition_variable cv_;
+   std::vector<void*> images_;
+
+   void onImageAddedToBuffer(const char*) override {
+      if (!core_) return;
+      void* buf = nullptr;
+      try {
+         buf = core_->popNextImage();
+      } catch (const CMMError&) {
+         return; // Buffer empty due to race (e.g. overwrite cleared it)
+      }
+      {
+         std::lock_guard<std::mutex> lock(mutex_);
+         images_.push_back(buf);
+      }
+      cv_.notify_one();
+   }
+
+   bool waitForImages(size_t count, std::chrono::milliseconds timeout) {
+      std::unique_lock<std::mutex> lock(mutex_);
+      return cv_.wait_for(lock, timeout,
+         [this, count] { return images_.size() >= count; });
    }
 };
 
@@ -623,4 +659,39 @@ TEST_CASE("ImageAddedToBuffer fires notification during continuous sequence acqu
 
    core.stopSequenceAcquisition();
    core.registerCallback(nullptr);
+}
+
+TEST_CASE("Images popped from onImageAddedToBuffer callback are unique and valid",
+   "[SequenceAcquisition][Notification][Integration]")
+{
+   // cb must be declared BEFORE core: C++ destroys locals in reverse order,
+   // so core is destroyed first. core's destructor joins the notification
+   // delivery thread (which holds a raw pointer to cb), ensuring cb is still
+   // alive when the thread exits. Setting core_ separately avoids requiring
+   // core to exist at cb's construction site.
+   RotatingBufferCallback cb;
+   AsyncCamera cam;
+   MockAdapterWithDevices adapter{{"cam", &cam}};
+   CMMCore core;
+   adapter.LoadIntoCore(core);
+   core.setCameraDevice("cam");
+
+   cb.core_ = &core;
+   core.registerCallback(&cb);
+
+   const long numImages = 5;
+   core.startSequenceAcquisition(numImages, 0.0, true);
+
+   CHECK(cb.waitForImages(numImages, std::chrono::seconds(5)));
+
+   core.stopSequenceAcquisition();
+   // Explicitly join the delivery thread now so that cb.images_ is stable
+   // for the checks below. (core's destructor will call this again; it is
+   // a no-op the second time.)
+   core.registerCallback(nullptr);
+
+   CHECK(static_cast<long>(cb.images_.size()) == numImages);
+   std::set<void*> unique(cb.images_.begin(), cb.images_.end());
+   CHECK(unique.size() == cb.images_.size());
+   CHECK(unique.count(nullptr) == 0);
 }

--- a/MMCore/unittest/SequenceAcquisition-Tests.cpp
+++ b/MMCore/unittest/SequenceAcquisition-Tests.cpp
@@ -237,6 +237,31 @@ private:
    std::vector<unsigned char> imgBuf_;
 };
 
+class ImageAddedCallback : public MMEventCallback {
+public:
+   std::mutex mutex;
+   std::condition_variable cv;
+   int _receivedCalls = 0;
+   int _expectedCalls = 0;
+
+   ImageAddedCallback(int expectedCalls) {
+        
+        _expectedCalls = expectedCalls;
+   }
+
+   void onImageAddedToBuffer(const char*) override {
+      std::lock_guard<std::mutex> lock(mutex);
+      _receivedCalls++;
+      cv.notify_one();
+   }
+
+   bool waitForImageAdded(std::chrono::milliseconds timeout) {
+      std::unique_lock<std::mutex> lock(mutex);
+      return cv.wait_for(lock, timeout,
+         [this] { return _receivedCalls == _expectedCalls; });
+   }
+};
+
 // --- Lifecycle error handling ---
 
 TEST_CASE("startSequenceAcquisition throws when no camera set",
@@ -558,4 +583,44 @@ TEST_CASE("stopSequenceAcquisition on finite acquisition stops it early",
    c.stopSequenceAcquisition();
    CHECK(c.isSequenceRunning() == false);
    CHECK(c.getRemainingImageCount() < 1000000);
+}
+
+TEST_CASE("ImageAddedToBuffer fires notification during sequence acquisition",
+   "[Notification][Integration]")
+{
+   ImageAddedCallback cb(5);
+   AsyncCamera cam;
+   MockAdapterWithDevices adapter{{"Camera", &cam}};
+   CMMCore core;
+
+   adapter.LoadIntoCore(core);
+   core.setCameraDevice("Camera");
+   core.registerCallback(&cb);
+
+   core.startSequenceAcquisition("Camera", 5, 100, false);
+
+   CHECK(cb.waitForImageAdded(std::chrono::milliseconds(600)));
+
+   core.stopSequenceAcquisition();
+   core.registerCallback(nullptr);
+}
+
+TEST_CASE("ImageAddedToBuffer fires notification during continuous sequence acquisition",
+   "[Notification][Integration]")
+{
+   ImageAddedCallback cb(5);
+   AsyncCamera cam;
+   MockAdapterWithDevices adapter{{"Camera", &cam}};
+   CMMCore core;
+
+   adapter.LoadIntoCore(core);
+   core.setCameraDevice("Camera");
+   core.registerCallback(&cb);
+
+   core.startContinuousSequenceAcquisition(100);
+
+   CHECK(cb.waitForImageAdded(std::chrono::milliseconds(550)));
+
+   core.stopSequenceAcquisition();
+   core.registerCallback(nullptr);
 }


### PR DESCRIPTION
I originally asked [this question](https://github.com/pymmcore-plus/pymmcore-plus/issues/493) and the reply was to follow a pattern of constantly polling the core. Initially this worked fine but now I'm in the situation where I would like to leverage the core in an asyncio event loop and a callback would be quite useful.

The change is simply to emit a callback with the label of the camera acquiring the image so that an user may provide its own callback (or pymmcore plus can provide a signal for this).

I added a couple of smoke tests to verify the correct behavior, I'd be happy to add other tests to ensure situations that might cause problems.

EDIT: just to be clear I did run these tests locally on Windows and they pass, not sure if the CI triggers a testing run

