### PR TITLE
MMCore: handle image tags in serialized form internally

### DIFF
--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -167,7 +167,7 @@ unsigned long CircularBuffer::GetRemainingImageCount() const
 */
 bool CircularBuffer::InsertImage(const unsigned char* pixArray,
    unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents,
-   const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError)
+   std::string_view serializedMetadata) MMCORE_LEGACY_THROW(CMMError)
 {
     (void)nComponents;
     std::lock_guard<std::mutex> insertGuard(insertLock_);
@@ -201,8 +201,8 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
           return false;
     }
 
-   if (pMd)
-      pImg->SetMetadata(*pMd);
+   pImg->SetSerializedMetadata(serializedMetadata);
+
    // TODO: In MMCore the ImgBuffer::GetPixels() returns const pointer.
    //       It would be better to have something like ImgBuffer::GetPixelsRW() in MMDevice.
    //       Or even better - pass tasksMemCopy_ to ImgBuffer constructor

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -32,6 +32,7 @@
 
 #include <memory>
 #include <mutex>
+#include <string_view>
 #include <vector>
 
 namespace mmcore {
@@ -62,7 +63,7 @@ public:
 
    bool InsertImage(const unsigned char* pixArray,
       unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents,
-      const Metadata* pMd) MMCORE_LEGACY_THROW(CMMError);
+      std::string_view serializedMetadata) MMCORE_LEGACY_THROW(CMMError);
    const unsigned char* GetTopImage() const;
    const unsigned char* GetNextImage();
    const ImgBuffer* GetTopImageBuffer(unsigned channel) const;

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -29,6 +29,7 @@
 #include "CoreCallback.h"
 #include "DeviceManager.h"
 #include "Notification.h"
+#include "SerializedMetadata.h"
 #include "SynchronizedConfiguration.h"
 
 #include "DeviceUtils.h"
@@ -219,24 +220,18 @@ CoreCallback::Sleep(const MM::Device*, double intervalMs)
 
 
 /**
- * Get the metadata tags attached to device caller, and merge them with metadata
- * in pMd (if not null). Returns a metadata object.
+ * Append the metadata tags attached to device caller to md.
  */
-Metadata
-CoreCallback::AddCameraMetadata(const MM::Device* caller, const Metadata* pMd)
+void
+CoreCallback::AddCameraMetadata(const MM::Device* caller,
+      SerializedMetadata& md)
 {
-   Metadata newMD;
-   if (pMd)
-   {
-      newMD = *pMd;
-   }
-
    std::shared_ptr<CameraInstance> camera =
       std::static_pointer_cast<CameraInstance>(
             core_->deviceManager_->GetDevice(caller));
 
    std::string label = camera->GetLabel();
-   newMD.PutImageTag(MM::g_Keyword_Metadata_CameraLabel, label);
+   md.AddTag(MM::g_Keyword_Metadata_CameraLabel, label);
 
    std::string serializedMD;
    try
@@ -245,14 +240,10 @@ CoreCallback::AddCameraMetadata(const MM::Device* caller, const Metadata* pMd)
    }
    catch (const CMMError&)
    {
-      return newMD;
+      return;
    }
 
-   Metadata devMD;
-   devMD.Restore(serializedMD.c_str());
-   newMD.Merge(devMD);
-
-   return newMD;
+   md.AppendSerialized(serializedMD.c_str());
 }
 
 int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf,
@@ -262,15 +253,17 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
    return InsertImage(caller, buf, width, height, bytesPerPixel, 1, serializedMetadata);
 }
 
-Metadata CoreCallback::BuildSequenceImageMetadata(const MM::Device* caller,
+SerializedMetadata
+CoreCallback::BuildSequenceImageMetadata(const MM::Device* caller,
    unsigned width, unsigned height,
    unsigned byteDepth, unsigned nComponents,
-   const Metadata* origMd)
+   const char* origSerializedMd)
 {
-   Metadata md = AddCameraMetadata(caller, origMd);
+   SerializedMetadata md(origSerializedMd);
+   AddCameraMetadata(caller, md);
 
-   md.PutImageTag(MM::g_Keyword_Metadata_Width, width);
-   md.PutImageTag(MM::g_Keyword_Metadata_Height, height);
+   md.AddTag(MM::g_Keyword_Metadata_Width, width);
+   md.AddTag(MM::g_Keyword_Metadata_Height, height);
 
    const char* pixelType = MM::g_Keyword_PixelType_Unknown;
    if (byteDepth == 1)
@@ -282,12 +275,12 @@ Metadata CoreCallback::BuildSequenceImageMetadata(const MM::Device* caller,
                                      : MM::g_Keyword_PixelType_RGB32;
    else if (byteDepth == 8)
       pixelType = MM::g_Keyword_PixelType_RGB64;
-   md.PutImageTag(MM::g_Keyword_PixelType, pixelType);
+   md.AddTag(MM::g_Keyword_PixelType, pixelType);
 
    // Note: It is not ideal to use local time. I think this tag is rarely
    // used. Consider replacing with UTC (micro)seconds-since-epoch (with
    // different tag key) after addressing current usage.
-   md.PutImageTag(MM::g_Keyword_Metadata_TimeInCore,
+   md.AddTag(MM::g_Keyword_Metadata_TimeInCore,
          FormatLocalTime(std::chrono::system_clock::now()));
 
    {
@@ -296,14 +289,14 @@ Metadata CoreCallback::BuildSequenceImageMetadata(const MM::Device* caller,
       {
          using namespace std::chrono;
          auto elapsed = steady_clock::now() - startTime_;
-         md.PutImageTag(MM::g_Keyword_Elapsed_Time_ms,
+         md.AddTag(MM::g_Keyword_Elapsed_Time_ms,
             std::to_string(duration_cast<milliseconds>(elapsed).count()));
       }
 
-      const std::string cameraLabel =
-         md.GetSingleTag(MM::g_Keyword_Metadata_CameraLabel).GetValue();
-      long& counter = imageNumbers_[cameraLabel];
-      md.PutImageTag(MM::g_Keyword_Metadata_ImageNumber,
+      auto cameraLabel = md.GetTag(MM::g_Keyword_Metadata_CameraLabel);
+      assert(cameraLabel.has_value());
+      long& counter = imageNumbers_[std::string(*cameraLabel)];
+      md.AddTag(MM::g_Keyword_Metadata_ImageNumber,
          CDeviceUtils::ConvertToString(counter));
       ++counter;
    }
@@ -315,23 +308,18 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
    unsigned width, unsigned height, unsigned bytesPerPixel, unsigned nComponents,
    const char* serializedMetadata)
 {
-   Metadata origMd;
-   if (serializedMetadata)
-   {
-      origMd.Restore(serializedMetadata);
-   }
-
    try
    {
-      Metadata md = BuildSequenceImageMetadata(
-         caller, width, height, bytesPerPixel, nComponents, &origMd);
+      SerializedMetadata md = BuildSequenceImageMetadata(
+         caller, width, height, bytesPerPixel, nComponents, serializedMetadata);
 
       MM::ImageProcessor* ip = GetImageProcessor(caller);
       if (ip != nullptr)
       {
          ip->Process(const_cast<unsigned char*>(buf), width, height, bytesPerPixel);
       }
-      if (core_->cbuf_->InsertImage(buf, width, height, bytesPerPixel, nComponents, &md))
+      if (core_->cbuf_->InsertImage(buf, width, height, bytesPerPixel, nComponents,
+            md.View()))
          return DEVICE_OK;
       else
          return DEVICE_BUFFER_OVERFLOW;

--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -39,6 +39,7 @@ namespace mmcore {
 namespace internal {
 
 class DeviceManager;
+class SerializedMetadata;
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -136,11 +137,11 @@ private:
    std::map<std::string, long> imageNumbers_;
    std::chrono::time_point<std::chrono::steady_clock> startTime_;
 
-   Metadata AddCameraMetadata(const MM::Device* caller, const Metadata* pMd);
-   Metadata BuildSequenceImageMetadata(const MM::Device* caller,
+   void AddCameraMetadata(const MM::Device* caller, SerializedMetadata& md);
+   SerializedMetadata BuildSequenceImageMetadata(const MM::Device* caller,
          unsigned width, unsigned height,
          unsigned byteDepth, unsigned nComponents,
-         const Metadata* origMd);
+         const char* origSerializedMd);
    MM::ImageProcessor* GetImageProcessor(const MM::Device* caller);
 };
 

--- a/MMCore/Devices/CameraInstance.cpp
+++ b/MMCore/Devices/CameraInstance.cpp
@@ -126,8 +126,7 @@ bool CameraInstance::IsCapturing() { RequireInitialized(__func__); return GetImp
 std::string CameraInstance::GetTags()
 {
    RequireInitialized(__func__);
-   // TODO Probably makes sense to deserialize here.
-   // Also note the danger of limiting serialized metadata to MM::MaxStrLength
+   // TODO Note the danger of limiting serialized metadata to MM::MaxStrLength
    // (CCameraBase takes no precaution to limit string length; it is an
    // interface bug).
    DeviceStringBuffer serializedMetadataBuf(this, "GetTags");

--- a/MMCore/FrameBuffer.cpp
+++ b/MMCore/FrameBuffer.cpp
@@ -69,13 +69,9 @@ void ImgBuffer::Resize(unsigned xSize, unsigned ySize)
    memset(pixels_.get(), 0, width_ * height_ * pixDepth_);
 }
 
-void ImgBuffer::SetMetadata(const Metadata& md)
+void ImgBuffer::SetSerializedMetadata(std::string_view serialized)
 {
-   //metadata_ = md;
-   // Serialize/Restore instead of =operator used to avoid object new/delete
-   // issues across the DLL boundary (on Windows)
-   // TODO: this is inefficient and should be revised
-    metadata_.Restore(md.Serialize().c_str());
+   serializedMetadata_.assign(serialized);
 }
 
 

--- a/MMCore/FrameBuffer.h
+++ b/MMCore/FrameBuffer.h
@@ -18,9 +18,9 @@
 
 #pragma once
 
-#include "ImageMetadata.h"
-
 #include <memory>
+#include <string>
+#include <string_view>
 
 namespace mmcore {
 namespace internal {
@@ -31,7 +31,7 @@ class ImgBuffer
    unsigned int width_;
    unsigned int height_;
    unsigned int pixDepth_;
-   Metadata metadata_;
+   std::string serializedMetadata_;
 
 public:
    ImgBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth);
@@ -46,8 +46,10 @@ public:
    void Resize(unsigned xSize, unsigned ySize, unsigned pixDepth);
    void Resize(unsigned xSize, unsigned ySize);
 
-   void SetMetadata(const Metadata& md);
-   const Metadata& GetMetadata() const {return metadata_;}
+   void SetSerializedMetadata(std::string_view serialized);
+   const std::string& GetSerializedMetadata() const {
+      return serializedMetadata_;
+   }
 
 private:
    ImgBuffer& operator=(const ImgBuffer&);

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -3300,7 +3300,7 @@ void* CMMCore::getLastImageMD(unsigned channel, unsigned slice, Metadata& md) co
    const mmi::ImgBuffer* pBuf = cbuf_->GetTopImageBuffer(channel);
    if (pBuf != 0)
    {
-      md = pBuf->GetMetadata();
+      md.Restore(pBuf->GetSerializedMetadata().c_str());
       return const_cast<unsigned char*>(pBuf->GetPixels());
    }
    else
@@ -3341,7 +3341,7 @@ void* CMMCore::getNBeforeLastImageMD(unsigned long n, Metadata& md) const MMCORE
    const mmi::ImgBuffer* pBuf = cbuf_->GetNthFromTopImageBuffer(n);
    if (pBuf != 0)
    {
-      md = pBuf->GetMetadata();
+      md.Restore(pBuf->GetSerializedMetadata().c_str());
       return const_cast<unsigned char*>(pBuf->GetPixels());
    }
    else
@@ -3386,7 +3386,7 @@ void* CMMCore::popNextImageMD(unsigned channel, unsigned slice, Metadata& md) MM
    const mmi::ImgBuffer* pBuf = cbuf_->GetNextImageBuffer(channel);
    if (pBuf != 0)
    {
-      md = pBuf->GetMetadata();
+      md.Restore(pBuf->GetSerializedMetadata().c_str());
       return const_cast<unsigned char*>(pBuf->GetPixels());
    }
    else

--- a/MMCore/MMCore.vcxproj
+++ b/MMCore/MMCore.vcxproj
@@ -151,6 +151,7 @@
     <ClInclude Include="ErrorCodes.h" />
     <ClInclude Include="FrameBuffer.h" />
     <ClInclude Include="ImageMetadata.h" />
+    <ClInclude Include="SerializedMetadata.h" />
     <ClInclude Include="LibraryInfo\LibraryPaths.h" />
     <ClInclude Include="LoadableModules\LoadedDeviceAdapter.h" />
     <ClInclude Include="LoadableModules\LoadedDeviceAdapterImpl.h" />

--- a/MMCore/MMCore.vcxproj.filters
+++ b/MMCore/MMCore.vcxproj.filters
@@ -188,6 +188,9 @@
     <ClInclude Include="ImageMetadata.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="SerializedMetadata.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="MMCore.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/MMCore/Makefile.am
+++ b/MMCore/Makefile.am
@@ -106,6 +106,7 @@ libMMCore_la_SOURCES = \
 	NotificationQueue.h \
 	PluginManager.cpp \
 	PluginManager.h \
+	SerializedMetadata.h \
 	Semaphore.cpp \
 	Semaphore.h \
 	SynchronizedConfiguration.h \

--- a/MMCore/SerializedMetadata.h
+++ b/MMCore/SerializedMetadata.h
@@ -1,0 +1,200 @@
+// COPYRIGHT:  2026, Board of Regents of the University of Wisconsin System
+//
+// LICENSE:    This file is distributed under the "Lesser GPL" (LGPL) license.
+//             License text is included with the source distribution.
+//
+//             This file is distributed in the hope that it will be useful,
+//             but WITHOUT ANY WARRANTY; without even the implied warranty
+//             of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//             IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//             CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//             INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace mmcore {
+namespace internal {
+
+// Append-and-scan buffer that holds image metadata in the wire-serialized
+// form documented in MMDevice/CameraImageMetadata.h. Used internally by
+// MMCore to keep camera-supplied tags and Core-added tags in their
+// already-serialized form until the public retrieval API needs to hand a
+// Metadata to the caller.
+//
+// The serialization format MUST stay byte-compatible with
+// MM::CameraImageMetadata (which is part of the versioned Device
+// Interface) and must be parseable by Metadata::Restore. If you change the
+// format here, change it there too.
+//
+// This class deliberately does not depend on the Metadata class: callers
+// hand the buffer to Metadata::Restore via View() at retrieval time.
+class SerializedMetadata {
+public:
+   SerializedMetadata() { Clear(); }
+
+   // Adopt the contents of an existing serialized blob (as produced by
+   // MM::CameraImageMetadata::Serialize(), this class's View(), or
+   // Metadata::Serialize()). A null or empty pointer is treated as "empty".
+   explicit SerializedMetadata(const char* serialized) {
+      AdoptSerialized(serialized);
+   }
+
+   void Clear() {
+      buffer_.assign(kCountWidth, ' ');
+      buffer_.push_back('\n');
+      count_ = 0;
+   }
+
+   template <typename V>
+   void AddTag(const char* key, V value) {
+      assert(key != nullptr);
+      std::ostringstream strm;
+      strm << value;
+      AppendTag(key, strm.str().c_str());
+   }
+
+   void AddTag(const char* key, const char* value) {
+      assert(key != nullptr);
+      assert(value != nullptr);
+      AppendTag(key, value);
+   }
+
+   template <typename V>
+   void AddTag(const std::string& key, V value) {
+      AddTag(key.c_str(), value);
+   }
+
+   bool HasTag(const char* key) const {
+      return FindTagValue(key).first != std::string_view::npos;
+   }
+
+   // Returns the value of the (last) tag matching key, or std::nullopt.
+   // The returned view is valid until the next mutation of this object.
+   std::optional<std::string_view> GetTag(const char* key) const {
+      auto pos = FindTagValue(key);
+      if (pos.first == std::string_view::npos)
+         return std::nullopt;
+      return std::string_view(buffer_.data() + pos.first,
+                              pos.second - pos.first);
+   }
+
+   // Append the tag records from another serialized blob (as produced by
+   // MM::CameraImageMetadata::Serialize, this class, or Metadata::Serialize).
+   // The other blob's count header is parsed and added to this object's
+   // count; its records are appended verbatim.
+   void AppendSerialized(const char* otherSerialized) {
+      if (otherSerialized == nullptr)
+         return;
+      const char* nl = std::strchr(otherSerialized, '\n');
+      if (nl == nullptr)
+         return;
+      const std::size_t otherCount =
+         static_cast<std::size_t>(std::atol(otherSerialized));
+      buffer_.append(nl + 1);
+      count_ += otherCount;
+   }
+
+   // Returns a view of the buffer in the serialized wire format. The
+   // returned view is valid until this object is mutated or destroyed.
+   std::string_view View() const {
+      WriteCountHeader();
+      return buffer_;
+   }
+
+private:
+   static constexpr std::size_t kCountWidth =
+      std::numeric_limits<std::size_t>::digits10 + 1;
+
+   void AppendTag(const char* key, const char* value) {
+      buffer_ += "s\n";
+      buffer_ += key;
+      buffer_ += "\n_\n1\n";
+      buffer_ += value;
+      buffer_ += '\n';
+      ++count_;
+   }
+
+   void AdoptSerialized(const char* serialized) {
+      if (serialized == nullptr || serialized[0] == '\0') {
+         Clear();
+         return;
+      }
+      const char* nl = std::strchr(serialized, '\n');
+      if (nl == nullptr) {
+         Clear();
+         return;
+      }
+      count_ = static_cast<std::size_t>(std::atol(serialized));
+      buffer_.assign(kCountWidth, ' ');
+      buffer_.push_back('\n');
+      buffer_.append(nl + 1);
+   }
+
+   void WriteCountHeader() const {
+      const std::string s = std::to_string(count_);
+      assert(s.size() <= kCountWidth);
+      auto out = std::copy(s.begin(), s.end(), buffer_.begin());
+      std::fill(out, buffer_.begin() + kCountWidth, ' ');
+   }
+
+   // Locate the value bytes of the tag with the given key. Returns
+   // (begin, end) byte offsets within buffer_, or (npos, npos) if not
+   // found. If a key occurs multiple times, returns the last occurrence
+   // (matches Metadata::Restore's "last wins" behavior).
+   std::pair<std::size_t, std::size_t>
+   FindTagValue(const char* key) const {
+      const std::size_t keyLen = std::strlen(key);
+      const std::string_view buf(buffer_);
+      const std::size_t headerEnd = kCountWidth + 1;
+      std::size_t pos = headerEnd;
+      std::pair<std::size_t, std::size_t> last = {std::string_view::npos,
+                                                  std::string_view::npos};
+      while (pos < buf.size()) {
+         // Each record starts with "s\n".
+         if (buf.compare(pos, 2, "s\n") != 0)
+            break;
+         std::size_t nameStart = pos + 2;
+         std::size_t nameEnd = buf.find('\n', nameStart);
+         if (nameEnd == std::string_view::npos)
+            break;
+         std::size_t deviceStart = nameEnd + 1;
+         std::size_t deviceEnd = buf.find('\n', deviceStart);
+         if (deviceEnd == std::string_view::npos)
+            break;
+         std::size_t roEnd = buf.find('\n', deviceEnd + 1);
+         if (roEnd == std::string_view::npos)
+            break;
+         std::size_t valueStart = roEnd + 1;
+         std::size_t valueEnd = buf.find('\n', valueStart);
+         if (valueEnd == std::string_view::npos)
+            break;
+
+         const bool nameMatches = (nameEnd - nameStart) == keyLen &&
+            buf.compare(nameStart, keyLen, key, keyLen) == 0;
+         const bool isImageTag = (deviceEnd - deviceStart) == 1 &&
+            buf[deviceStart] == '_';
+         if (nameMatches && isImageTag)
+            last = {valueStart, valueEnd};
+
+         pos = valueEnd + 1;
+      }
+      return last;
+   }
+
+   mutable std::string buffer_;
+   std::size_t count_ = 0;
+};
+
+} // namespace internal
+} // namespace mmcore

--- a/MMCore/unittest/SerializedMetadata-Tests.cpp
+++ b/MMCore/unittest/SerializedMetadata-Tests.cpp
@@ -1,0 +1,127 @@
+#include <catch2/catch_all.hpp>
+
+#include "CameraImageMetadata.h"
+#include "ImageMetadata.h"
+#include "SerializedMetadata.h"
+
+#include <string>
+
+using mmcore::internal::SerializedMetadata;
+
+namespace {
+bool RestoreFromView(Metadata& md, std::string_view view) {
+   return md.Restore(std::string(view).c_str());
+}
+} // namespace
+
+TEST_CASE("Empty SerializedMetadata round-trips through Metadata::Restore") {
+   SerializedMetadata sm;
+   Metadata md;
+   REQUIRE(RestoreFromView(md, sm.View()));
+   CHECK(md.GetKeys().empty());
+}
+
+TEST_CASE("AddTag values are visible after Metadata::Restore") {
+   SerializedMetadata sm;
+   sm.AddTag("Greeting", "hello");
+   sm.AddTag("IntVal", 42);
+   sm.AddTag("FloatVal", 3.5);
+
+   Metadata md;
+   REQUIRE(RestoreFromView(md, sm.View()));
+   CHECK(md.GetSingleTag("Greeting").GetValue() == "hello");
+   CHECK(md.GetSingleTag("IntVal").GetValue() == "42");
+   CHECK(md.GetSingleTag("FloatVal").GetValue() == "3.5");
+   CHECK(md.GetKeys().size() == 3);
+}
+
+TEST_CASE("Construction from CameraImageMetadata blob preserves tags") {
+   MM::CameraImageMetadata cim;
+   cim.AddTag("A", "1");
+   cim.AddTag("B", "two");
+
+   SerializedMetadata sm(cim.Serialize());
+   sm.AddTag("C", "three");
+
+   Metadata md;
+   REQUIRE(RestoreFromView(md, sm.View()));
+   CHECK(md.GetSingleTag("A").GetValue() == "1");
+   CHECK(md.GetSingleTag("B").GetValue() == "two");
+   CHECK(md.GetSingleTag("C").GetValue() == "three");
+   CHECK(md.GetKeys().size() == 3);
+}
+
+TEST_CASE("Construction from null or empty produces empty buffer") {
+   SerializedMetadata smNull(nullptr);
+   SerializedMetadata smEmpty("");
+   Metadata md;
+   REQUIRE(RestoreFromView(md, smNull.View()));
+   CHECK(md.GetKeys().empty());
+   REQUIRE(RestoreFromView(md, smEmpty.View()));
+   CHECK(md.GetKeys().empty());
+}
+
+TEST_CASE("HasTag and GetTag find added tags") {
+   SerializedMetadata sm;
+   sm.AddTag("foo", "1");
+   sm.AddTag("bar", "two");
+
+   CHECK(sm.HasTag("foo"));
+   CHECK(sm.HasTag("bar"));
+   CHECK_FALSE(sm.HasTag("baz"));
+
+   REQUIRE(sm.GetTag("foo").has_value());
+   CHECK(*sm.GetTag("foo") == "1");
+   REQUIRE(sm.GetTag("bar").has_value());
+   CHECK(*sm.GetTag("bar") == "two");
+   CHECK_FALSE(sm.GetTag("baz").has_value());
+}
+
+TEST_CASE("HasTag does not match substrings of keys or values") {
+   SerializedMetadata sm;
+   sm.AddTag("foobar", "value");
+   sm.AddTag("other", "containsfoo");
+
+   CHECK(sm.HasTag("foobar"));
+   CHECK_FALSE(sm.HasTag("foo"));
+   CHECK_FALSE(sm.HasTag("bar"));
+   CHECK_FALSE(sm.HasTag("contains"));
+}
+
+TEST_CASE("GetTag returns the last occurrence for duplicate keys") {
+   SerializedMetadata sm;
+   sm.AddTag("k", "first");
+   sm.AddTag("k", "second");
+   sm.AddTag("k", "third");
+
+   REQUIRE(sm.GetTag("k").has_value());
+   CHECK(*sm.GetTag("k") == "third");
+}
+
+TEST_CASE("AppendSerialized merges tags and updates the count") {
+   MM::CameraImageMetadata cim;
+   cim.AddTag("X", "1");
+   cim.AddTag("Y", "2");
+
+   SerializedMetadata sm;
+   sm.AddTag("A", "a");
+   sm.AppendSerialized(cim.Serialize());
+
+   Metadata md;
+   REQUIRE(RestoreFromView(md, sm.View()));
+   CHECK(md.GetSingleTag("A").GetValue() == "a");
+   CHECK(md.GetSingleTag("X").GetValue() == "1");
+   CHECK(md.GetSingleTag("Y").GetValue() == "2");
+   CHECK(md.GetKeys().size() == 3);
+}
+
+TEST_CASE("AppendSerialized handles a null pointer") {
+   SerializedMetadata sm;
+   sm.AddTag("A", "a");
+   sm.AppendSerialized(nullptr);
+
+   Metadata md;
+   REQUIRE(RestoreFromView(md, sm.View()));
+   CHECK(md.GetSingleTag("A").GetValue() == "a");
+   CHECK(md.GetKeys().size() == 1);
+}

--- a/MMCore/unittest/meson.build
+++ b/MMCore/unittest/meson.build
@@ -26,6 +26,7 @@ mmcore_test_sources = files(
     'Notification-Tests.cpp',
     'PixelSize-Tests.cpp',
     'SequenceAcquisition-Tests.cpp',
+    'SerializedMetadata-Tests.cpp',
     'StubDevices-Tests.cpp',
     'UnloadDevice-Tests.cpp',
 )


### PR DESCRIPTION
Instead of converting to `Metadata` (internally `std::map`) during image insertion, keep it in serialized form until the last minute: convert to `Metadata` only if the application retrieves it.

Use a new `SerializedMetadata` class for this. It largely duplicates MMDevice's `CameraImageMetadata` class, but adds querying and merging capabilities and can be customized as needed for MMCore's own use.

- Further decouples `CircularBuffer` from metadata format (now the buffer just has a `std::string` slot for metadata).

- Removes use of the `Metadata` class from MMCore internals. That class has multiple issues, and it is now only kept for API compatibility.

- Avoids `std::map` manipulation, which involves a lot of allocations and pointer following (which is cache-unfriendly). I have not measured performance, and it won't matter for large images, but it might be an advantage for high-frame-rate, small images.

In serialized form, querying the tags requires a linear search. But this is likely faster than `std::map` when the number of keys is small, and we only query it a couple of times during image insertion. Making copies of the serialized form should be much faster than copying a `std::map`.

More important than any potential performance gains is the fact that now the internals of MMCore do not need to be tied to the way in which we expose metadata to the API.

No behavioral changes are expected.