### PR TITLE
Move Core image tagging out of CircularBuffer

### DIFF
--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -31,11 +31,7 @@
 
 #include "DeviceUtils.h"
 
-#include <chrono>
-#include <cstdio>
-#include <ctime>
 #include <memory>
-#include <string>
 
 namespace mmcore {
 namespace internal {
@@ -74,8 +70,6 @@ int CircularBuffer::SetOverwriteData(bool overwrite) {
 bool CircularBuffer::Initialize(unsigned int w, unsigned int h, unsigned int pixDepth)
 {
    std::lock_guard<std::mutex> guard(bufferLock_);
-   imageNumbers_.clear();
-   startTime_ = std::chrono::steady_clock::now();
 
    bool ret = true;
    try
@@ -144,8 +138,6 @@ void CircularBuffer::ClearLocked()
    insertIndex_=0;
    saveIndex_=0;
    overflow_ = false;
-   startTime_ = std::chrono::steady_clock::now();
-   imageNumbers_.clear();
 }
 
 unsigned long CircularBuffer::GetSize() const
@@ -170,33 +162,6 @@ unsigned long CircularBuffer::GetRemainingImageCount() const
    return (unsigned long)(insertIndex_ - saveIndex_);
 }
 
-static std::string FormatLocalTime(std::chrono::time_point<std::chrono::system_clock> tp) {
-   using namespace std::chrono;
-   auto us = duration_cast<microseconds>(tp.time_since_epoch());
-   auto secs = duration_cast<seconds>(us);
-   auto whole = duration_cast<microseconds>(secs);
-   auto frac = static_cast<int>((us - whole).count());
-
-   // As of C++14/17, it is simpler (and probably faster) to use C functions for
-   // date-time formatting
-
-   std::time_t t(secs.count()); // time_t is seconds on platforms we support
-   std::tm *ptm;
-#ifdef _WIN32 // Windows localtime() is documented thread-safe
-   ptm = std::localtime(&t);
-#else // POSIX has localtime_r()
-   std::tm tmstruct;
-   ptm = localtime_r(&t, &tmstruct);
-#endif
-
-   // Format as "yyyy-mm-dd hh:mm:ss.uuuuuu" (26 chars)
-   const char *timeFmt = "%Y-%m-%d %H:%M:%S";
-   char buf[32];
-   std::size_t len = std::strftime(buf, sizeof(buf), timeFmt, ptm);
-   std::snprintf(buf + len, sizeof(buf) - len, ".%06d", frac);
-   return buf;
-}
-
 /**
 * Inserts a single image, possibly with multiple components, in the buffer.
 */
@@ -204,11 +169,12 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
    unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents,
    const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError)
 {
+    (void)nComponents;
     std::lock_guard<std::mutex> insertGuard(insertLock_);
 
     ImgBuffer* pImg;
     unsigned long singleChannelSize = (unsigned long)width * height * byteDepth;
- 
+
     {
        std::lock_guard<std::mutex> guard(bufferLock_);
 
@@ -228,66 +194,15 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
             return false;
          }
        }
+
+       // we assume that all buffers are pre-allocated
+       pImg = frameArray_[insertIndex_ % frameArray_.size()].FindImage(0);
+       if (!pImg)
+          return false;
     }
- 
-   Metadata md;
-   {
-      std::lock_guard<std::mutex> guard(bufferLock_);
-      // we assume that all buffers are pre-allocated
-      pImg = frameArray_[insertIndex_ % frameArray_.size()].FindImage(0);
-      if (!pImg)
-         return false;
- 
-      if (pMd)
-      {
-         md = *pMd;
-      }
 
-      std::string cameraName = md.GetSingleTag(MM::g_Keyword_Metadata_CameraLabel).GetValue();
-      if (imageNumbers_.end() == imageNumbers_.find(cameraName))
-      {
-         imageNumbers_[cameraName] = 0;
-      }
-
-      // insert image number. 
-      md.PutImageTag(MM::g_Keyword_Metadata_ImageNumber, CDeviceUtils::ConvertToString(imageNumbers_[cameraName]));
-      ++imageNumbers_[cameraName];
-   }
-
-   if (!md.HasTag(MM::g_Keyword_Elapsed_Time_ms))
-   {
-      // if time tag was not supplied by the camera insert current timestamp
-      using namespace std::chrono;
-      auto elapsed = steady_clock::now() - startTime_;
-      md.PutImageTag(MM::g_Keyword_Elapsed_Time_ms,
-         std::to_string(duration_cast<milliseconds>(elapsed).count()));
-   }
-
-   // Note: It is not ideal to use local time. I think this tag is rarely
-   // used. Consider replacing with UTC (micro)seconds-since-epoch (with
-   // different tag key) after addressing current usage.
-   auto now = std::chrono::system_clock::now();
-   md.PutImageTag(MM::g_Keyword_Metadata_TimeInCore, FormatLocalTime(now));
-
-   md.PutImageTag(MM::g_Keyword_Metadata_Width, width);
-   md.PutImageTag(MM::g_Keyword_Metadata_Height, height);
-   if (byteDepth == 1)
-      md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_GRAY8);
-   else if (byteDepth == 2)
-      md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_GRAY16);
-   else if (byteDepth == 4)
-   {
-      if (nComponents == 1)
-         md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_GRAY32);
-      else
-         md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_RGB32);
-   }
-   else if (byteDepth == 8)
-      md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_RGB64);
-   else
-      md.PutImageTag(MM::g_Keyword_PixelType, MM::g_Keyword_PixelType_Unknown);
-
-   pImg->SetMetadata(md);
+   if (pMd)
+      pImg->SetMetadata(*pMd);
    // TODO: In MMCore the ImgBuffer::GetPixels() returns const pointer.
    //       It would be better to have something like ImgBuffer::GetPixelsRW() in MMDevice.
    //       Or even better - pass tasksMemCopy_ to ImgBuffer constructor

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -211,11 +211,14 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
  
     {
        std::lock_guard<std::mutex> guard(bufferLock_);
- 
+
+       if (overflow_)
+          return false;
+
        // check image dimensions
        if (width != width_ || height != height_ || byteDepth != pixDepth_)
           throw CMMError("Incompatible image dimensions in the circular buffer", MMERR_CircularBufferIncompatibleImage);
- 
+
        bool overflowed = (insertIndex_ - saveIndex_) >= static_cast<long>(frameArray_.size());
        if (overflowed) {
          if (overwriteData_) {

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -30,7 +30,6 @@
 
 #include "MMDevice.h"
 
-#include <chrono>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -88,8 +87,6 @@ private:
    unsigned int height_;
    unsigned int pixDepth_;
    long imageCounter_;
-   std::chrono::time_point<std::chrono::steady_clock> startTime_;
-   std::map<std::string, long> imageNumbers_;
 
    // Invariants:
    // 0 <= saveIndex_ <= insertIndex_

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -36,6 +36,8 @@
 
 #include <cassert>
 #include <chrono>
+#include <cstdio>
+#include <ctime>
 #include <string>
 #include <vector>
 #include <algorithm>
@@ -47,9 +49,46 @@ namespace internal {
 
 
 CoreCallback::CoreCallback(CMMCore* c) :
-   core_(c)
+   core_(c),
+   startTime_(std::chrono::steady_clock::now())
 {
    assert(core_);
+}
+
+
+void CoreCallback::ResetImageInsertionState()
+{
+   std::lock_guard<std::mutex> guard(imageInsertionStateMutex_);
+   imageNumbers_.clear();
+   startTime_ = std::chrono::steady_clock::now();
+}
+
+
+static std::string FormatLocalTime(std::chrono::time_point<std::chrono::system_clock> tp) {
+   using namespace std::chrono;
+   auto us = duration_cast<microseconds>(tp.time_since_epoch());
+   auto secs = duration_cast<seconds>(us);
+   auto whole = duration_cast<microseconds>(secs);
+   auto frac = static_cast<int>((us - whole).count());
+
+   // As of C++14/17, it is simpler (and probably faster) to use C functions for
+   // date-time formatting
+
+   std::time_t t(secs.count()); // time_t is seconds on platforms we support
+   std::tm *ptm;
+#ifdef _WIN32 // Windows localtime() is documented thread-safe
+   ptm = std::localtime(&t);
+#else // POSIX has localtime_r()
+   std::tm tmstruct;
+   ptm = localtime_r(&t, &tmstruct);
+#endif
+
+   // Format as "yyyy-mm-dd hh:mm:ss.uuuuuu" (26 chars)
+   const char *timeFmt = "%Y-%m-%d %H:%M:%S";
+   char buf[32];
+   std::size_t len = std::strftime(buf, sizeof(buf), timeFmt, ptm);
+   std::snprintf(buf + len, sizeof(buf) - len, ".%06d", frac);
+   return buf;
 }
 
 
@@ -223,6 +262,55 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
    return InsertImage(caller, buf, width, height, bytesPerPixel, 1, serializedMetadata);
 }
 
+Metadata CoreCallback::BuildSequenceImageMetadata(const MM::Device* caller,
+   unsigned width, unsigned height,
+   unsigned byteDepth, unsigned nComponents,
+   const Metadata* origMd)
+{
+   Metadata md = AddCameraMetadata(caller, origMd);
+
+   md.PutImageTag(MM::g_Keyword_Metadata_Width, width);
+   md.PutImageTag(MM::g_Keyword_Metadata_Height, height);
+
+   const char* pixelType = MM::g_Keyword_PixelType_Unknown;
+   if (byteDepth == 1)
+      pixelType = MM::g_Keyword_PixelType_GRAY8;
+   else if (byteDepth == 2)
+      pixelType = MM::g_Keyword_PixelType_GRAY16;
+   else if (byteDepth == 4)
+      pixelType = (nComponents == 1) ? MM::g_Keyword_PixelType_GRAY32
+                                     : MM::g_Keyword_PixelType_RGB32;
+   else if (byteDepth == 8)
+      pixelType = MM::g_Keyword_PixelType_RGB64;
+   md.PutImageTag(MM::g_Keyword_PixelType, pixelType);
+
+   // Note: It is not ideal to use local time. I think this tag is rarely
+   // used. Consider replacing with UTC (micro)seconds-since-epoch (with
+   // different tag key) after addressing current usage.
+   md.PutImageTag(MM::g_Keyword_Metadata_TimeInCore,
+         FormatLocalTime(std::chrono::system_clock::now()));
+
+   {
+      std::lock_guard<std::mutex> guard(imageInsertionStateMutex_);
+      if (!md.HasTag(MM::g_Keyword_Elapsed_Time_ms))
+      {
+         using namespace std::chrono;
+         auto elapsed = steady_clock::now() - startTime_;
+         md.PutImageTag(MM::g_Keyword_Elapsed_Time_ms,
+            std::to_string(duration_cast<milliseconds>(elapsed).count()));
+      }
+
+      const std::string cameraLabel =
+         md.GetSingleTag(MM::g_Keyword_Metadata_CameraLabel).GetValue();
+      long& counter = imageNumbers_[cameraLabel];
+      md.PutImageTag(MM::g_Keyword_Metadata_ImageNumber,
+         CDeviceUtils::ConvertToString(counter));
+      ++counter;
+   }
+
+   return md;
+}
+
 int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf,
    unsigned width, unsigned height, unsigned bytesPerPixel, unsigned nComponents,
    const char* serializedMetadata)
@@ -233,15 +321,16 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
       origMd.Restore(serializedMetadata);
    }
 
-   try 
+   try
    {
-      Metadata md = AddCameraMetadata(caller, &origMd);
+      Metadata md = BuildSequenceImageMetadata(
+         caller, width, height, bytesPerPixel, nComponents, &origMd);
 
-         MM::ImageProcessor* ip = GetImageProcessor(caller);
-         if( NULL != ip)
-         {
-            ip->Process(const_cast<unsigned char*>(buf), width, height, bytesPerPixel);
-         }
+      MM::ImageProcessor* ip = GetImageProcessor(caller);
+      if (ip != nullptr)
+      {
+         ip->Process(const_cast<unsigned char*>(buf), width, height, bytesPerPixel);
+      }
       if (core_->cbuf_->InsertImage(buf, width, height, bytesPerPixel, nComponents, &md))
          return DEVICE_OK;
       else

--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -30,6 +30,11 @@
 
 #include "DeviceUtils.h"
 
+#include <chrono>
+#include <map>
+#include <mutex>
+#include <string>
+
 namespace mmcore {
 namespace internal {
 
@@ -115,6 +120,10 @@ public:
    void GetLoadedDeviceOfType(const MM::Device* caller, MM::DeviceType devType,
          char* deviceName, const unsigned int deviceIterator);
 
+   // Reset per-acquisition image-metadata state: per-camera ImageNumber
+   // counters and the ElapsedTime-ms reference point.
+   void ResetImageInsertionState();
+
 private:
    CMMCore* core_;
    // Serializes OnPropertyChanged calls to reduce (but not eliminate)
@@ -122,7 +131,16 @@ private:
    // lookups used to determine which notifications to post.
    std::mutex onPropertyChangedLock_;
 
+   // Guards imageNumbers_ and startTime_.
+   std::mutex imageInsertionStateMutex_;
+   std::map<std::string, long> imageNumbers_;
+   std::chrono::time_point<std::chrono::steady_clock> startTime_;
+
    Metadata AddCameraMetadata(const MM::Device* caller, const Metadata* pMd);
+   Metadata BuildSequenceImageMetadata(const MM::Device* caller,
+         unsigned width, unsigned height,
+         unsigned byteDepth, unsigned nComponents,
+         const Metadata* origMd);
    MM::ImageProcessor* GetImageProcessor(const MM::Device* caller);
 };
 

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -3046,6 +3046,7 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
 				throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
 			}
 			cbuf_->Clear();
+			callback_->ResetImageInsertionState();
          cbuf_->SetOverwriteData(!stopOnOverflow);
          mmi::DeviceModuleLockGuard guard(camera);
 
@@ -3092,6 +3093,7 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
       throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
    }
    cbuf_->Clear();
+   callback_->ResetImageInsertionState();
    cbuf_->SetOverwriteData(!stopOnOverflow);
    LOG_DEBUG(coreLogger_) <<
       "Will start sequence acquisition from camera " << label;
@@ -3139,6 +3141,7 @@ void CMMCore::initializeCircularBuffer() MMCORE_LEGACY_THROW(CMMError)
          throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
       }
       cbuf_->Clear();
+      callback_->ResetImageInsertionState();
    }
    else
    {
@@ -3192,6 +3195,7 @@ void CMMCore::startContinuousSequenceAcquisition(double intervalMs) MMCORE_LEGAC
          throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
       }
       cbuf_->Clear();
+      callback_->ResetImageInsertionState();
       cbuf_->SetOverwriteData(true);
       LOG_DEBUG(coreLogger_) << "Will start continuous sequence acquisition from current camera";
       int nRet = camera->StartSequenceAcquisition(intervalMs);
@@ -3406,6 +3410,7 @@ void* CMMCore::popNextImageMD(Metadata& md) MMCORE_LEGACY_THROW(CMMError)
 void CMMCore::clearCircularBuffer() MMCORE_LEGACY_THROW(CMMError)
 {
    cbuf_->Clear();
+   callback_->ResetImageInsertionState();
 }
 
 /**
@@ -3439,6 +3444,7 @@ void CMMCore::setCircularBufferMemoryFootprint(unsigned sizeMB ///< n megabytes
          mmi::DeviceModuleLockGuard guard(camera);
          if (!cbuf_->Initialize(camera->GetImageWidth(), camera->GetImageHeight(), camera->GetImageBytesPerPixel()))
 				throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
+         callback_->ResetImageInsertionState();
 		}
 
       LOG_DEBUG(coreLogger_) << "Did set circular buffer size to " <<
@@ -4701,6 +4707,7 @@ void CMMCore::setROI(int x, int y, int xSize, int ySize) MMCORE_LEGACY_THROW(CMM
       // popNextImage() to handle this correctly, so we need to make sure we
       // discard such images.
       cbuf_->Clear();
+      callback_->ResetImageInsertionState();
    }
    else
       throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
@@ -4780,6 +4787,7 @@ void CMMCore::setROI(const char* label, int x, int y, int xSize, int ySize) MMCO
      // popNextImage() to handle this correctly, so we need to make sure we
      // discard such images.
      cbuf_->Clear();
+     callback_->ResetImageInsertionState();
   }
   else
      throw CMMError(getCoreErrorText(MMERR_CameraNotAvailable).c_str(), MMERR_CameraNotAvailable);
@@ -4839,6 +4847,7 @@ void CMMCore::clearROI() MMCORE_LEGACY_THROW(CMMError)
       // popNextImage() to handle this correctly, so we need to make sure we
       // discard such images.
       cbuf_->Clear();
+      callback_->ResetImageInsertionState();
    }
 }
 

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -730,7 +730,7 @@ private:
    std::unique_ptr<PixelSizeConfigGroup> pixelSizeGroup_;
    std::unique_ptr<mmcore::internal::CorePropertyCollection> properties_;
    std::unique_ptr<mmcore::internal::CircularBuffer> cbuf_;
-   std::unique_ptr<MM::Core> callback_;
+   std::unique_ptr<mmcore::internal::CoreCallback> callback_;
 
    std::shared_ptr<mmcore::internal::CPluginManager> pluginManager_;
    std::shared_ptr<mmcore::internal::DeviceManager> deviceManager_;

--- a/MMCore/unittest/CircularBuffer-Tests.cpp
+++ b/MMCore/unittest/CircularBuffer-Tests.cpp
@@ -419,6 +419,29 @@ TEST_CASE("clearCircularBuffer resets remaining count", "[CircularBuffer]") {
    CHECK(c.getRemainingImageCount() == 0);
 }
 
+TEST_CASE("Overflow is sticky until buffer is cleared", "[CircularBuffer]") {
+   StubCamera cam;
+   MockAdapterWithDevices adapter{{"cam", &cam}};
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("cam");
+   c.setCircularBufferMemoryFootprint(1);
+   c.initializeCircularBuffer();
+
+   long total = c.getBufferTotalCapacity();
+   REQUIRE(total == 4);
+   for (long i = 0; i < total; ++i)
+      REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+   REQUIRE(cam.InsertTestImage() == DEVICE_BUFFER_OVERFLOW);
+
+   // Popping one image frees a slot, but insert should still fail until clear.
+   REQUIRE(c.popNextImage() != nullptr);
+   CHECK(cam.InsertTestImage() == DEVICE_BUFFER_OVERFLOW);
+
+   c.clearCircularBuffer();
+   CHECK(cam.InsertTestImage() == DEVICE_OK);
+}
+
 TEST_CASE("clearCircularBuffer resets overflow flag", "[CircularBuffer]") {
    StubCamera cam;
    MockAdapterWithDevices adapter{{"cam", &cam}};

--- a/MMCore/unittest/ImageMetadataTags-Tests.cpp
+++ b/MMCore/unittest/ImageMetadataTags-Tests.cpp
@@ -233,3 +233,122 @@ TEST_CASE("RemoveTag removes a previously added device tag") {
    c.getLastImageMD(md);
    CHECK(md.GetKeys().size() == 7);
 }
+
+TEST_CASE("ImageNumber is tracked per camera across interleaved inserts") {
+   StubCamera camA;
+   StubCamera camB;
+   MockAdapterWithDevices adapter{{"camA", &camA}, {"camB", &camB}};
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("camA");
+   c.initializeCircularBuffer();
+
+   REQUIRE(camA.InsertTestImage() == DEVICE_OK);
+   REQUIRE(camB.InsertTestImage() == DEVICE_OK);
+   REQUIRE(camA.InsertTestImage() == DEVICE_OK);
+   REQUIRE(camB.InsertTestImage() == DEVICE_OK);
+
+   struct Expected { const char* label; const char* number; };
+   const Expected expected[] = {
+      {"camA", "0"}, {"camB", "0"}, {"camA", "1"}, {"camB", "1"},
+   };
+   for (const auto& e : expected) {
+      Metadata md;
+      c.popNextImageMD(md);
+      CHECK(md.GetSingleTag(MM::g_Keyword_Metadata_CameraLabel).GetValue() ==
+            e.label);
+      CHECK(md.GetSingleTag(MM::g_Keyword_Metadata_ImageNumber).GetValue() ==
+            e.number);
+   }
+}
+
+TEST_CASE("ImageNumber resets after clearCircularBuffer") {
+   StubCamera cam;
+   MockAdapterWithDevices adapter{{"cam", &cam}};
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("cam");
+   c.initializeCircularBuffer();
+
+   REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+   REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+   REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+
+   c.clearCircularBuffer();
+   REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+
+   Metadata md;
+   c.popNextImageMD(md);
+   CHECK(md.GetSingleTag(MM::g_Keyword_Metadata_ImageNumber).GetValue() == "0");
+}
+
+TEST_CASE("ImageNumber resets after re-initializeCircularBuffer") {
+   StubCamera cam;
+   MockAdapterWithDevices adapter{{"cam", &cam}};
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("cam");
+   c.initializeCircularBuffer();
+
+   REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+   REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+
+   c.initializeCircularBuffer();
+   REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+
+   Metadata md;
+   c.popNextImageMD(md);
+   CHECK(md.GetSingleTag(MM::g_Keyword_Metadata_ImageNumber).GetValue() == "0");
+}
+
+TEST_CASE("ImageNumber is monotonic across overwrite-on-overflow wrap") {
+   StubCamera cam;
+   MockAdapterWithDevices adapter{{"cam", &cam}};
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("cam");
+   c.setCircularBufferMemoryFootprint(1);
+   // stopOnOverflow=false enables overwrite mode
+   c.startSequenceAcquisition(100, 0.0, false);
+
+   long total = c.getBufferTotalCapacity();
+   REQUIRE(total == 4);
+   for (long i = 0; i < total + 1; ++i)
+      REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+
+   // The wrap-on-overflow path discards buffered images, so only the last
+   // insert remains. Under the old code, the mid-acquisition wrap also reset
+   // the per-camera ImageNumber counter, producing "0". Under the new code,
+   // the counter is independent of buffer state, so the retained image
+   // carries its original acquisition index.
+   REQUIRE(c.getRemainingImageCount() == 1);
+   Metadata md;
+   c.popNextImageMD(md);
+   CHECK(md.GetSingleTag(MM::g_Keyword_Metadata_ImageNumber).GetValue() ==
+         std::to_string(total));
+}
+
+TEST_CASE("ImageNumbers are contiguous under stop-on-overflow") {
+   StubCamera cam;
+   MockAdapterWithDevices adapter{{"cam", &cam}};
+   CMMCore c;
+   adapter.LoadIntoCore(c);
+   c.setCameraDevice("cam");
+   c.setCircularBufferMemoryFootprint(1);
+   c.initializeCircularBuffer();
+
+   long total = c.getBufferTotalCapacity();
+   REQUIRE(total == 4);
+
+   for (long i = 0; i < total; ++i)
+      REQUIRE(cam.InsertTestImage() == DEVICE_OK);
+   REQUIRE(cam.InsertTestImage() == DEVICE_BUFFER_OVERFLOW);
+   REQUIRE(cam.InsertTestImage() == DEVICE_BUFFER_OVERFLOW);
+
+   for (long i = 0; i < total; ++i) {
+      Metadata md;
+      c.popNextImageMD(md);
+      CHECK(md.GetSingleTag(MM::g_Keyword_Metadata_ImageNumber).GetValue() ==
+            std::to_string(i));
+   }
+}


### PR DESCRIPTION
Separation of concerns: buffer should be buffer.
    
Also, `ImageNumber` and `ElapsedTime-ms` are no longer reset when buffer fills up in overwrite mode: `ImageNumber` counts the skipped images. (Arguably a bug fix.)

A slight down side is that calls to `ResetImageInsertionState()` needed to be added in multiple locations. But this better reflects the intent until we have an explicit "acquisition" object to track sequence acquisitions.

In addition: Do not allow cameras to insert further images after a buffer overflow. Cameras shouldn't, but now we enforce it in the Core. (This ensures that `ImageNumber` doesn't have an edge case ("recovery" after overflow) where behavior may changes from previous.)