### PR TITLE
Missing dashes in image tags

### DIFF
--- a/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
+++ b/DeviceAdapters/TwoPhoton/TwoPhoton.cpp
@@ -1016,11 +1016,11 @@ int BitFlowCamera::LiveThread::svc()
 		  char buf[MM::MaxStrLength];
 		  snprintf(buf, MM::MaxStrLength, "%d", i);
 		  md.AddTag(MM::g_Keyword_CameraChannelIndex, buf);
-		  md.AddTag(labelStr + MM::g_Keyword_CameraChannelIndex, buf); // compat
+		  md.AddTag(labelStr + "-" + MM::g_Keyword_CameraChannelIndex, buf); // compat
 
 		  cam_->GetChannelName(i, buf);
 		  md.AddTag(MM::g_Keyword_CameraChannelName, buf);
-		  md.AddTag(labelStr + MM::g_Keyword_CameraChannelName, buf); // compat
+		  md.AddTag(labelStr + "-" + MM::g_Keyword_CameraChannelName, buf); // compat
 
 		  ret = cam_->GetCoreCallback()->InsertImage(cam_, cam_->GetImageBuffer(i),
 			  cam_->GetImageWidth(),


### PR DESCRIPTION
Missed in 6f4c429f22ef42bc635003b416a8aeb1045374af.

This restores previous behavior.