### PR TITLE
Rename unimplemented intervalMs param to unused

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -3022,11 +3022,17 @@ long CMMCore::getImageBufferSize()
  * Starts streaming camera sequence acquisition.
  * This command does not block the calling thread for the duration of the acquisition.
  *
- * @param numImages        Number of images requested from the camera
- * @param intervalMs       The interval between images, currently only supported by Andor cameras
- * @param stopOnOverflow   whether or not the camera stops acquiring when the circular buffer is full
+ * @param numImages       Number of images requested from the camera.
+ * @param unused          Has no effect. Pass 0.0. This parameter was
+ *                        previously named `intervalMs` but was never
+ *                        reliably implemented across camera adapters.
+ *                        Cameras that support a configurable frame rate
+ *                        typically expose it as a device property.
+ * @param stopOnOverflow  Whether the camera stops acquiring when the
+ *                        circular buffer is full. If false, frames may be
+ *                        skipped.
  */
-void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError)
+void CMMCore::startSequenceAcquisition(long numImages, double unused, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<mmi::CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -3054,7 +3060,11 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
          mmi::DeviceModuleLockGuard guard(camera);
 
          LOG_DEBUG(coreLogger_) << "Will start sequence acquisition from default camera";
-			int nRet = camera->StartSequenceAcquisition(numImages, intervalMs, stopOnOverflow);
+			// Forward `unused` to the device rather than substituting 0.0:
+			// a small number of camera adapters (Andor) did implement this
+			// parameter, and passing 0.0 unconditionally could regress them.
+			// The MM::Camera contract now says new adapters must ignore it.
+			int nRet = camera->StartSequenceAcquisition(numImages, unused, stopOnOverflow);
 			if (nRet != DEVICE_OK)
 				throw CMMError(getDeviceErrorText(nRet, camera).c_str(), MMERR_DEVICE_GENERIC);
 		}
@@ -3079,8 +3089,16 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
  * This command does not block the calling thread for the duration of the acquisition.
  * The difference between this method and the one with the same name but operating on the "default"
  * camera is that it does not automatically initialize the circular buffer.
+ *
+ * @param label            Label of the camera device.
+ * @param numImages        Number of images requested from the camera.
+ * @param unused           Has no effect. Pass 0.0. See the default-camera
+ *                         overload for details.
+ * @param stopOnOverflow   Whether the camera stops acquiring when the
+ *                         circular buffer is full. If false, frames may be
+ *                         skipped.
  */
-void CMMCore::startSequenceAcquisition(const char* label, long numImages, double intervalMs, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError)
+void CMMCore::startSequenceAcquisition(const char* label, long numImages, double unused, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<mmi::CameraInstance> pCam =
       deviceManager_->GetDeviceOfType<mmi::CameraInstance>(label);
@@ -3103,7 +3121,11 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
    cbuf_->SetOverwriteData(!stopOnOverflow);
    LOG_DEBUG(coreLogger_) <<
       "Will start sequence acquisition from camera " << label;
-   int nRet = pCam->StartSequenceAcquisition(numImages, intervalMs, stopOnOverflow);
+   // Forward `unused` to the device rather than substituting 0.0: a small
+   // number of camera adapters (Andor) did implement this parameter, and
+   // passing 0.0 unconditionally could regress them. The MM::Camera
+   // contract now says new adapters must ignore it.
+   int nRet = pCam->StartSequenceAcquisition(numImages, unused, stopOnOverflow);
    if (nRet != DEVICE_OK)
       throw CMMError(getDeviceErrorText(nRet, pCam).c_str(), MMERR_DEVICE_GENERIC);
 
@@ -3184,8 +3206,11 @@ void CMMCore::stopSequenceAcquisition(const char* label) MMCORE_LEGACY_THROW(CMM
 /**
  * Starts the continuous camera sequence acquisition.
  * This command does not block the calling thread for the duration of the acquisition.
+ *
+ * @param unused  Has no effect. Pass 0.0. See `startSequenceAcquisition` for
+ *                the history of this parameter.
  */
-void CMMCore::startContinuousSequenceAcquisition(double intervalMs) MMCORE_LEGACY_THROW(CMMError)
+void CMMCore::startContinuousSequenceAcquisition(double unused) MMCORE_LEGACY_THROW(CMMError)
 {
    std::shared_ptr<mmi::CameraInstance> camera = currentCameraDevice_.lock();
    if (camera)
@@ -3210,7 +3235,11 @@ void CMMCore::startContinuousSequenceAcquisition(double intervalMs) MMCORE_LEGAC
       callback_->ResetImageInsertionState();
       cbuf_->SetOverwriteData(true);
       LOG_DEBUG(coreLogger_) << "Will start continuous sequence acquisition from current camera";
-      int nRet = camera->StartSequenceAcquisition(intervalMs);
+      // Forward `unused` to the device rather than substituting 0.0: a small
+      // number of camera adapters (Andor) did implement this parameter, and
+      // passing 0.0 unconditionally could regress them. The MM::Camera
+      // contract now says new adapters must ignore it.
+      int nRet = camera->StartSequenceAcquisition(unused);
       if (nRet != DEVICE_OK)
          throw CMMError(getDeviceErrorText(nRet, camera).c_str(), MMERR_DEVICE_GENERIC);
    }

--- a/MMCore/MMCore.h
+++ b/MMCore/MMCore.h
@@ -425,12 +425,12 @@ public:
    void setShutterOpen(const char* shutterLabel, bool state) MMCORE_LEGACY_THROW(CMMError);
    bool getShutterOpen(const char* shutterLabel) MMCORE_LEGACY_THROW(CMMError);
 
-   void startSequenceAcquisition(long numImages, double intervalMs,
+   void startSequenceAcquisition(long numImages, double unused,
          bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError);
    void startSequenceAcquisition(const char* cameraLabel, long numImages,
-         double intervalMs, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError);
+         double unused, bool stopOnOverflow) MMCORE_LEGACY_THROW(CMMError);
    MMCORE_DEPRECATED void prepareSequenceAcquisition(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
-   void startContinuousSequenceAcquisition(double intervalMs) MMCORE_LEGACY_THROW(CMMError);
+   void startContinuousSequenceAcquisition(double unused) MMCORE_LEGACY_THROW(CMMError);
    void stopSequenceAcquisition() MMCORE_LEGACY_THROW(CMMError);
    void stopSequenceAcquisition(const char* cameraLabel) MMCORE_LEGACY_THROW(CMMError);
    bool isSequenceRunning() MMCORE_NOEXCEPT;

--- a/MMCore/unittest/SequenceAcquisition-Tests.cpp
+++ b/MMCore/unittest/SequenceAcquisition-Tests.cpp
@@ -64,12 +64,12 @@ struct SyncCamera : CCameraBase<SyncCamera> {
       return DEVICE_OK;
    }
 
-   int StartSequenceAcquisition(long, double, bool) override {
+   int StartSequenceAcquisition(long /*numImages*/, double /*unused*/, bool /*stopOnOverflow*/) override {
       capturing_ = true;
       GetCoreCallback()->PrepareForAcq(this);
       return DEVICE_OK;
    }
-   int StartSequenceAcquisition(double) override {
+   int StartSequenceAcquisition(double /*unused*/) override {
       capturing_ = true;
       GetCoreCallback()->PrepareForAcq(this);
       return DEVICE_OK;
@@ -148,7 +148,7 @@ struct AsyncCamera : CCameraBase<AsyncCamera> {
       return DEVICE_OK;
    }
 
-   int StartSequenceAcquisition(long numImages, double, bool) override {
+   int StartSequenceAcquisition(long numImages, double /*unused*/, bool /*stopOnOverflow*/) override {
       GetCoreCallback()->PrepareForAcq(this);
       {
          std::lock_guard<std::mutex> lk(mu_);
@@ -161,7 +161,7 @@ struct AsyncCamera : CCameraBase<AsyncCamera> {
       return DEVICE_OK;
    }
 
-   int StartSequenceAcquisition(double) override {
+   int StartSequenceAcquisition(double /*unused*/) override {
       GetCoreCallback()->PrepareForAcq(this);
       {
          std::lock_guard<std::mutex> lk(mu_);

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1413,9 +1413,9 @@ public:
    /**
     * @brief Start continuous sequence acquisition.
     *
-    * Default to sequence acquisition with a high number of images.
+    * See `MM::Camera::StartSequenceAcquisition` — `unused` has no effect.
     */
-   virtual int StartSequenceAcquisition(double interval) = 0;
+   virtual int StartSequenceAcquisition(double unused) = 0;
 
    /**
     * @brief Stop and wait for the thread to finish.
@@ -1484,8 +1484,10 @@ public:
 
    /**
     * @brief Start sequence acquisition.
+    *
+    * See `MM::Camera::StartSequenceAcquisition` — `unused` has no effect.
     */
-   virtual int StartSequenceAcquisition(long numImages, double interval_ms,
+   virtual int StartSequenceAcquisition(long numImages, double unused,
                               bool stopOnOverflow) = 0;
 
    virtual int GetExposureSequenceMaxLength(long& /*nrEvents*/) const
@@ -1603,11 +1605,11 @@ public:
    /**
     * @brief Start continuous sequence acquisition.
     *
-    * Default to sequence acquisition with a high number of images.
+    * See `MM::Camera::StartSequenceAcquisition` — `unused` has no effect.
     */
-   virtual int StartSequenceAcquisition(double interval)
+   virtual int StartSequenceAcquisition(double /*unused*/)
    {
-      return StartSequenceAcquisition(LONG_MAX, interval, false);
+      return StartSequenceAcquisition(LONG_MAX, 0.0, false);
    }
 
    /**
@@ -1626,8 +1628,8 @@ public:
    // Implementation of a sequence acquisition as a series of snaps
    // This was a temporary method used for debugging, which is why its now
    // implemented in this legacy class. It's preferable that camera devices
-   // inherit directly from CCameraBase and not use these default implementations.   
-   virtual int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow)
+   // inherit directly from CCameraBase and not use these default implementations.
+   virtual int StartSequenceAcquisition(long numImages, double /*unused*/, bool stopOnOverflow)
    {
       if (IsCapturing())
          return DEVICE_CAMERA_BUSY_ACQUIRING;
@@ -1635,7 +1637,7 @@ public:
       int ret = this->GetCoreCallback()->PrepareForAcq(this);
       if (ret != DEVICE_OK)
          return ret;
-      thd_->Start(numImages,interval_ms);
+      thd_->Start(numImages);
       stopWhenCBOverflows_ = stopOnOverflow;
       return DEVICE_OK;
    }
@@ -1724,11 +1726,10 @@ protected:
    class BaseSequenceThread : public MMDeviceThreadBase
    {
       friend class CLegacyCameraBase;
-      enum { default_numImages=1, default_intervalMS = 100 };
+      enum { default_numImages=1 };
    public:
       BaseSequenceThread(CLegacyCameraBase* pCam)
-         :intervalMs_(default_intervalMS)
-         ,numImages_(default_numImages)
+         :numImages_(default_numImages)
          ,imageCounter_(0)
          ,stop_(true)
          ,suspend_(false)
@@ -1745,12 +1746,11 @@ protected:
          stop_=true;
       }
 
-      void Start(long numImages, double intervalMs)
+      void Start(long numImages)
       {
          MMThreadGuard g1(this->stopLock_);
          MMThreadGuard g2(this->suspendLock_);
          numImages_=numImages;
-         intervalMs_=intervalMs;
          imageCounter_=0;
          stop_ = false;
          suspend_=false;
@@ -1775,9 +1775,7 @@ protected:
          MMThreadGuard g(this->suspendLock_);
          suspend_ = false;
       }
-      double GetIntervalMs(){return intervalMs_;}
       void SetLength(long images) {numImages_ = images;}
-      //long GetLength() const {return numImages_;}
 
       long GetImageCounter(){return imageCounter_;}
       MM::MMTime GetStartTime(){return startTime_;}
@@ -1810,7 +1808,6 @@ protected:
          return ret;
       }
    private:
-      double intervalMs_;
       long numImages_;
       long imageCounter_;
       bool stop_;

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -461,15 +461,28 @@ namespace MM {
       virtual int GetMultiROI(unsigned* xs, unsigned* ys, unsigned* widths,
               unsigned* heights, unsigned* length) = 0;
       /**
-       * @brief Start continuous acquisition.
-       */
-      virtual int StartSequenceAcquisition(long numImages, double interval_ms, bool stopOnOverflow) = 0;
-      /**
-       * @brief Start Sequence Acquisition with given interval.
+       * @brief Start sequence acquisition.
        *
-       * Most camera adapters will ignore this number.
+       * @param numImages       Number of images to acquire.
+       * @param unused          Has no effect. Implementations **must** ignore
+       *                        this parameter. Previously named `intervalMs` /
+       *                        `interval_ms`, this parameter was never
+       *                        reliably implemented. Cameras that need a
+       *                        configurable frame rate should expose it as a
+       *                        device property.
+       * @param stopOnOverflow  If true, stop acquiring when MMCore's sequence
+       *                        buffer is full; if false, overwrite old frames.
+       *                        This is handled by MMCore automatically, but
+       *                        when false, the camera is allowed to drop
+       *                        frames.
        */
-      virtual int StartSequenceAcquisition(double interval_ms) = 0;
+      virtual int StartSequenceAcquisition(long numImages, double unused, bool stopOnOverflow) = 0;
+      /**
+       * @brief Start continuous sequence acquisition.
+       *
+       * @param unused  Has no effect — see the three-argument overload.
+       */
+      virtual int StartSequenceAcquisition(double unused) = 0;
       /**
        * @brief Stop an ongoing sequence acquisition.
        */


### PR DESCRIPTION
The `intervalMs`/`interval_ms` parameter to `CMMCore::startSequenceAcquisition()` and `MM::Camera::StartSequenceAcquisition()` are not implemented in the vast majority of cameras. And frame rate control should work the same way as exposure or gain control, that is, it should be a property (or a dedicated function, or both). It doesn't make sense to have a special place for frame rate/interval only.

There is no plan to make this work for all (or most) cameras, so let's present it honestly: it's an unused parameter.

Except, of course, when its not unused:

- `Andor` (not `AndorSDK3`) does set the frame interval using this parameter (and does not have a corresponding property).
- `HamamatsuHam` appears to set up the acquisition slightly differently when interval_ms is > 0, although it does not use the value.

So, at least for now, we keep the plumbing and pass the `unused` parameter all the way to the camera device, so that behavior does not change. (Perhaps those 2 camera adapters can be updated in the future so that we can fully drop this parameter.)