### PR TITLE
MMDevice: avoid std::map in CameraImageMetadata

### DIFF
--- a/MMDevice/CameraImageMetadata.h
+++ b/MMDevice/CameraImageMetadata.h
@@ -17,8 +17,10 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cassert>
-#include <map>
+#include <cstddef>
+#include <limits>
 #include <sstream>
 #include <string>
 
@@ -26,29 +28,28 @@ namespace MM {
 
 class CameraImageMetadata {
 public:
-   // The memory warning in the AddTag() docs below doesn't apply to the
-   // current std::map implementation but will apply to an intended future
-   // implementation that serializes on the fly.
+   CameraImageMetadata() { Clear(); }
 
    /**
     * @brief Add a tag.
-    * 
+    *
     * The key must not contain newlines.
-    * 
+    *
     * At present, standard and custom keys are not formally distinguished. In
     * custom keys, it is recommended to include a prefix identifying the camera
     * adapter. For example, "AcmeCam-SensorTemperature" where AcmeCam is the
     * name of the camera adapter.
-    * 
+    *
     * The value should be a string, integer, or floating point number. If it is
     * a string, it must not contain newlines. Very long strings are
     * discouraged.
-    * 
-    * If a tag with the same key is added more than once, the last value wins.
-    * However, doing so may consume memory. Call Clear() to reuse an instance;
-    * if some of the tags are constant, keep an instance with just the constant
-    * tags and copy-assign it to the reused instance.
-    * 
+    *
+    * If a tag with the same key is added more than once, the last value wins
+    * on the MMCore side after deserialization. However, every added tag
+    * consumes memory in the serialized buffer. Call Clear() to reuse an
+    * instance; if some of the tags are constant, keep an instance with just
+    * the constant tags and copy-assign it to the reused instance.
+    *
     * @param key the key (must not be null)
     * @param value the value
     */
@@ -57,14 +58,14 @@ public:
       assert(key != nullptr);
       std::ostringstream strm;
       strm << value;
-      tags_[key] = strm.str();
+      AppendTag(key, strm.str().c_str());
    }
 
    /** @brief Optimized overload for string values. */
    void AddTag(const char* key, const char* value) {
       assert(key != nullptr);
       assert(value != nullptr);
-      tags_[key] = value;
+      AppendTag(key, value);
    }
 
    /** @brief Overload for std::string key. */
@@ -78,51 +79,67 @@ public:
    /**
     * @brief Remove all tags.
     */
-   void Clear() { tags_.clear(); }
+   void Clear() {
+      buffer_.assign(kCountWidth, ' ');
+      buffer_.push_back('\n');
+      count_ = 0;
+   }
 
    /**
     * @brief Return this metadata map serialized to string form.
-    * 
+    *
     * This is the form used to transmit data from a camera device to MMCore via
-    * the InsertImage() function. (The exact format may change with the Device
-    * Interface Version.)
+    * the InsertImage() function.
     *
     * The returned string is valid until this metadata map is mutated or
     * destroyed.
+    * 
+    * Device adapters must not depend on the serialization format, which may
+    * change in the future.
     *
     * @return the serialized metadata map
     */
    const char* Serialize() const {
-      // The serialization format used here is part of the versioned Device
-      // Interface.
+      // The serialization format is part of the versioned Device Interface:
       //
       // Header: <tag_count>\n
-      // (Spaces are tolerated before and after the tag count.)
+      // (Spaces are tolerated before and after the tag count; this
+      // implementation right-pads the count to a fixed width.)
       // For each tag: s\n<name>\n_\n1\n<value>\n
       // (The 's' indicates "single (not array) tag"; arrays are never used.)
       // (The '_' device-label field is always "_".)
       // (The '1' indicates "read-only"; no actual meaning.)
       //
-      // Tags must have unique keys up to DIV 74. In DIV 75+, the last
-      // occurrence of duplicate tags wins.
+      // Tags must have unique keys up to DIV 74. In DIV 75+, duplicate keys are
+      // permitted on the wire; the last occurrence wins on deserialization.
 
-      serialized_.clear();
-      serialized_ = std::to_string(tags_.size());
-      serialized_ += '\n';
-      for (const auto& tag : tags_) {
-         serialized_ += "s\n";
-         serialized_ += tag.first;
-         serialized_ += "\n_\n1\n";
-         serialized_ += tag.second;
-         serialized_ += '\n';
-      }
-      return serialized_.c_str();
+      WriteCountHeader();
+      return buffer_.c_str();
    }
 
 private:
-   std::map<std::string, std::string> tags_;
+   // Enough to hold any std::size_t in decimal (20 on 64-bit platforms).
+   static constexpr std::size_t kCountWidth =
+      std::numeric_limits<std::size_t>::digits10 + 1;
 
-   mutable std::string serialized_; // Valid after Serialize()
+   void AppendTag(const char* key, const char* value) {
+      buffer_ += "s\n";
+      buffer_ += key;
+      buffer_ += "\n_\n1\n";
+      buffer_ += value;
+      buffer_ += '\n';
+      ++count_;
+   }
+
+   void WriteCountHeader() const {
+      const std::string s = std::to_string(count_);
+      assert(s.size() <= kCountWidth);
+      auto out = std::copy(s.begin(), s.end(), buffer_.begin());
+      std::fill(out, buffer_.begin() + kCountWidth, ' ');
+   }
+
+   mutable std::string buffer_;
+   std::size_t count_ = 0;
 };
 
 } // namespace MM

--- a/MMDevice/unittest/CameraImageMetadata-Tests.cpp
+++ b/MMDevice/unittest/CameraImageMetadata-Tests.cpp
@@ -2,61 +2,91 @@
 
 #include "CameraImageMetadata.h"
 
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
 #include <string>
+#include <utility>
 
 // --- CameraImageMetadata serialization ---
 
+// Split the serialized output into (count, body). The count header's exact
+// padding is an implementation detail (the wire spec permits any amount of
+// whitespace around the count), so tests should not pin it down.
+static std::pair<std::size_t, std::string> SplitSerialized(const char* s) {
+   const char* nl = std::strchr(s, '\n');
+   REQUIRE(nl != nullptr);
+   const std::size_t count = static_cast<std::size_t>(
+      std::atol(std::string(s, nl).c_str()));
+   return std::make_pair(count, std::string(nl + 1));
+}
+
 TEST_CASE("CameraImageMetadata serialize empty", "[Metadata]") {
    MM::CameraImageMetadata m;
-   CHECK(std::string(m.Serialize()) == "0\n");
+   auto r = SplitSerialized(m.Serialize());
+   CHECK(r.first == 0);
+   CHECK(r.second.empty());
 }
 
 TEST_CASE("CameraImageMetadata serialize single string tag",
           "[Metadata]") {
    MM::CameraImageMetadata m;
    m.AddTag("Exposure", "10.0");
-   CHECK(std::string(m.Serialize()) == "1\ns\nExposure\n_\n1\n10.0\n");
+   auto r = SplitSerialized(m.Serialize());
+   CHECK(r.first == 1);
+   CHECK(r.second == "s\nExposure\n_\n1\n10.0\n");
 }
 
 TEST_CASE("CameraImageMetadata serialize single int tag", "[Metadata]") {
    MM::CameraImageMetadata m;
    m.AddTag("Binning", 2);
-   CHECK(std::string(m.Serialize()) == "1\ns\nBinning\n_\n1\n2\n");
+   auto r = SplitSerialized(m.Serialize());
+   CHECK(r.first == 1);
+   CHECK(r.second == "s\nBinning\n_\n1\n2\n");
 }
 
 TEST_CASE("CameraImageMetadata serialize single double tag",
           "[Metadata]") {
    MM::CameraImageMetadata m;
    m.AddTag("X", 1.5);
-   CHECK(std::string(m.Serialize()) == "1\ns\nX\n_\n1\n1.5\n");
+   auto r = SplitSerialized(m.Serialize());
+   CHECK(r.first == 1);
+   CHECK(r.second == "s\nX\n_\n1\n1.5\n");
 }
 
-TEST_CASE("CameraImageMetadata serialize multiple tags in key order",
+TEST_CASE("CameraImageMetadata serialize multiple tags",
           "[Metadata]") {
    MM::CameraImageMetadata m;
    m.AddTag("Exposure", "10.0");
    m.AddTag("Binning", 2);
    m.AddTag("X", 1.5);
-   CHECK(std::string(m.Serialize()) ==
-       "3\n"
-       "s\nBinning\n_\n1\n2\n"
+   auto r = SplitSerialized(m.Serialize());
+   CHECK(r.first == 3);
+   CHECK(r.second ==
        "s\nExposure\n_\n1\n10.0\n"
+       "s\nBinning\n_\n1\n2\n"
        "s\nX\n_\n1\n1.5\n");
 }
 
-TEST_CASE("CameraImageMetadata duplicate key keeps last value",
+TEST_CASE("CameraImageMetadata duplicate key appended, last value wins on deserialize",
           "[Metadata]") {
    MM::CameraImageMetadata m;
    m.AddTag("Key", "first");
    m.AddTag("Key", "second");
-   CHECK(std::string(m.Serialize()) == "1\ns\nKey\n_\n1\nsecond\n");
+   auto r = SplitSerialized(m.Serialize());
+   CHECK(r.first == 2);
+   CHECK(r.second ==
+       "s\nKey\n_\n1\nfirst\n"
+       "s\nKey\n_\n1\nsecond\n");
 }
 
 TEST_CASE("CameraImageMetadata AddTag with std::string key",
           "[Metadata]") {
    MM::CameraImageMetadata m;
    m.AddTag(std::string("Key"), "val");
-   CHECK(std::string(m.Serialize()) == "1\ns\nKey\n_\n1\nval\n");
+   auto r = SplitSerialized(m.Serialize());
+   CHECK(r.first == 1);
+   CHECK(r.second == "s\nKey\n_\n1\nval\n");
 }
 
 TEST_CASE("CameraImageMetadata Clear resets to empty", "[Metadata]") {
@@ -64,7 +94,9 @@ TEST_CASE("CameraImageMetadata Clear resets to empty", "[Metadata]") {
    m.AddTag("Exposure", "10.0");
    m.AddTag("Binning", 2);
    m.Clear();
-   CHECK(std::string(m.Serialize()) == "0\n");
+   auto r = SplitSerialized(m.Serialize());
+   CHECK(r.first == 0);
+   CHECK(r.second.empty());
 }
 
 TEST_CASE("CameraImageMetadata Serialize twice returns same result",


### PR DESCRIPTION
Instead, (more or less) directly serialize to the wire format upon each `AddTag()` call. This avoids the per-tag allocation needed by `std::map`, and is optimized for the actual usage pattern (small number of tags, rarely overwritten).

Note that this is allowed by DIV 75, in which the last tag wins in the case of duplicate keys.

Tests updated to avoid constraining space-padding of the tag count.