### PR TITLE
ThorlabsUSBCamera: signal event after StopSequenceAcquisition

### DIFF
--- a/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.cpp
+++ b/DeviceAdapters/ThorlabsUSBCamera/ThorlabsUSBCamera.cpp
@@ -565,6 +565,8 @@ int ThorlabsUSBCam::StopSequenceAcquisition()
    int ret = is_StopLiveVideo(camHandle_, IS_DONT_WAIT);
    if (ret != IS_SUCCESS)
       LogMessage("Camera failed to stop live video.");
+   if (hEvent)
+      SetEvent(hEvent);
 
    if (!thd_->IsStopped()) {
       thd_->Stop();                                                       


### PR DESCRIPTION
when running two thorlabs USB cams via MultiCam, it takes a very long time to stop.  Debugging indicated that the wait time was after MultiCam sent the request to thorlabs, and setting a stop event was suggested (by claude) as the best way to fix the problem).