### PR TITLE
LightSheetManager: add IllumAngle to SCAPE microscope geometry

### DIFF
--- a/DeviceAdapters/LightSheetManager/MicroscopeGeometry.cpp
+++ b/DeviceAdapters/LightSheetManager/MicroscopeGeometry.cpp
@@ -109,6 +109,7 @@ void MicroscopeGeometry::CreateDeviceMap() {
                 {"TriggerLaser", MM::ShutterDevice},
                 {"IllumSlice", MM::GalvoDevice},
                 {"IllumBeam", MM::GalvoDevice}, // Skip property if "LightSheetType" is "Static"
+                {"IllumAngle", MM::StageDevice},
                 {"ImagingFocus", MM::StageDevice},
                 {"ImagingCamera", MM::CameraDevice},
                 {"PreviewCamera", MM::CameraDevice}


### PR DESCRIPTION
Add "IllumAngle" to SCAPE microscope geometry.