### PR TITLE
CircularBuffer cleanup

### DIFF
--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -208,7 +208,7 @@ const unsigned char* CircularBuffer::GetTopImage() const
 {
    const FrameBuffer* img = GetNthFromTopImageBuffer(0);
    if (!img)
-      return 0;
+      return nullptr;
    return img->GetPixels();
 }
 
@@ -223,7 +223,7 @@ const FrameBuffer* CircularBuffer::GetNthFromTopImageBuffer(std::size_t n) const
 
    const std::size_t availableImages = insertIndex_ - saveIndex_;
    if (n >= availableImages)
-      return 0;
+      return nullptr;
 
    const std::size_t targetIndex = (insertIndex_ - n - 1) % frameArray_.size();
    return &frameArray_[targetIndex];
@@ -233,7 +233,7 @@ const unsigned char* CircularBuffer::GetNextImage()
 {
    const FrameBuffer* img = GetNextImageBuffer();
    if (!img)
-      return 0;
+      return nullptr;
    return img->GetPixels();
 }
 
@@ -242,7 +242,7 @@ const FrameBuffer* CircularBuffer::GetNextImageBuffer()
    std::lock_guard<std::mutex> guard(bufferLock_);
 
    if (insertIndex_ == saveIndex_)
-      return 0;
+      return nullptr;
 
    const std::size_t targetIndex = saveIndex_ % frameArray_.size();
    ++saveIndex_;

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -166,7 +166,7 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
     (void)nComponents;
     std::lock_guard<std::mutex> insertGuard(insertLock_);
 
-    ImgBuffer* pImg;
+    FrameBuffer* pImg;
     unsigned long singleChannelSize = (unsigned long)width * height * byteDepth;
 
     {
@@ -194,9 +194,9 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
 
    pImg->SetSerializedMetadata(serializedMetadata);
 
-   // TODO: In MMCore the ImgBuffer::GetPixels() returns const pointer.
-   //       It would be better to have something like ImgBuffer::GetPixelsRW() in MMDevice.
-   //       Or even better - pass tasksMemCopy_ to ImgBuffer constructor
+   // TODO: In MMCore the FrameBuffer::GetPixels() returns const pointer.
+   //       It would be better to have something like FrameBuffer::GetPixelsRW() in MMDevice.
+   //       Or even better - pass tasksMemCopy_ to FrameBuffer constructor
    //       and utilize parallel copy also in single snap acquisitions.
    tasksMemCopy_->MemCopy((void*)pImg->GetPixels(),
          pixArray, singleChannelSize);
@@ -220,23 +220,23 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
 
 const unsigned char* CircularBuffer::GetTopImage() const
 {
-   const ImgBuffer* img = GetNthFromTopImageBuffer(0, 0);
+   const FrameBuffer* img = GetNthFromTopImageBuffer(0, 0);
    if (!img)
       return 0;
    return img->GetPixels();
 }
 
-const ImgBuffer* CircularBuffer::GetTopImageBuffer(unsigned channel) const
+const FrameBuffer* CircularBuffer::GetTopImageBuffer(unsigned channel) const
 {
    return GetNthFromTopImageBuffer(0, channel);
 }
 
-const ImgBuffer* CircularBuffer::GetNthFromTopImageBuffer(unsigned long n) const
+const FrameBuffer* CircularBuffer::GetNthFromTopImageBuffer(unsigned long n) const
 {
    return GetNthFromTopImageBuffer(static_cast<long>(n), 0);
 }
 
-const ImgBuffer* CircularBuffer::GetNthFromTopImageBuffer(long n,
+const FrameBuffer* CircularBuffer::GetNthFromTopImageBuffer(long n,
       unsigned channel) const
 {
    if (channel > 0)
@@ -258,13 +258,13 @@ const ImgBuffer* CircularBuffer::GetNthFromTopImageBuffer(long n,
 
 const unsigned char* CircularBuffer::GetNextImage()
 {
-   const ImgBuffer* img = GetNextImageBuffer(0);
+   const FrameBuffer* img = GetNextImageBuffer(0);
    if (!img)
       return 0;
    return img->GetPixels();
 }
 
-const ImgBuffer* CircularBuffer::GetNextImageBuffer(unsigned channel)
+const FrameBuffer* CircularBuffer::GetNextImageBuffer(unsigned channel)
 {
    if (channel > 0)
       return nullptr;

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -48,7 +48,6 @@ CircularBuffer::CircularBuffer(unsigned int memorySizeMB) :
    width_(0), 
    height_(0), 
    pixDepth_(0), 
-   imageCounter_(0), 
    insertIndex_(0), 
    saveIndex_(0), 
    overflow_(false),
@@ -203,7 +202,6 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
    {
       std::lock_guard<std::mutex> guard(bufferLock_);
 
-      imageCounter_++;
       insertIndex_++;
       if ((insertIndex_ - (long)frameArray_.size()) > adjustThreshold && (saveIndex_- (long)frameArray_.size()) > adjustThreshold)
       {

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -157,13 +157,12 @@ unsigned long CircularBuffer::GetRemainingImageCount() const
 }
 
 /**
-* Inserts a single image, possibly with multiple components, in the buffer.
+* Inserts a single image in the buffer.
 */
 bool CircularBuffer::InsertImage(const unsigned char* pixArray,
-   unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents,
+   unsigned int width, unsigned int height, unsigned int byteDepth,
    std::string_view serializedMetadata) MMCORE_LEGACY_THROW(CMMError)
 {
-    (void)nComponents;
     std::lock_guard<std::mutex> insertGuard(insertLock_);
 
     FrameBuffer* pImg;

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -31,25 +31,25 @@
 
 #include "DeviceUtils.h"
 
+#include <cstddef>
+#include <limits>
 #include <memory>
 
 namespace mmcore {
 namespace internal {
 
-const long long bytesInMB = 1 << 20;
-const long adjustThreshold = LONG_MAX / 2;
+constexpr std::size_t bytesInMB = 1 << 20;
+constexpr std::size_t adjustThreshold = std::numeric_limits<std::size_t>::max() / 2;
 
 // Maximum number of images allowed in the buffer. This arbitrary limit is code
 // smell, but kept for now until careful checks for integer overflow and
 // division by zero can be added.
-const unsigned long maxCBSize = 10000000;
+constexpr std::size_t maxCBSize = 10000000;
 
-CircularBuffer::CircularBuffer(unsigned int memorySizeMB) :
-   width_(0), 
-   height_(0), 
-   pixDepth_(0), 
-   insertIndex_(0), 
-   saveIndex_(0), 
+CircularBuffer::CircularBuffer(std::size_t memorySizeMB) :
+   frameSize_(0),
+   insertIndex_(0),
+   saveIndex_(0),
    overflow_(false),
    overwriteData_(false),
    memorySizeMB_(memorySizeMB),
@@ -66,23 +66,20 @@ int CircularBuffer::SetOverwriteData(bool overwrite) {
    return DEVICE_OK;
 }
 
-bool CircularBuffer::Initialize(unsigned int w, unsigned int h, unsigned int pixDepth)
+bool CircularBuffer::Initialize(std::size_t frameSize)
 {
    std::lock_guard<std::mutex> guard(bufferLock_);
 
    bool ret = true;
    try
    {
-      if (w == 0 || h==0 || pixDepth == 0)
-         return false; // does not make sense
+      if (frameSize == 0)
+         return false;
 
-      if (w == width_ && height_ == h && pixDepth_ == pixDepth)
-         if (frameArray_.size() > 0)
-            return true; // nothing to change
+      if (frameSize == frameSize_ && frameArray_.size() > 0)
+         return true;
 
-      width_ = w;
-      height_ = h;
-      pixDepth_ = pixDepth;
+      frameSize_ = frameSize;
 
       insertIndex_ = 0;
       saveIndex_ = 0;
@@ -91,26 +88,23 @@ bool CircularBuffer::Initialize(unsigned int w, unsigned int h, unsigned int pix
       // calculate the size of the entire buffer array once all images get allocated
       // the actual size at the time of the creation is going to be less, because
       // images are not allocated until pixels become available
-      unsigned long frameSizeBytes = width_ * height_ * pixDepth_;
-      unsigned long cbSize = (unsigned long) ((memorySizeMB_ * bytesInMB) / frameSizeBytes);
+      std::size_t cbSize = (memorySizeMB_ * bytesInMB) / frameSize_;
 
-      if (cbSize == 0) 
+      if (cbSize == 0)
       {
          frameArray_.resize(0);
          return false; // memory footprint too small
       }
 
-      // set a reasonable limit to circular buffer capacity 
       if (cbSize > maxCBSize)
-         cbSize = maxCBSize; 
+         cbSize = maxCBSize;
 
       // TODO: verify if we have enough RAM to satisfy this request
 
       // allocate buffers  - could conceivably throw an out-of-memory exception
       frameArray_.resize(cbSize);
-      const auto frameSiz = std::size_t(w) * std::size_t(h) * pixDepth;
-      for (unsigned long i=0; i<frameArray_.size(); i++)
-         frameArray_[i].Resize(frameSiz);
+      for (std::size_t i = 0; i < frameArray_.size(); i++)
+         frameArray_[i].Resize(frameSize_);
    }
 
    catch( ... /* std::bad_alloc& ex */)
@@ -134,39 +128,34 @@ void CircularBuffer::ClearLocked()
    overflow_ = false;
 }
 
-unsigned long CircularBuffer::GetSize() const
+std::size_t CircularBuffer::GetSize() const
 {
    std::lock_guard<std::mutex> guard(bufferLock_);
-   return (unsigned long)frameArray_.size();
+   return frameArray_.size();
 }
 
-unsigned long CircularBuffer::GetFreeSize() const
+std::size_t CircularBuffer::GetFreeSize() const
 {
    std::lock_guard<std::mutex> guard(bufferLock_);
-   long freeSize = (long)frameArray_.size() - (insertIndex_ - saveIndex_);
-   if (freeSize < 0)
-      return 0;
-   else
-      return (unsigned long)freeSize;
+   return frameArray_.size() - (insertIndex_ - saveIndex_);
 }
 
-unsigned long CircularBuffer::GetRemainingImageCount() const
+std::size_t CircularBuffer::GetRemainingImageCount() const
 {
    std::lock_guard<std::mutex> guard(bufferLock_);
-   return (unsigned long)(insertIndex_ - saveIndex_);
+   return insertIndex_ - saveIndex_;
 }
 
 /**
 * Inserts a single image in the buffer.
 */
 bool CircularBuffer::InsertImage(const unsigned char* pixArray,
-   unsigned int width, unsigned int height, unsigned int byteDepth,
+   std::size_t frameSize,
    std::string_view serializedMetadata) MMCORE_LEGACY_THROW(CMMError)
 {
     std::lock_guard<std::mutex> insertGuard(insertLock_);
 
     FrameBuffer* pImg;
-    unsigned long singleChannelSize = (unsigned long)width * height * byteDepth;
 
     {
        std::lock_guard<std::mutex> guard(bufferLock_);
@@ -174,11 +163,10 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
        if (overflow_)
           return false;
 
-       // check image dimensions
-       if (width != width_ || height != height_ || byteDepth != pixDepth_)
-          throw CMMError("Incompatible image dimensions in the circular buffer", MMERR_CircularBufferIncompatibleImage);
+       if (frameSize != frameSize_)
+          throw CMMError("Incompatible image size in the circular buffer", MMERR_CircularBufferIncompatibleImage);
 
-       bool overflowed = (insertIndex_ - saveIndex_) >= static_cast<long>(frameArray_.size());
+       bool overflowed = (insertIndex_ - saveIndex_) >= frameArray_.size();
        if (overflowed) {
          if (overwriteData_) {
             ClearLocked();
@@ -197,18 +185,18 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
    //       It would be better to have something like FrameBuffer::GetPixelsRW() in MMDevice.
    //       Or even better - pass tasksMemCopy_ to FrameBuffer constructor
    //       and utilize parallel copy also in single snap acquisitions.
-   tasksMemCopy_->MemCopy((void*)pImg->GetPixels(),
-         pixArray, singleChannelSize);
+   tasksMemCopy_->MemCopy((void*)pImg->GetPixels(), pixArray, frameSize);
 
    {
       std::lock_guard<std::mutex> guard(bufferLock_);
 
       insertIndex_++;
-      if ((insertIndex_ - (long)frameArray_.size()) > adjustThreshold && (saveIndex_- (long)frameArray_.size()) > adjustThreshold)
+      // Periodically rebase indices to keep them from growing without bound.
+      if (insertIndex_ > frameArray_.size() + adjustThreshold &&
+          saveIndex_  > frameArray_.size() + adjustThreshold)
       {
-         // adjust buffer indices to avoid overflowing integer size
          insertIndex_ -= adjustThreshold;
-         saveIndex_ -= adjustThreshold;
+         saveIndex_   -= adjustThreshold;
       }
    }
 
@@ -229,20 +217,15 @@ const FrameBuffer* CircularBuffer::GetTopImageBuffer() const
    return GetNthFromTopImageBuffer(0);
 }
 
-const FrameBuffer* CircularBuffer::GetNthFromTopImageBuffer(unsigned long n) const
+const FrameBuffer* CircularBuffer::GetNthFromTopImageBuffer(std::size_t n) const
 {
    std::lock_guard<std::mutex> guard(bufferLock_);
 
-   const long ln = static_cast<long>(n);
-   long availableImages = insertIndex_ - saveIndex_;
-   if (ln + 1 > availableImages)
+   const std::size_t availableImages = insertIndex_ - saveIndex_;
+   if (n >= availableImages)
       return 0;
 
-   long targetIndex = insertIndex_ - ln - 1L;
-   while (targetIndex < 0)
-      targetIndex += (long) frameArray_.size();
-   targetIndex %= frameArray_.size();
-
+   const std::size_t targetIndex = (insertIndex_ - n - 1) % frameArray_.size();
    return &frameArray_[targetIndex];
 }
 
@@ -258,11 +241,10 @@ const FrameBuffer* CircularBuffer::GetNextImageBuffer()
 {
    std::lock_guard<std::mutex> guard(bufferLock_);
 
-   long availableImages = insertIndex_ - saveIndex_;
-   if (availableImages < 1)
+   if (insertIndex_ == saveIndex_)
       return 0;
 
-   long targetIndex = saveIndex_ % frameArray_.size();
+   const std::size_t targetIndex = saveIndex_ % frameArray_.size();
    ++saveIndex_;
    return &frameArray_[targetIndex];
 }

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -107,16 +107,10 @@ bool CircularBuffer::Initialize(unsigned int w, unsigned int h, unsigned int pix
 
       // TODO: verify if we have enough RAM to satisfy this request
 
-      for (unsigned long i=0; i<frameArray_.size(); i++)
-         frameArray_[i].Clear();
-
       // allocate buffers  - could conceivably throw an out-of-memory exception
       frameArray_.resize(cbSize);
       for (unsigned long i=0; i<frameArray_.size(); i++)
-      {
          frameArray_[i].Resize(w, h, pixDepth);
-         frameArray_[i].Preallocate();
-      }
    }
 
    catch( ... /* std::bad_alloc& ex */)
@@ -195,10 +189,7 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
          }
        }
 
-       // we assume that all buffers are pre-allocated
-       pImg = frameArray_[insertIndex_ % frameArray_.size()].FindImage(0);
-       if (!pImg)
-          return false;
+       pImg = &frameArray_[insertIndex_ % frameArray_.size()];
     }
 
    pImg->SetSerializedMetadata(serializedMetadata);
@@ -248,6 +239,9 @@ const ImgBuffer* CircularBuffer::GetNthFromTopImageBuffer(unsigned long n) const
 const ImgBuffer* CircularBuffer::GetNthFromTopImageBuffer(long n,
       unsigned channel) const
 {
+   if (channel > 0)
+      return nullptr;
+
    std::lock_guard<std::mutex> guard(bufferLock_);
 
    long availableImages = insertIndex_ - saveIndex_;
@@ -259,7 +253,7 @@ const ImgBuffer* CircularBuffer::GetNthFromTopImageBuffer(long n,
       targetIndex += (long) frameArray_.size();
    targetIndex %= frameArray_.size();
 
-   return frameArray_[targetIndex].FindImage(channel);
+   return &frameArray_[targetIndex];
 }
 
 const unsigned char* CircularBuffer::GetNextImage()
@@ -272,6 +266,9 @@ const unsigned char* CircularBuffer::GetNextImage()
 
 const ImgBuffer* CircularBuffer::GetNextImageBuffer(unsigned channel)
 {
+   if (channel > 0)
+      return nullptr;
+
    std::lock_guard<std::mutex> guard(bufferLock_);
 
    long availableImages = insertIndex_ - saveIndex_;
@@ -280,7 +277,7 @@ const ImgBuffer* CircularBuffer::GetNextImageBuffer(unsigned channel)
 
    long targetIndex = saveIndex_ % frameArray_.size();
    ++saveIndex_;
-   return frameArray_[targetIndex].FindImage(channel);
+   return &frameArray_[targetIndex];
 }
 
 } // namespace internal

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -31,9 +31,11 @@
 
 #include "DeviceUtils.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <new>
 
 namespace mmcore {
 namespace internal {
@@ -70,49 +72,42 @@ bool CircularBuffer::Initialize(std::size_t frameSize)
 {
    std::lock_guard<std::mutex> guard(bufferLock_);
 
-   bool ret = true;
+   overflow_ = false;
+   insertIndex_ = 0;
+   saveIndex_ = 0;
+
    try
    {
       if (frameSize == 0)
+      {
+         frameSize_ = 0;
          return false;
+      }
 
-      if (frameSize == frameSize_ && frameArray_.size() > 0)
-         return true;
-
-      frameSize_ = frameSize;
-
-      insertIndex_ = 0;
-      saveIndex_ = 0;
-      overflow_ = false;
-
-      // calculate the size of the entire buffer array once all images get allocated
-      // the actual size at the time of the creation is going to be less, because
-      // images are not allocated until pixels become available
-      std::size_t cbSize = (memorySizeMB_ * bytesInMB) / frameSize_;
+      const std::size_t cbSize = std::min(maxCBSize,
+         (memorySizeMB_ * bytesInMB) / frameSize);
 
       if (cbSize == 0)
       {
+         frameSize_ = frameSize;
          frameArray_.resize(0);
          return false; // memory footprint too small
       }
 
-      if (cbSize > maxCBSize)
-         cbSize = maxCBSize;
+      if (frameSize == frameSize_ && frameArray_.size() == cbSize)
+         return true;
 
-      // TODO: verify if we have enough RAM to satisfy this request
-
-      // allocate buffers  - could conceivably throw an out-of-memory exception
+      frameSize_ = frameSize;
       frameArray_.resize(cbSize);
-      for (std::size_t i = 0; i < frameArray_.size(); i++)
-         frameArray_[i].Resize(frameSize_);
+      for (auto& frameBuf : frameArray_)
+         frameBuf.Resize(frameSize_);
+      return true;
    }
-
-   catch( ... /* std::bad_alloc& ex */)
+   catch (std::bad_alloc&)
    {
       frameArray_.resize(0);
-      ret = false;
+      return false;
    }
-   return ret;
 }
 
 void CircularBuffer::Clear()

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -108,8 +108,9 @@ bool CircularBuffer::Initialize(unsigned int w, unsigned int h, unsigned int pix
 
       // allocate buffers  - could conceivably throw an out-of-memory exception
       frameArray_.resize(cbSize);
+      const auto frameSiz = std::size_t(w) * std::size_t(h) * pixDepth;
       for (unsigned long i=0; i<frameArray_.size(); i++)
-         frameArray_[i].Resize(w, h, pixDepth);
+         frameArray_[i].Resize(frameSiz);
    }
 
    catch( ... /* std::bad_alloc& ex */)

--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -220,35 +220,27 @@ bool CircularBuffer::InsertImage(const unsigned char* pixArray,
 
 const unsigned char* CircularBuffer::GetTopImage() const
 {
-   const FrameBuffer* img = GetNthFromTopImageBuffer(0, 0);
+   const FrameBuffer* img = GetNthFromTopImageBuffer(0);
    if (!img)
       return 0;
    return img->GetPixels();
 }
 
-const FrameBuffer* CircularBuffer::GetTopImageBuffer(unsigned channel) const
+const FrameBuffer* CircularBuffer::GetTopImageBuffer() const
 {
-   return GetNthFromTopImageBuffer(0, channel);
+   return GetNthFromTopImageBuffer(0);
 }
 
 const FrameBuffer* CircularBuffer::GetNthFromTopImageBuffer(unsigned long n) const
 {
-   return GetNthFromTopImageBuffer(static_cast<long>(n), 0);
-}
-
-const FrameBuffer* CircularBuffer::GetNthFromTopImageBuffer(long n,
-      unsigned channel) const
-{
-   if (channel > 0)
-      return nullptr;
-
    std::lock_guard<std::mutex> guard(bufferLock_);
 
+   const long ln = static_cast<long>(n);
    long availableImages = insertIndex_ - saveIndex_;
-   if (n + 1 > availableImages)
+   if (ln + 1 > availableImages)
       return 0;
 
-   long targetIndex = insertIndex_ - n - 1L;
+   long targetIndex = insertIndex_ - ln - 1L;
    while (targetIndex < 0)
       targetIndex += (long) frameArray_.size();
    targetIndex %= frameArray_.size();
@@ -258,17 +250,14 @@ const FrameBuffer* CircularBuffer::GetNthFromTopImageBuffer(long n,
 
 const unsigned char* CircularBuffer::GetNextImage()
 {
-   const FrameBuffer* img = GetNextImageBuffer(0);
+   const FrameBuffer* img = GetNextImageBuffer();
    if (!img)
       return 0;
    return img->GetPixels();
 }
 
-const FrameBuffer* CircularBuffer::GetNextImageBuffer(unsigned channel)
+const FrameBuffer* CircularBuffer::GetNextImageBuffer()
 {
-   if (channel > 0)
-      return nullptr;
-
    std::lock_guard<std::mutex> guard(bufferLock_);
 
    long availableImages = insertIndex_ - saveIndex_;

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -57,10 +57,6 @@ public:
    unsigned long GetFreeSize() const;
    unsigned long GetRemainingImageCount() const;
 
-   unsigned int Width() const {std::lock_guard<std::mutex> guard(bufferLock_); return width_;}
-   unsigned int Height() const {std::lock_guard<std::mutex> guard(bufferLock_); return height_;}
-   unsigned int Depth() const {std::lock_guard<std::mutex> guard(bufferLock_); return pixDepth_;}
-
    bool InsertImage(const unsigned char* pixArray,
       unsigned int width, unsigned int height, unsigned int byteDepth,
       std::string_view serializedMetadata) MMCORE_LEGACY_THROW(CMMError);

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -71,7 +71,7 @@ public:
    const FrameBuffer* GetNextImageBuffer();
    void Clear(); 
 
-   bool Overflow() {std::lock_guard<std::mutex> guard(bufferLock_); return overflow_;}
+   bool Overflow() const {std::lock_guard<std::mutex> guard(bufferLock_); return overflow_;}
 
 private:
    void ClearLocked();

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -62,7 +62,7 @@ public:
    unsigned int Depth() const {std::lock_guard<std::mutex> guard(bufferLock_); return pixDepth_;}
 
    bool InsertImage(const unsigned char* pixArray,
-      unsigned int width, unsigned int height, unsigned int byteDepth, unsigned int nComponents,
+      unsigned int width, unsigned int height, unsigned int byteDepth,
       std::string_view serializedMetadata) MMCORE_LEGACY_THROW(CMMError);
    const unsigned char* GetTopImage() const;
    const unsigned char* GetNextImage();

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -86,7 +86,6 @@ private:
    unsigned int width_;
    unsigned int height_;
    unsigned int pixDepth_;
-   long imageCounter_;
 
    // Invariants:
    // 0 <= saveIndex_ <= insertIndex_

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -30,6 +30,7 @@
 
 #include "MMDevice.h"
 
+#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <string_view>
@@ -45,27 +46,26 @@ class TaskSet_CopyMemory;
 class CircularBuffer
 {
 public:
-   CircularBuffer(unsigned int memorySizeMB);
+   CircularBuffer(std::size_t memorySizeMB);
    ~CircularBuffer();
 
    int SetOverwriteData(bool overwrite);
 
-   unsigned GetMemorySizeMB() const { return memorySizeMB_; }
+   std::size_t GetMemorySizeMB() const { return memorySizeMB_; }
 
-   bool Initialize(unsigned int xSize, unsigned int ySize, unsigned int pixDepth);
-   unsigned long GetSize() const;
-   unsigned long GetFreeSize() const;
-   unsigned long GetRemainingImageCount() const;
+   bool Initialize(std::size_t frameSize);
+   std::size_t GetSize() const;
+   std::size_t GetFreeSize() const;
+   std::size_t GetRemainingImageCount() const;
 
-   bool InsertImage(const unsigned char* pixArray,
-      unsigned int width, unsigned int height, unsigned int byteDepth,
+   bool InsertImage(const unsigned char* pixArray, std::size_t frameSize,
       std::string_view serializedMetadata) MMCORE_LEGACY_THROW(CMMError);
    const unsigned char* GetTopImage() const;
    const unsigned char* GetNextImage();
    const FrameBuffer* GetTopImageBuffer() const;
-   const FrameBuffer* GetNthFromTopImageBuffer(unsigned long n) const;
+   const FrameBuffer* GetNthFromTopImageBuffer(std::size_t n) const;
    const FrameBuffer* GetNextImageBuffer();
-   void Clear(); 
+   void Clear();
 
    bool Overflow() const {std::lock_guard<std::mutex> guard(bufferLock_); return overflow_;}
 
@@ -79,22 +79,20 @@ private:
    // Guards all mutable state below except where noted.
    mutable std::mutex bufferLock_;
 
-   unsigned int width_;
-   unsigned int height_;
-   unsigned int pixDepth_;
+   std::size_t frameSize_;
 
    // Invariants:
    // 0 <= saveIndex_ <= insertIndex_
    // insertIndex_ - saveIndex_ <= frameArray_.size()
-   long insertIndex_;
-   long saveIndex_;
+   std::size_t insertIndex_;
+   std::size_t saveIndex_;
 
    bool overflow_;
    bool overwriteData_;
    std::vector<FrameBuffer> frameArray_;
 
    // Effectively const after construction.
-   unsigned long memorySizeMB_;
+   std::size_t memorySizeMB_;
    std::shared_ptr<ThreadPool> threadPool_;
    std::shared_ptr<TaskSet_CopyMemory> tasksMemCopy_;
 };

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -97,7 +97,7 @@ private:
 
    bool overflow_;
    bool overwriteData_;
-   std::vector<FrameBuffer> frameArray_;
+   std::vector<ImgBuffer> frameArray_;
 
    // Effectively const after construction.
    unsigned long memorySizeMB_;

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -66,10 +66,9 @@ public:
       std::string_view serializedMetadata) MMCORE_LEGACY_THROW(CMMError);
    const unsigned char* GetTopImage() const;
    const unsigned char* GetNextImage();
-   const FrameBuffer* GetTopImageBuffer(unsigned channel) const;
+   const FrameBuffer* GetTopImageBuffer() const;
    const FrameBuffer* GetNthFromTopImageBuffer(unsigned long n) const;
-   const FrameBuffer* GetNthFromTopImageBuffer(long n, unsigned channel) const;
-   const FrameBuffer* GetNextImageBuffer(unsigned channel);
+   const FrameBuffer* GetNextImageBuffer();
    void Clear(); 
 
    bool Overflow() {std::lock_guard<std::mutex> guard(bufferLock_); return overflow_;}

--- a/MMCore/CircularBuffer.h
+++ b/MMCore/CircularBuffer.h
@@ -66,10 +66,10 @@ public:
       std::string_view serializedMetadata) MMCORE_LEGACY_THROW(CMMError);
    const unsigned char* GetTopImage() const;
    const unsigned char* GetNextImage();
-   const ImgBuffer* GetTopImageBuffer(unsigned channel) const;
-   const ImgBuffer* GetNthFromTopImageBuffer(unsigned long n) const;
-   const ImgBuffer* GetNthFromTopImageBuffer(long n, unsigned channel) const;
-   const ImgBuffer* GetNextImageBuffer(unsigned channel);
+   const FrameBuffer* GetTopImageBuffer(unsigned channel) const;
+   const FrameBuffer* GetNthFromTopImageBuffer(unsigned long n) const;
+   const FrameBuffer* GetNthFromTopImageBuffer(long n, unsigned channel) const;
+   const FrameBuffer* GetNextImageBuffer(unsigned channel);
    void Clear(); 
 
    bool Overflow() {std::lock_guard<std::mutex> guard(bufferLock_); return overflow_;}
@@ -97,7 +97,7 @@ private:
 
    bool overflow_;
    bool overwriteData_;
-   std::vector<ImgBuffer> frameArray_;
+   std::vector<FrameBuffer> frameArray_;
 
    // Effectively const after construction.
    unsigned long memorySizeMB_;

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -317,8 +317,7 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
       {
          ip->Process(const_cast<unsigned char*>(buf), width, height, bytesPerPixel);
       }
-      if (core_->cbuf_->InsertImage(buf, width, height, bytesPerPixel, nComponents,
-            md.View()))
+      if (core_->cbuf_->InsertImage(buf, width, height, bytesPerPixel, md.View()))
          return DEVICE_OK;
       else
          return DEVICE_BUFFER_OVERFLOW;

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -317,7 +317,9 @@ int CoreCallback::InsertImage(const MM::Device* caller, const unsigned char* buf
       {
          ip->Process(const_cast<unsigned char*>(buf), width, height, bytesPerPixel);
       }
-      if (core_->cbuf_->InsertImage(buf, width, height, bytesPerPixel, md.View()))
+      if (core_->cbuf_->InsertImage(buf,
+            static_cast<std::size_t>(width) * height * bytesPerPixel,
+            md.View()))
          return DEVICE_OK;
       else
          return DEVICE_BUFFER_OVERFLOW;
@@ -339,7 +341,7 @@ bool CoreCallback::InitializeImageBuffer(unsigned channels, unsigned slices,
    if (slices != 1)
       return false;
 
-   return core_->cbuf_->Initialize(w, h, pixDepth);
+   return core_->cbuf_->Initialize(static_cast<std::size_t>(w) * h * pixDepth);
 }
 
 int CoreCallback::AcqFinished(const MM::Device* caller, int /*statusCode*/)

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -33,7 +33,6 @@
 #include "SynchronizedConfiguration.h"
 
 #include "DeviceUtils.h"
-#include "ImgBuffer.h"
 
 #include <cassert>
 #include <chrono>

--- a/MMCore/FrameBuffer.cpp
+++ b/MMCore/FrameBuffer.cpp
@@ -24,9 +24,9 @@
 namespace mmcore {
 namespace internal {
 
-FrameBuffer::FrameBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth) :
-   pixels_(new unsigned char[xSize * ySize * pixDepth]()),
-   width_(xSize), height_(ySize), pixDepth_(pixDepth)
+FrameBuffer::FrameBuffer(std::size_t size) :
+   size_(size),
+   pixels_(new unsigned char[size]())
 {
 }
 
@@ -37,20 +37,17 @@ const unsigned char* FrameBuffer::GetPixels() const
 
 void FrameBuffer::SetPixels(const void* pix)
 {
-   memcpy((void*)pixels_.get(), pix, width_ * height_ * pixDepth_);
+   memcpy(pixels_.get(), pix, size_);
 }
 
-void FrameBuffer::Resize(unsigned xSize, unsigned ySize, unsigned pixDepth)
+void FrameBuffer::Resize(std::size_t size)
 {
    // re-allocate internal buffer if it is not big enough
-   if (width_ * height_ * pixDepth_ < xSize * ySize * pixDepth)
+   if (size_ < size)
    {
-      pixels_.reset(new unsigned char[xSize * ySize * pixDepth]);
+      pixels_.reset(new unsigned char[size]());
    }
-
-   width_ = xSize;
-   height_ = ySize;
-   pixDepth_ = pixDepth;
+   size_ = size;
 }
 
 void FrameBuffer::SetSerializedMetadata(std::string_view serialized)

--- a/MMCore/FrameBuffer.cpp
+++ b/MMCore/FrameBuffer.cpp
@@ -30,8 +30,6 @@ ImgBuffer::ImgBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth) :
 {
 }
 
-ImgBuffer::~ImgBuffer() = default;
-
 const unsigned char* ImgBuffer::GetPixels() const
 {
    return pixels_.get();
@@ -72,52 +70,6 @@ void ImgBuffer::Resize(unsigned xSize, unsigned ySize)
 void ImgBuffer::SetSerializedMetadata(std::string_view serialized)
 {
    serializedMetadata_.assign(serialized);
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-// FrameBuffer class
-///////////////////////////////////////////////////////////////////////////////
-
-FrameBuffer::FrameBuffer(unsigned xSize, unsigned ySize, unsigned byteDepth)
-{
-   width_ = xSize;
-   height_ = ySize;
-   depth_ = byteDepth;
-}
-
-FrameBuffer::FrameBuffer()
-{
-   width_ = 0;
-   height_ = 0;
-   depth_ = 0;
-}
-
-void FrameBuffer::Clear()
-{
-   buffer_.reset();
-}
-
-void FrameBuffer::Preallocate()
-{
-   if (!buffer_) {
-      buffer_ = std::make_unique<ImgBuffer>(width_, height_, depth_);
-   }
-}
-
-void FrameBuffer::Resize(unsigned xSize, unsigned ySize, unsigned byteDepth)
-{
-   Clear();
-   width_ = xSize;
-   height_ = ySize;
-   depth_ = byteDepth;
-}
-
-ImgBuffer* FrameBuffer::FindImage(unsigned channel) const
-{
-   if (channel > 0)
-      return nullptr;
-   return buffer_.get();
 }
 
 } // namespace internal

--- a/MMCore/FrameBuffer.cpp
+++ b/MMCore/FrameBuffer.cpp
@@ -53,20 +53,6 @@ void FrameBuffer::Resize(unsigned xSize, unsigned ySize, unsigned pixDepth)
    pixDepth_ = pixDepth;
 }
 
-void FrameBuffer::Resize(unsigned xSize, unsigned ySize)
-{
-   // re-allocate internal buffer if it is not big enough
-   if (width_ * height_ < xSize * ySize)
-   {
-      pixels_.reset(new unsigned char[xSize * ySize * pixDepth_]);
-   }
-
-   width_ = xSize;
-   height_ = ySize;
-
-   memset(pixels_.get(), 0, width_ * height_ * pixDepth_);
-}
-
 void FrameBuffer::SetSerializedMetadata(std::string_view serialized)
 {
    serializedMetadata_.assign(serialized);

--- a/MMCore/FrameBuffer.cpp
+++ b/MMCore/FrameBuffer.cpp
@@ -24,23 +24,23 @@
 namespace mmcore {
 namespace internal {
 
-ImgBuffer::ImgBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth) :
+FrameBuffer::FrameBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth) :
    pixels_(new unsigned char[xSize * ySize * pixDepth]()),
    width_(xSize), height_(ySize), pixDepth_(pixDepth)
 {
 }
 
-const unsigned char* ImgBuffer::GetPixels() const
+const unsigned char* FrameBuffer::GetPixels() const
 {
    return pixels_.get();
 }
 
-void ImgBuffer::SetPixels(const void* pix)
+void FrameBuffer::SetPixels(const void* pix)
 {
    memcpy((void*)pixels_.get(), pix, width_ * height_ * pixDepth_);
 }
 
-void ImgBuffer::Resize(unsigned xSize, unsigned ySize, unsigned pixDepth)
+void FrameBuffer::Resize(unsigned xSize, unsigned ySize, unsigned pixDepth)
 {
    // re-allocate internal buffer if it is not big enough
    if (width_ * height_ * pixDepth_ < xSize * ySize * pixDepth)
@@ -53,7 +53,7 @@ void ImgBuffer::Resize(unsigned xSize, unsigned ySize, unsigned pixDepth)
    pixDepth_ = pixDepth;
 }
 
-void ImgBuffer::Resize(unsigned xSize, unsigned ySize)
+void FrameBuffer::Resize(unsigned xSize, unsigned ySize)
 {
    // re-allocate internal buffer if it is not big enough
    if (width_ * height_ < xSize * ySize)
@@ -67,7 +67,7 @@ void ImgBuffer::Resize(unsigned xSize, unsigned ySize)
    memset(pixels_.get(), 0, width_ * height_ * pixDepth_);
 }
 
-void ImgBuffer::SetSerializedMetadata(std::string_view serialized)
+void FrameBuffer::SetSerializedMetadata(std::string_view serialized)
 {
    serializedMetadata_.assign(serialized);
 }

--- a/MMCore/FrameBuffer.cpp
+++ b/MMCore/FrameBuffer.cpp
@@ -26,7 +26,6 @@ namespace internal {
 
 FrameBuffer::FrameBuffer(std::size_t size) :
    size_(size),
-   allocatedSize_(size),
    pixels_(new unsigned char[size]())
 {
 }
@@ -43,12 +42,13 @@ void FrameBuffer::SetPixels(const void* pix)
 
 void FrameBuffer::Resize(std::size_t size)
 {
-   if (size > allocatedSize_)
+   if (size != size_)
    {
+      // Deallocate before allocating, since these buffers can be large
+      pixels_.reset();
       pixels_.reset(new unsigned char[size]());
-      allocatedSize_ = size;
+      size_ = size;
    }
-   size_ = size;
 }
 
 void FrameBuffer::SetSerializedMetadata(std::string_view serialized)

--- a/MMCore/FrameBuffer.cpp
+++ b/MMCore/FrameBuffer.cpp
@@ -26,6 +26,7 @@ namespace internal {
 
 FrameBuffer::FrameBuffer(std::size_t size) :
    size_(size),
+   allocatedSize_(size),
    pixels_(new unsigned char[size]())
 {
 }
@@ -42,10 +43,10 @@ void FrameBuffer::SetPixels(const void* pix)
 
 void FrameBuffer::Resize(std::size_t size)
 {
-   // re-allocate internal buffer if it is not big enough
-   if (size_ < size)
+   if (size > allocatedSize_)
    {
       pixels_.reset(new unsigned char[size]());
+      allocatedSize_ = size;
    }
    size_ = size;
 }

--- a/MMCore/FrameBuffer.h
+++ b/MMCore/FrameBuffer.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -27,15 +28,13 @@ namespace internal {
 
 class FrameBuffer
 {
+   std::size_t size_ = 0;
    std::unique_ptr<unsigned char[]> pixels_;
-   unsigned int width_ = 0;
-   unsigned int height_ = 0;
-   unsigned int pixDepth_ = 0;
    std::string serializedMetadata_;
 
 public:
    FrameBuffer() = default;
-   FrameBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth);
+   FrameBuffer(std::size_t size);
 
    FrameBuffer(FrameBuffer&&) = default;
    FrameBuffer& operator=(FrameBuffer&&) = default;
@@ -45,7 +44,7 @@ public:
    void SetPixels(const void* pixArray);
    const unsigned char* GetPixels() const;
 
-   void Resize(unsigned xSize, unsigned ySize, unsigned pixDepth);
+   void Resize(std::size_t size);
 
    void SetSerializedMetadata(std::string_view serialized);
    const std::string& GetSerializedMetadata() const {

--- a/MMCore/FrameBuffer.h
+++ b/MMCore/FrameBuffer.h
@@ -29,7 +29,6 @@ namespace internal {
 class FrameBuffer
 {
    std::size_t size_ = 0;
-   std::size_t allocatedSize_ = 0;
    std::unique_ptr<unsigned char[]> pixels_;
    std::string serializedMetadata_;
 

--- a/MMCore/FrameBuffer.h
+++ b/MMCore/FrameBuffer.h
@@ -29,6 +29,7 @@ namespace internal {
 class FrameBuffer
 {
    std::size_t size_ = 0;
+   std::size_t allocatedSize_ = 0;
    std::unique_ptr<unsigned char[]> pixels_;
    std::string serializedMetadata_;
 

--- a/MMCore/FrameBuffer.h
+++ b/MMCore/FrameBuffer.h
@@ -42,14 +42,10 @@ public:
    FrameBuffer(const FrameBuffer&) = delete;
    FrameBuffer& operator=(const FrameBuffer&) = delete;
 
-   unsigned int Width() const {return width_;}
-   unsigned int Height() const {return height_;}
-   unsigned int Depth() const {return pixDepth_;}
    void SetPixels(const void* pixArray);
    const unsigned char* GetPixels() const;
 
    void Resize(unsigned xSize, unsigned ySize, unsigned pixDepth);
-   void Resize(unsigned xSize, unsigned ySize);
 
    void SetSerializedMetadata(std::string_view serialized);
    const std::string& GetSerializedMetadata() const {

--- a/MMCore/FrameBuffer.h
+++ b/MMCore/FrameBuffer.h
@@ -25,7 +25,7 @@
 namespace mmcore {
 namespace internal {
 
-class ImgBuffer
+class FrameBuffer
 {
    std::unique_ptr<unsigned char[]> pixels_;
    unsigned int width_ = 0;
@@ -34,13 +34,13 @@ class ImgBuffer
    std::string serializedMetadata_;
 
 public:
-   ImgBuffer() = default;
-   ImgBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth);
+   FrameBuffer() = default;
+   FrameBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth);
 
-   ImgBuffer(ImgBuffer&&) = default;
-   ImgBuffer& operator=(ImgBuffer&&) = default;
-   ImgBuffer(const ImgBuffer&) = delete;
-   ImgBuffer& operator=(const ImgBuffer&) = delete;
+   FrameBuffer(FrameBuffer&&) = default;
+   FrameBuffer& operator=(FrameBuffer&&) = default;
+   FrameBuffer(const FrameBuffer&) = delete;
+   FrameBuffer& operator=(const FrameBuffer&) = delete;
 
    unsigned int Width() const {return width_;}
    unsigned int Height() const {return height_;}

--- a/MMCore/FrameBuffer.h
+++ b/MMCore/FrameBuffer.h
@@ -28,14 +28,19 @@ namespace internal {
 class ImgBuffer
 {
    std::unique_ptr<unsigned char[]> pixels_;
-   unsigned int width_;
-   unsigned int height_;
-   unsigned int pixDepth_;
+   unsigned int width_ = 0;
+   unsigned int height_ = 0;
+   unsigned int pixDepth_ = 0;
    std::string serializedMetadata_;
 
 public:
+   ImgBuffer() = default;
    ImgBuffer(unsigned xSize, unsigned ySize, unsigned pixDepth);
-   ~ImgBuffer();
+
+   ImgBuffer(ImgBuffer&&) = default;
+   ImgBuffer& operator=(ImgBuffer&&) = default;
+   ImgBuffer(const ImgBuffer&) = delete;
+   ImgBuffer& operator=(const ImgBuffer&) = delete;
 
    unsigned int Width() const {return width_;}
    unsigned int Height() const {return height_;}
@@ -50,33 +55,6 @@ public:
    const std::string& GetSerializedMetadata() const {
       return serializedMetadata_;
    }
-
-private:
-   ImgBuffer& operator=(const ImgBuffer&);
-};
-
-// The FrameBuffer class wraps ImgBuffer (which is part of the MMCore API) for
-// internal use. It was also previously part of a never-completed scheme to
-// support multi-channel frames.
-class FrameBuffer
-{
-   std::unique_ptr<ImgBuffer> buffer_; // May be empty
-   unsigned int width_;
-   unsigned int height_;
-   unsigned int depth_;
-
-public:
-   FrameBuffer(unsigned xSize, unsigned ySize, unsigned byteDepth);
-   FrameBuffer();
-
-   void Resize(unsigned xSize, unsigned ySize, unsigned pixDepth);
-   void Clear();
-   void Preallocate();
-
-   ImgBuffer* FindImage(unsigned channel) const;
-   unsigned Width() const {return width_;}
-   unsigned Height() const {return height_;}
-   unsigned Depth() const {return depth_;}
 };
 
 } // namespace internal

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -3297,7 +3297,7 @@ void* CMMCore::getLastImageMD(unsigned channel, unsigned slice, Metadata& md) co
    if (slice != 0)
       throw CMMError("Slice must be 0");
 
-   const mmi::ImgBuffer* pBuf = cbuf_->GetTopImageBuffer(channel);
+   const mmi::FrameBuffer* pBuf = cbuf_->GetTopImageBuffer(channel);
    if (pBuf != 0)
    {
       md.Restore(pBuf->GetSerializedMetadata().c_str());
@@ -3338,7 +3338,7 @@ void* CMMCore::getLastImageMD(Metadata& md) const MMCORE_LEGACY_THROW(CMMError)
  */
 void* CMMCore::getNBeforeLastImageMD(unsigned long n, Metadata& md) const MMCORE_LEGACY_THROW(CMMError)
 {
-   const mmi::ImgBuffer* pBuf = cbuf_->GetNthFromTopImageBuffer(n);
+   const mmi::FrameBuffer* pBuf = cbuf_->GetNthFromTopImageBuffer(n);
    if (pBuf != 0)
    {
       md.Restore(pBuf->GetSerializedMetadata().c_str());
@@ -3383,7 +3383,7 @@ void* CMMCore::popNextImageMD(unsigned channel, unsigned slice, Metadata& md) MM
    if (slice != 0)
       throw CMMError("Slice must be 0");
 
-   const mmi::ImgBuffer* pBuf = cbuf_->GetNextImageBuffer(channel);
+   const mmi::FrameBuffer* pBuf = cbuf_->GetNextImageBuffer(channel);
    if (pBuf != 0)
    {
       md.Restore(pBuf->GetSerializedMetadata().c_str());

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -3038,15 +3038,18 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
             ,MMERR_NotAllowedDuringSequenceAcquisition);
       }
 
-		try
-		{
-			if (!cbuf_->Initialize(camera->GetImageWidth(), camera->GetImageHeight(), camera->GetImageBytesPerPixel()))
-			{
-				logError(getDeviceName(camera).c_str(), getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str());
-				throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
-			}
-			cbuf_->Clear();
-			callback_->ResetImageInsertionState();
+      try
+      {
+         if (!cbuf_->Initialize(
+               static_cast<std::size_t>(camera->GetImageWidth()) *
+               camera->GetImageHeight() *
+               camera->GetImageBytesPerPixel()))
+         {
+            logError(getDeviceName(camera).c_str(), getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str());
+            throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
+         }
+         cbuf_->Clear();
+         callback_->ResetImageInsertionState();
          cbuf_->SetOverwriteData(!stopOnOverflow);
          mmi::DeviceModuleLockGuard guard(camera);
 
@@ -3087,7 +3090,10 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
       throw CMMError(getCoreErrorText(MMERR_NotAllowedDuringSequenceAcquisition).c_str(),
                      MMERR_NotAllowedDuringSequenceAcquisition);
 
-   if (!cbuf_->Initialize(pCam->GetImageWidth(), pCam->GetImageHeight(), pCam->GetImageBytesPerPixel()))
+   if (!cbuf_->Initialize(
+         static_cast<std::size_t>(pCam->GetImageWidth()) *
+         pCam->GetImageHeight() *
+         pCam->GetImageBytesPerPixel()))
    {
       logError(getDeviceName(pCam).c_str(), getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str());
       throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
@@ -3135,7 +3141,10 @@ void CMMCore::initializeCircularBuffer() MMCORE_LEGACY_THROW(CMMError)
    if (camera)
    {
       mmi::DeviceModuleLockGuard guard(camera);
-      if (!cbuf_->Initialize(camera->GetImageWidth(), camera->GetImageHeight(), camera->GetImageBytesPerPixel()))
+      if (!cbuf_->Initialize(
+            static_cast<std::size_t>(camera->GetImageWidth()) *
+            camera->GetImageHeight() *
+            camera->GetImageBytesPerPixel()))
       {
          logError(getDeviceName(camera).c_str(), getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str());
          throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
@@ -3189,7 +3198,10 @@ void CMMCore::startContinuousSequenceAcquisition(double intervalMs) MMCORE_LEGAC
             ,MMERR_NotAllowedDuringSequenceAcquisition);
       }
 
-      if (!cbuf_->Initialize(camera->GetImageWidth(), camera->GetImageHeight(), camera->GetImageBytesPerPixel()))
+      if (!cbuf_->Initialize(
+            static_cast<std::size_t>(camera->GetImageWidth()) *
+            camera->GetImageHeight() *
+            camera->GetImageBytesPerPixel()))
       {
          logError(getDeviceName(camera).c_str(), getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str());
          throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
@@ -3442,7 +3454,10 @@ void CMMCore::setCircularBufferMemoryFootprint(unsigned sizeMB ///< n megabytes
       if (camera)
 		{
          mmi::DeviceModuleLockGuard guard(camera);
-         if (!cbuf_->Initialize(camera->GetImageWidth(), camera->GetImageHeight(), camera->GetImageBytesPerPixel()))
+         if (!cbuf_->Initialize(
+               static_cast<std::size_t>(camera->GetImageWidth()) *
+               camera->GetImageHeight() *
+               camera->GetImageBytesPerPixel()))
 				throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
          callback_->ResetImageInsertionState();
 		}

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -3297,7 +3297,7 @@ void* CMMCore::getLastImageMD(unsigned channel, unsigned slice, Metadata& md) co
    if (slice != 0)
       throw CMMError("Slice must be 0");
 
-   const mmi::FrameBuffer* pBuf = cbuf_->GetTopImageBuffer(channel);
+   const mmi::FrameBuffer* pBuf = cbuf_->GetTopImageBuffer();
    if (pBuf != 0)
    {
       md.Restore(pBuf->GetSerializedMetadata().c_str());
@@ -3383,7 +3383,7 @@ void* CMMCore::popNextImageMD(unsigned channel, unsigned slice, Metadata& md) MM
    if (slice != 0)
       throw CMMError("Slice must be 0");
 
-   const mmi::FrameBuffer* pBuf = cbuf_->GetNextImageBuffer(channel);
+   const mmi::FrameBuffer* pBuf = cbuf_->GetNextImageBuffer();
    if (pBuf != 0)
    {
       md.Restore(pBuf->GetSerializedMetadata().c_str());


### PR DESCRIPTION
- Remove vestiges of multi-channel buffering
- `ImgBuffer` subsumed into `FrameBuffer` (no more confusion with MMDevice's unrelated `ImgBuffer`)
- Remove tracking of width/height/byteDepth, use just size
- Remove dead code and unused parameters
- Use `size_t` throughout, remove `long` and casts
- Fix: reset overflow on `Initialize()` even if frame size doesn't change

This is a series of small tidy-ups. None of the fundamental issues (e.g., race conditions) are addressed here.