### PR TITLE
MMCore: speed up logging shutdown

### DIFF
--- a/MMCore/Logging/GenericPacketQueue.h
+++ b/MMCore/Logging/GenericPacketQueue.h
@@ -130,11 +130,10 @@ private:
       {
          if (timedWaitMode)
          {
-            // TODO Make interval configurable
-            std::this_thread::sleep_for(10ms);
-
             {
-               std::lock_guard<std::mutex> lock(mutex_);
+               std::unique_lock<std::mutex> lock(mutex_);
+               condVar_.wait_for(lock, 10ms,
+                  [&] { return shutdownRequested_; });
                if (shutdownRequested_)
                {
                   shutdownRequested_ = false; // Allow for restarting


### PR DESCRIPTION
Avoid the up to 10 ms sleep before logging is shut down.

Didn't matter much for regular use, but adds up in MMCore unit tests.