### PR TITLE
Fix Sapphire laser power readback

### DIFF
--- a/DeviceAdapters/Sapphire/Sapphire.cpp
+++ b/DeviceAdapters/Sapphire/Sapphire.cpp
@@ -87,15 +87,18 @@ Sapphire::Sapphire(const char* name) :
    busy_(false),
    changedTime_(0.0),
 	queryToken_("?"),
-	powerSetpointToken_("P"),
+	powerSetpointToken_("SP"),
 	powerReadbackToken_("P"),
 	//CDRHToken_("CDRH"),  // if this is on, laser delays 5 SEC before turning on
    //CWToken_("CW"),
 	laserOnToken_("L"),
 	TECServoToken_("T"),
 	headSerialNoToken_("HID"),
-	headUsageHoursToken_("HH")
-	//wavelengthToken_("WAVE"),
+	headUsageHoursToken_("HH"),
+	laserDiodeCurrentToken_("C"),
+	basePlateTemperatureToken_("BT"),
+	maximumLaserPowerToken_("MAXLP"),
+	wavelengthToken_("WAVE")
 	//externalPowerControlToken_("EXT")
 
 
@@ -268,6 +271,17 @@ void Sapphire::GenerateReadOnlyIDProperties()
 {
 	CPropertyAction* pAct; 
  
+	pAct = new CPropertyAction(this, &Sapphire::OnHeadID);
+   CreateProperty("Head ID", "", MM::String, true, pAct);
+
+	pAct = new CPropertyAction(this, &Sapphire::OnHeadUsageHours);
+   CreateProperty("Head Usage Hours", "", MM::Float, true, pAct);
+
+	pAct = new CPropertyAction(this, &Sapphire::OnLaserDiodeCurrent);
+   CreateProperty("Laser Diode Current", "", MM::Float, true, pAct);
+
+	pAct = new CPropertyAction(this, &Sapphire::OnBasePlateTemperature);
+   CreateProperty("BasePlate Temperature", "", MM::Float, true, pAct);
 
    pAct = new CPropertyAction(this, &Sapphire::OnMinimumLaserPower);
    CreateProperty("Minimum Laser Power", "", MM::Float, false, pAct);
@@ -276,7 +290,7 @@ void Sapphire::GenerateReadOnlyIDProperties()
    CreateProperty("Maximum Laser Power", "", MM::Float, false, pAct);
 
 	pAct = new CPropertyAction(this, &Sapphire::OnWaveLength);
-   CreateProperty("Wavelength", "", MM::Float, false, pAct);
+   CreateProperty("Wavelength", "", MM::Float, true, pAct);
 
 
 }
@@ -386,14 +400,7 @@ int Sapphire::OnPowerSetpoint(MM::PropertyBase* pProp, MM::ActionType eAct, long
    else if (eAct == MM::AfterSet)
    {
       pProp->Get(powerSetpoint);
-		double achievedSetpoint;
-      SetPowerSetpoint(powerSetpoint, achievedSetpoint);
-		if( 0. != powerSetpoint)
-		{
-			double fractionError = fabs(achievedSetpoint - powerSetpoint) / powerSetpoint;
-			if (( 0.05 < fractionError ) && (fractionError  < 0.10))
-				pProp->Set(achievedSetpoint);
-		}
+      SetPowerSetpoint(powerSetpoint);
    }
    return HandleErrors();
 }
@@ -425,7 +432,9 @@ int Sapphire::OnHeadID(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
    {
-		pProp->Set((this->queryLaser(headSerialNoToken_)).c_str());
+		std::string svalue = this->queryLaser(headSerialNoToken_);
+		svalue = svalue.substr(0, svalue.find('.'));
+		pProp->Set(svalue.c_str());
    }
    else if (eAct == MM::AfterSet)
    {
@@ -446,6 +455,38 @@ int Sapphire::OnHeadUsageHours(MM::PropertyBase* pProp, MM::ActionType eAct)
    else if (eAct == MM::AfterSet)
    {
 			// never do anything!!
+   }
+   return HandleErrors();
+}
+
+
+int Sapphire::OnLaserDiodeCurrent(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      std::string svalue = this->queryLaser(laserDiodeCurrentToken_);
+      double dvalue = atof(svalue.c_str());
+      pProp->Set(dvalue);
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // read-only
+   }
+   return HandleErrors();
+}
+
+
+int Sapphire::OnBasePlateTemperature(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      std::string svalue = this->queryLaser(basePlateTemperatureToken_);
+      double dvalue = atof(svalue.c_str());
+      pProp->Set(dvalue);
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // read-only
    }
    return HandleErrors();
 }
@@ -526,11 +567,13 @@ int Sapphire::OnWaveLength(MM::PropertyBase* pProp, MM::ActionType eAct /* , lon
 {
    if (eAct == MM::BeforeGet)
    {
-		pProp->Set(wave_);
+		std::string svalue = this->queryLaser(wavelengthToken_);
+		double dvalue = atof(svalue.c_str());
+		pProp->Set(dvalue);
    }
    else if (eAct == MM::AfterSet)
    {
-	        pProp->Get(wave_);
+      // read-only
    }
    return HandleErrors();
 }
@@ -542,29 +585,15 @@ void Sapphire::GetPowerReadback(double& value)
 	value = atof(ans.c_str());
 }
 
-void Sapphire::SetPowerSetpoint(double requestedPowerSetpoint, double& achievedPowerSetpoint)
+void Sapphire::SetPowerSetpoint(double requestedPowerSetpoint)
 {
-	std::string result;
 	std::ostringstream setpointString;
+	std::stringstream msg;
 	// number like 100.00
 	setpointString << setprecision(5) << requestedPowerSetpoint;
-	result = this->setLaser("P", setpointString.str());
-	//compare quantized setpoint to requested setpoint
-	// the difference can be rather large
-
-	//if( 0. < requestedPowerSetpoint)
-	//{
-		achievedPowerSetpoint = atof( result.c_str());
-
-		// if device echos a setpoint more the 10% of full scale from requested setpoint, log a warning message
-		if ( this->maxlp()/10. < fabs( achievedPowerSetpoint-requestedPowerSetpoint))
-		{
-			std::ostringstream messs;
-			messs << "requested setpoint: " << requestedPowerSetpoint << " but echo setpoint is: " << achievedPowerSetpoint;
-			LogMessage(messs.str().c_str());
-		}
-	//}
-
+	msg << "P=" << setpointString.str();
+	Purge();
+	Send(msg.str());
 }
 
 void Sapphire::GetPowerSetpoint(double& value)

--- a/DeviceAdapters/Sapphire/Sapphire.cpp
+++ b/DeviceAdapters/Sapphire/Sapphire.cpp
@@ -594,6 +594,7 @@ void Sapphire::SetPowerSetpoint(double requestedPowerSetpoint)
 	msg << "P=" << setpointString.str();
 	Purge();
 	Send(msg.str());
+	CDeviceUtils::SleepMs(700);
 }
 
 void Sapphire::GetPowerSetpoint(double& value)

--- a/DeviceAdapters/Sapphire/Sapphire.h
+++ b/DeviceAdapters/Sapphire/Sapphire.h
@@ -124,13 +124,12 @@ public:
 
 	void initLimits()
 	{
-		//std::string val = queryLaser("MINLP");
-		//minlp(atof(val.c_str()));
-		minlp(0.5);
-		//val = queryLaser("MAXLP");
-		//maxlp(atof(val.c_str()));
-		maxlp(50.0);
-		wave(561.0);
+		std::string val = queryLaser("MINLP");
+		minlp(atof(val.c_str()));
+		//minlp(0.5);
+		val = queryLaser("MAXLP");
+		maxlp(atof(val.c_str()));
+		//maxlp(50.0);
 
 	}
 
@@ -169,6 +168,8 @@ public:
 	// some important read-only properties
 	int OnHeadID(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnHeadUsageHours(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnLaserDiodeCurrent(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnBasePlateTemperature(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnMinimumLaserPower(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnMaximumLaserPower(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnWaveLength(MM::PropertyBase* pProp, MM::ActionType eAct/*, long*/);
@@ -202,6 +203,9 @@ private:
 	const std::string TECServoToken_;
 	const std::string headSerialNoToken_;
 	const std::string headUsageHoursToken_;
+	const std::string laserDiodeCurrentToken_;
+	const std::string basePlateTemperatureToken_;
+	const std::string maximumLaserPowerToken_;
 	const std::string externalPowerControlToken_;
 	const std::string wavelengthToken_;
 
@@ -216,7 +220,7 @@ private:
 
 
 
-   void SetPowerSetpoint(double powerSetpoint__, double& achievedSetpoint__);
+   void SetPowerSetpoint(double powerSetpoint__);
    void GetPowerSetpoint(double& powerSetpoint__);
 	void GetPowerReadback(double& value__);
    void ReadGreeting();


### PR DESCRIPTION
The issue was reported on the forum: https://forum.image.sc/t/power-setting-readback-issue-sapphire-laser/115005?u=evdwee. I encountered the same issue when changing the laser power in Micro-Manager, the actual laser output changes correctly, but the displayed `PowerSetpoint` and `PowerReadback` values can be incorrect immediately after setting the power. For example, if the current power is 20 mW and the slider is moved to 50 mW, the laser output reaches the requested power, but the displayed value may remain close to the old output value, such as around 23 mW. Refreshing the device properties later shows the correct value.

The main cause was that `setLaser()` sent `P=<value>` and then immediately queried `?P`. Since `?P` reports actual output power, this could return a transient value while the laser was still moving toward the new setpoint. The adapter then used that transient value as the achieved PowerSetpoint. The [Sapphire OEM manual](https://acmerevival.com/wp-content/uploads/2022/10/coherent-sapphire-488-operator-s-manual-84.pdf) distinguishes `?P`, actual output power, from `?SP`, configured power setpoint. This PR uses `?SP` for `PowerSetpoint`, keeps `?P` for `PowerReadback`, and sends `P=<value>` directly when setting laser power without expecting an echo or immediately querying `?P`.

Another cause of inaccuracy is that MMStudio's property browser may refresh after `PowerSetpoint` is changed, while the laser output is still changing toward the new setpoint. This is especially noticeable after large power changes. So I add a short 700 ms delay after setting the power so that the laser has time to settle closer to the requested output.

I also add additional device information properties, including head ID, usage hours, laser diode current, baseplate temperature, maximum laser power, and wavelength.

Tested with a Coherent Sapphire 488 CW 100 mW laser and Micro-Manager_20260430. And I am happy to do some new test.