### PR TITLE
Zero outputs when live mode is stopped

### DIFF
--- a/DeviceAdapters/iSIMWaveforms/IDAQDevice.h
+++ b/DeviceAdapters/iSIMWaveforms/IDAQDevice.h
@@ -92,6 +92,22 @@ public:
     /// setting up a new waveform configuration.
     virtual void clearTasks() = 0;
 
+    /// Write a single constant value to each specified channel (on-demand, no timing required).
+    ///
+    /// Intended for setting outputs to a known static state (e.g., zeroing after a task stops).
+    /// Each parallel vector must have the same length.
+    ///
+    /// @param channels  Hardware channel names (e.g., "Dev1/ao0")
+    /// @param minVoltages  Per-channel minimum voltage
+    /// @param maxVoltages  Per-channel maximum voltage
+    /// @param values  Per-channel output values to write
+    virtual void writeStaticOutputs(
+        const std::vector<std::string>& channels,
+        const std::vector<double>& minVoltages,
+        const std::vector<double>& maxVoltages,
+        const std::vector<double>& values
+    ) = 0;
+
     // =========================================================================
     // Discovery methods
     // =========================================================================

--- a/DeviceAdapters/iSIMWaveforms/MockDAQAdapter.h
+++ b/DeviceAdapters/iSIMWaveforms/MockDAQAdapter.h
@@ -109,6 +109,24 @@ public:
             logger_("[MockDAQ] clearTasks()");
     }
 
+    void writeStaticOutputs(
+        const std::vector<std::string>& channels,
+        const std::vector<double>& minVoltages,
+        const std::vector<double>& maxVoltages,
+        const std::vector<double>& values
+    ) override
+    {
+        (void)minVoltages;
+        (void)maxVoltages;
+        (void)values;
+        if (logger_)
+        {
+            std::ostringstream oss;
+            oss << "[MockDAQ] writeStaticOutputs: " << channels.size() << " channels";
+            logger_(oss.str());
+        }
+    }
+
     std::vector<std::string> getDeviceNames() const override
     {
         return {"MockDev1", "MockDev2"};

--- a/DeviceAdapters/iSIMWaveforms/NIDAQmxAdapter.h
+++ b/DeviceAdapters/iSIMWaveforms/NIDAQmxAdapter.h
@@ -264,6 +264,68 @@ public:
         channelCount_ = 0;
     }
 
+    void writeStaticOutputs(
+        const std::vector<std::string>& channels,
+        const std::vector<double>& minVoltages,
+        const std::vector<double>& maxVoltages,
+        const std::vector<double>& values
+    ) override
+    {
+        if (channels.empty())
+            return;
+
+        TaskHandle tempTask = 0;
+        try
+        {
+            checkError(DAQmxCreateTask("StaticOutputTask", &tempTask));
+
+            for (size_t i = 0; i < channels.size(); ++i)
+            {
+                checkError(DAQmxCreateAOVoltageChan(
+                    tempTask,
+                    channels[i].c_str(),
+                    nullptr,
+                    minVoltages[i],
+                    maxVoltages[i],
+                    DAQmx_Val_Volts,
+                    nullptr
+                ));
+            }
+
+            // No timing configured -> on-demand (software-timed) output.
+            // autoStart=TRUE: DAQmx starts the task before writing.
+            int32 written = 0;
+            checkError(DAQmxWriteAnalogF64(
+                tempTask,
+                1,
+                TRUE,
+                10.0,
+                DAQmx_Val_GroupByChannel,
+                values.data(),
+                &written,
+                nullptr
+            ));
+
+            DAQmxStopTask(tempTask);
+            DAQmxClearTask(tempTask);
+            tempTask = 0;
+
+            if (logger_)
+            {
+                std::ostringstream oss;
+                oss << "[NIDAQmx] writeStaticOutputs: wrote " << channels.size()
+                    << " channels to static values";
+                logger_(oss.str());
+            }
+        }
+        catch (...)
+        {
+            if (tempTask != 0)
+                DAQmxClearTask(tempTask);
+            throw;
+        }
+    }
+
     std::vector<std::string> getDeviceNames() const override
     {
         int32 bufSize = DAQmxGetSysDevNames(nullptr, 0);

--- a/DeviceAdapters/iSIMWaveforms/iSIMWaveforms.cpp
+++ b/DeviceAdapters/iSIMWaveforms/iSIMWaveforms.cpp
@@ -1950,6 +1950,52 @@ int iSIMWaveforms::StartSequenceAcquisition(long numImages, double interval_ms, 
 	return DEVICE_OK;
 }
 
+void iSIMWaveforms::SetConfiguredOutputsToZero()
+{
+	if (!daq_ || channelMapping_.empty())
+		return;
+
+	// Release channel ownership from the stopped task so we can create a new on-demand task.
+	daq_->clearTasks();
+
+	// Build channel vectors from all pre-init configured channels (skip unmapped "None" entries).
+	std::vector<std::string> channels;
+	std::vector<double> minVs, maxVs, zeros;
+
+	for (const auto& entry : channelMapping_)
+	{
+		if (entry.second == "None")
+			continue;
+
+		const std::string& semantic = entry.first;
+		channels.push_back(entry.second);
+		minVs.push_back(minVoltage_.at(semantic));
+		maxVs.push_back(maxVoltage_.at(semantic));
+		zeros.push_back(0.0);
+	}
+
+	if (channels.empty())
+		return;
+
+	try
+	{
+		daq_->writeStaticOutputs(channels, minVs, maxVs, zeros);
+		LogMessage("SetConfiguredOutputsToZero: all channels set to 0V", false);
+	}
+	catch (const std::runtime_error& e)
+	{
+		LogMessage(std::string("SetConfiguredOutputsToZero error: ") + e.what(), false);
+	}
+
+	// writeStaticOutputs uses a temporary task that is cleared after writing, so daq_ now has
+	// no configured tasks. Rebuild so that the next StartWaveformOutput() call finds valid
+	// task handles. RebuildWaveforms() calls ConfigureDAQChannels() which is safe here.
+	int ret = RebuildWaveforms();
+	if (ret != DEVICE_OK)
+		LogMessage("SetConfiguredOutputsToZero: RebuildWaveforms failed (error " +
+		           std::to_string(ret) + ")", false);
+}
+
 int iSIMWaveforms::StopSequenceAcquisition()
 {
 	MM::Camera* camera = GetPhysicalCamera();
@@ -1959,8 +2005,9 @@ int iSIMWaveforms::StopSequenceAcquisition()
 	if (camera)
 		ret = camera->StopSequenceAcquisition();
 
-	// Then stop waveforms
+	// Stop waveforms, then drive all channels to 0V
 	StopWaveformOutput();
+	SetConfiguredOutputsToZero();
 
 	return ret;
 }

--- a/DeviceAdapters/iSIMWaveforms/iSIMWaveforms.h
+++ b/DeviceAdapters/iSIMWaveforms/iSIMWaveforms.h
@@ -204,6 +204,7 @@ private:
 	int BuildAndWriteWaveforms();
 	int StartWaveformOutput();
 	int StopWaveformOutput();
+	void SetConfiguredOutputsToZero();
 
 	// State
 	bool initialized_;


### PR DESCRIPTION
The iSIMWaveforms device adapter will currently leave the AOTF channels in their active state when Live mode is stopped. This is not the behavior that I intended, nor do users expect it.

This change addresses the problem by zeroing the output channels in the `StopSequenceAcquisition()` method.