### PR TITLE
DemoCamera:  Fixed DemoXYStage position reporting bugs and added a polling thread

### DIFF
--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -654,8 +654,8 @@ public:
    int OnUsesCallbacks(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
-   void StartPollingThread();
-   void StopPollingThread();
+   void StartNotificationThread();
+   void StopNotificationThread();
    // Convert internal controller-space um (steps * stepSize) to user-space um
    // (with adapter origin and mirroring applied), suitable for callbacks.
    std::pair<double, double> ControllerUmToUserUm(double x_um, double y_um);
@@ -672,18 +672,18 @@ private:
    double lowerLimit_ = 0.0;
    double upperLimit_ = 20000.0;
    MMThreadLock moveLock_;
-   std::atomic<bool> stopPollingThread_ = false;
+   std::atomic<bool> stopNotificationThread_ = false;
    bool usesCallbacks_ = true;
 
    void ComputeIntermediatePosition(const MM::MMTime& currentTime,
       double& currentPosX,
       double& currentPosY);
 
-   class PollingThread : public MMDeviceThreadBase
+   class NotificationThread : public MMDeviceThreadBase
    {
    public:
-      explicit PollingThread(CDemoXYStage* stage);
-      ~PollingThread();
+      explicit NotificationThread(CDemoXYStage* stage);
+      ~NotificationThread();
       int svc() override;
       void NotifyMoveStarted();  // wake the thread immediately when a move begins
    private:
@@ -693,7 +693,7 @@ private:
       bool                    eventSignaled_ = false;
       void WaitForMoveOrTimeout(unsigned long timeoutMs);
    };
-   PollingThread* pollingThread_ = nullptr;
+   NotificationThread* notificationThread_ = nullptr;
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -38,7 +38,9 @@
 #include <cstring>
 #include <stdint.h>
 #include <atomic>
+#include <condition_variable>
 #include <future>
+#include <mutex>
 #include <vector>
 
 //////////////////////////////////////////////////////////////////////////////
@@ -685,14 +687,10 @@ private:
       int svc() override;
       void NotifyMoveStarted();  // wake the thread immediately when a move begins
    private:
-      CDemoXYStage* stage_;
-#ifdef _WIN32
-      HANDLE moveEvent_;
-#else
-      pthread_mutex_t eventMutex_;
-      pthread_cond_t  eventCond_;
-      bool            eventSignaled_ = false;
-#endif
+      CDemoXYStage*           stage_;
+      std::mutex              eventMutex_;
+      std::condition_variable eventCond_;
+      bool                    eventSignaled_ = false;
       void WaitForMoveOrTimeout(unsigned long timeoutMs);
    };
    PollingThread* pollingThread_ = nullptr;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <cstring>
 #include <stdint.h>
+#include <atomic>
 #include <future>
 #include <vector>
 
@@ -663,7 +664,7 @@ private:
    double lowerLimit_ = 0.0;
    double upperLimit_ = 20000.0;
    MMThreadLock moveLock_;
-   bool stopPollingThread_ = false;
+   std::atomic<bool> stopPollingThread_ = false;
 
    void ComputeIntermediatePosition(const MM::MMTime& currentTime,
       double& currentPosX,

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -654,6 +654,9 @@ public:
 private:
    void StartPollingThread();
    void StopPollingThread();
+   // Convert internal controller-space um (steps * stepSize) to user-space um
+   // (with adapter origin and mirroring applied), suitable for callbacks.
+   std::pair<double, double> ControllerUmToUserUm(double x_um, double y_um);
    double stepSize_um_ = 0.015;
    double posX_um_ = 0.0;
    double posY_um_ = 0.0;

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -641,7 +641,7 @@ public:
 
    int IsXYStageSequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}
 
-   int UsesOnXYStagePositionChanged(bool& result) const { result = true; return DEVICE_OK; }
+   int UsesOnXYStagePositionChanged(bool& result) const { result = usesCallbacks_; return DEVICE_OK; }
 
    virtual int SetRelativePositionUm(double dx, double dy);
 
@@ -649,8 +649,11 @@ public:
    // ----------------
    int OnPosition(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnVelocity(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnUsesCallbacks(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
+   void StartPollingThread();
+   void StopPollingThread();
    double stepSize_um_ = 0.015;
    double posX_um_ = 0.0;
    double posY_um_ = 0.0;
@@ -665,6 +668,7 @@ private:
    double upperLimit_ = 20000.0;
    MMThreadLock moveLock_;
    std::atomic<bool> stopPollingThread_ = false;
+   bool usesCallbacks_ = true;
 
    void ComputeIntermediatePosition(const MM::MMTime& currentTime,
       double& currentPosX,

--- a/DeviceAdapters/DemoCamera/DemoCamera.h
+++ b/DeviceAdapters/DemoCamera/DemoCamera.h
@@ -642,6 +642,8 @@ public:
 
    int UsesOnXYStagePositionChanged(bool& result) const { result = true; return DEVICE_OK; }
 
+   virtual int SetRelativePositionUm(double dx, double dy);
+
    // action interface
    // ----------------
    int OnPosition(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -660,11 +662,32 @@ private:
    bool initialized_ = false;
    double lowerLimit_ = 0.0;
    double upperLimit_ = 20000.0;
+   MMThreadLock moveLock_;
+   bool stopPollingThread_ = false;
 
-   void CommitCurrentIntermediatePosition_(const MM::MMTime& now);
    void ComputeIntermediatePosition(const MM::MMTime& currentTime,
       double& currentPosX,
       double& currentPosY);
+
+   class PollingThread : public MMDeviceThreadBase
+   {
+   public:
+      explicit PollingThread(CDemoXYStage* stage);
+      ~PollingThread();
+      int svc() override;
+      void NotifyMoveStarted();  // wake the thread immediately when a move begins
+   private:
+      CDemoXYStage* stage_;
+#ifdef _WIN32
+      HANDLE moveEvent_;
+#else
+      pthread_mutex_t eventMutex_;
+      pthread_cond_t  eventCond_;
+      bool            eventSignaled_ = false;
+#endif
+      void WaitForMoveOrTimeout(unsigned long timeoutMs);
+   };
+   PollingThread* pollingThread_ = nullptr;
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/DeviceAdapters/DemoCamera/DemoImageGeneration.cpp
+++ b/DeviceAdapters/DemoCamera/DemoImageGeneration.cpp
@@ -845,7 +845,7 @@ void CDemoCamera::RenderBeadToImage(ImgBuffer& img, const Bead& bead, double blu
    }
 }
 
-void CDemoCamera::GenerateBeadsImage(ImgBuffer& img, double exposure)
+void CDemoCamera::GenerateBeadsImage(ImgBuffer& img, double /* exposure */)
 {
    if (img.Height() == 0 || img.Width() == 0 || img.Depth() == 0)
       return;

--- a/DeviceAdapters/DemoCamera/DemoStages.cpp
+++ b/DeviceAdapters/DemoCamera/DemoStages.cpp
@@ -503,6 +503,8 @@ int CDemoXYStage::Stop()
 
 void CDemoXYStage::StartPollingThread()
 {
+   if (pollingThread_ != nullptr)
+      return;  // already running; don't leak a second thread
    stopPollingThread_ = false;
    pollingThread_ = new PollingThread(this);
    pollingThread_->activate();
@@ -546,16 +548,11 @@ int CDemoXYStage::OnUsesCallbacks(MM::PropertyBase* pProp, MM::ActionType eAct)
    }
    else if (eAct == MM::AfterSet)
    {
+      if (initialized_)
+         return DEVICE_ERR;  // strictly pre-init; reject changes after initialization
       std::string val;
       pProp->Get(val);
-      bool enable = (val == "Yes");
-      if (enable == usesCallbacks_)
-         return DEVICE_OK;
-      usesCallbacks_ = enable;
-      if (enable)
-         StartPollingThread();
-      else
-         StopPollingThread();
+      usesCallbacks_ = (val == "Yes");
    }
    return DEVICE_OK;
 }

--- a/DeviceAdapters/DemoCamera/DemoStages.cpp
+++ b/DeviceAdapters/DemoCamera/DemoStages.cpp
@@ -25,9 +25,7 @@
 #include <sstream>
 #include <cmath>
 #include <algorithm>
-#ifndef _WIN32
-#include <sys/time.h>
-#endif
+#include <chrono>
 
 // External names used by the rest of the system
 extern const char* g_StageDeviceName;
@@ -559,55 +557,27 @@ int CDemoXYStage::OnUsesCallbacks(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 CDemoXYStage::PollingThread::PollingThread(CDemoXYStage* stage) : stage_(stage)
 {
-#ifdef _WIN32
-   moveEvent_ = CreateEvent(NULL, FALSE, FALSE, NULL); // auto-reset
-#else
-   pthread_mutex_init(&eventMutex_, NULL);
-   pthread_cond_init(&eventCond_, NULL);
-   eventSignaled_ = false;
-#endif
 }
 
 CDemoXYStage::PollingThread::~PollingThread()
 {
-#ifdef _WIN32
-   CloseHandle(moveEvent_);
-#else
-   pthread_cond_destroy(&eventCond_);
-   pthread_mutex_destroy(&eventMutex_);
-#endif
 }
 
 void CDemoXYStage::PollingThread::NotifyMoveStarted()
 {
-#ifdef _WIN32
-   SetEvent(moveEvent_);
-#else
-   pthread_mutex_lock(&eventMutex_);
-   eventSignaled_ = true;
-   pthread_cond_signal(&eventCond_);
-   pthread_mutex_unlock(&eventMutex_);
-#endif
+   {
+      std::lock_guard<std::mutex> lock(eventMutex_);
+      eventSignaled_ = true;
+   }
+   eventCond_.notify_one();
 }
 
 void CDemoXYStage::PollingThread::WaitForMoveOrTimeout(unsigned long timeoutMs)
 {
-#ifdef _WIN32
-   WaitForSingleObject(moveEvent_, timeoutMs);
-#else
-   struct timeval tv;
-   gettimeofday(&tv, NULL);
-   struct timespec ts;
-   ts.tv_sec  = tv.tv_sec + timeoutMs / 1000;
-   ts.tv_nsec = tv.tv_usec * 1000L + (timeoutMs % 1000) * 1000000L;
-   if (ts.tv_nsec >= 1000000000L) { ts.tv_sec++; ts.tv_nsec -= 1000000000L; }
-   pthread_mutex_lock(&eventMutex_);
-   while (!eventSignaled_)
-      if (pthread_cond_timedwait(&eventCond_, &eventMutex_, &ts) != 0)
-         break;
+   std::unique_lock<std::mutex> lock(eventMutex_);
+   eventCond_.wait_for(lock, std::chrono::milliseconds(timeoutMs),
+                       [this] { return eventSignaled_; });
    eventSignaled_ = false;
-   pthread_mutex_unlock(&eventMutex_);
-#endif
 }
 
 int CDemoXYStage::PollingThread::svc()

--- a/DeviceAdapters/DemoCamera/DemoStages.cpp
+++ b/DeviceAdapters/DemoCamera/DemoStages.cpp
@@ -316,7 +316,7 @@ int CDemoXYStage::Initialize()
    initialized_ = true;
 
    if (usesCallbacks_)
-      StartPollingThread();
+      StartNotificationThread();
 
    return DEVICE_OK;
 }
@@ -325,7 +325,7 @@ int CDemoXYStage::Shutdown()
 {
    if (initialized_)
    {
-      StopPollingThread();
+      StopNotificationThread();
       initialized_ = false;
    }
    return DEVICE_OK;
@@ -406,8 +406,8 @@ int CDemoXYStage::SetPositionSteps(long x, long y)
       return ret;
 
    // Wake the polling thread immediately so it starts reporting mid-move positions.
-   if (pollingThread_ != nullptr)
-      pollingThread_->NotifyMoveStarted();
+   if (notificationThread_ != nullptr)
+      notificationThread_->NotifyMoveStarted();
 
    return DEVICE_OK;
 }
@@ -499,24 +499,24 @@ int CDemoXYStage::Stop()
    return DEVICE_OK;
 }
 
-void CDemoXYStage::StartPollingThread()
+void CDemoXYStage::StartNotificationThread()
 {
-   if (pollingThread_ != nullptr)
+   if (notificationThread_ != nullptr)
       return;  // already running; don't leak a second thread
-   stopPollingThread_ = false;
-   pollingThread_ = new PollingThread(this);
-   pollingThread_->activate();
+   stopNotificationThread_ = false;
+   notificationThread_ = new NotificationThread(this);
+   notificationThread_->activate();
 }
 
-void CDemoXYStage::StopPollingThread()
+void CDemoXYStage::StopNotificationThread()
 {
-   if (pollingThread_ != nullptr)
+   if (notificationThread_ != nullptr)
    {
-      stopPollingThread_ = true;
-      pollingThread_->NotifyMoveStarted();  // wake thread so it sees the stop flag immediately
-      pollingThread_->wait();
-      delete pollingThread_;
-      pollingThread_ = nullptr;
+      stopNotificationThread_ = true;
+      notificationThread_->NotifyMoveStarted();  // wake thread so it sees the stop flag immediately
+      notificationThread_->wait();
+      delete notificationThread_;
+      notificationThread_ = nullptr;
    }
    // Thread is gone; commit any in-flight or expired move so posX_um_/posY_um_
    // are correct and the timer is not leaked.
@@ -555,15 +555,15 @@ int CDemoXYStage::OnUsesCallbacks(MM::PropertyBase* pProp, MM::ActionType eAct)
    return DEVICE_OK;
 }
 
-CDemoXYStage::PollingThread::PollingThread(CDemoXYStage* stage) : stage_(stage)
+CDemoXYStage::NotificationThread::NotificationThread(CDemoXYStage* stage) : stage_(stage)
 {
 }
 
-CDemoXYStage::PollingThread::~PollingThread()
+CDemoXYStage::NotificationThread::~NotificationThread()
 {
 }
 
-void CDemoXYStage::PollingThread::NotifyMoveStarted()
+void CDemoXYStage::NotificationThread::NotifyMoveStarted()
 {
    {
       std::lock_guard<std::mutex> lock(eventMutex_);
@@ -572,7 +572,7 @@ void CDemoXYStage::PollingThread::NotifyMoveStarted()
    eventCond_.notify_one();
 }
 
-void CDemoXYStage::PollingThread::WaitForMoveOrTimeout(unsigned long timeoutMs)
+void CDemoXYStage::NotificationThread::WaitForMoveOrTimeout(unsigned long timeoutMs)
 {
    std::unique_lock<std::mutex> lock(eventMutex_);
    eventCond_.wait_for(lock, std::chrono::milliseconds(timeoutMs),
@@ -580,15 +580,15 @@ void CDemoXYStage::PollingThread::WaitForMoveOrTimeout(unsigned long timeoutMs)
    eventSignaled_ = false;
 }
 
-int CDemoXYStage::PollingThread::svc()
+int CDemoXYStage::NotificationThread::svc()
 {
-   while (!stage_->stopPollingThread_)
+   while (!stage_->stopNotificationThread_)
    {
       // When idle, sleep up to 1 s — NotifyMoveStarted() wakes us immediately.
       WaitForMoveOrTimeout(1000);
 
       // Drive position callbacks for the duration of the move.
-      while (!stage_->stopPollingThread_)
+      while (!stage_->stopNotificationThread_)
       {
          double posX = 0.0, posY = 0.0;
          bool report = false;

--- a/DeviceAdapters/DemoCamera/DemoStages.cpp
+++ b/DeviceAdapters/DemoCamera/DemoStages.cpp
@@ -261,6 +261,11 @@ CDemoXYStage::CDemoXYStage()
 
    // parent ID display
    CreateHubIDProperty();
+
+   CPropertyAction* pAct = new CPropertyAction(this, &CDemoXYStage::OnUsesCallbacks);
+   CreateStringProperty("UsesCallbacks", "Yes", false, pAct, true);
+   AddAllowedValue("UsesCallbacks", "Yes");
+   AddAllowedValue("UsesCallbacks", "No");
 }
 
 CDemoXYStage::~CDemoXYStage()
@@ -306,20 +311,14 @@ int CDemoXYStage::Initialize()
    if (ret != DEVICE_OK)
       return ret;
 
-   pAct = new CPropertyAction(this, &CDemoXYStage::OnUsesCallbacks);
-   ret = CreateStringProperty("UsesCallbacks", "Yes", false, pAct);
-   if (ret != DEVICE_OK)
-      return ret;
-   AddAllowedValue("UsesCallbacks", "Yes");
-   AddAllowedValue("UsesCallbacks", "No");
-
    ret = UpdateStatus();
    if (ret != DEVICE_OK)
       return ret;
 
    initialized_ = true;
 
-   StartPollingThread();
+   if (usesCallbacks_)
+      StartPollingThread();
 
    return DEVICE_OK;
 }
@@ -340,6 +339,13 @@ bool CDemoXYStage::Busy()
    if (timeOutTimer_ == nullptr)
       return false;
    return !timeOutTimer_->expired(GetCurrentMMTime());
+}
+
+std::pair<double, double> CDemoXYStage::ControllerUmToUserUm(double x_um, double y_um)
+{
+   long xSteps = (long)(x_um / stepSize_um_);
+   long ySteps = (long)(y_um / stepSize_um_);
+   return ConvertPositionStepsToUm(xSteps, ySteps);
 }
 
 int CDemoXYStage::SetPositionSteps(long x, long y)
@@ -395,8 +401,9 @@ int CDemoXYStage::SetPositionSteps(long x, long y)
       startY = startPosY_um_;
    }
 
-   // Notify listeners of the starting position (as an acknowledgement).
-   int ret = OnXYStagePositionChanged(startX, startY);
+   // Notify listeners of the starting position in user/adapter coordinates.
+   auto userStart = ControllerUmToUserUm(startX, startY);
+   int ret = OnXYStagePositionChanged(userStart.first, userStart.second);
    if (ret != DEVICE_OK)
       return ret;
 
@@ -489,7 +496,8 @@ int CDemoXYStage::Stop()
       posY = posY_um_;
    }
    // Call outside the lock to avoid re-entrancy issues with the core callback.
-   (void)OnXYStagePositionChanged(posX, posY);
+   auto userPos = ControllerUmToUserUm(posX, posY);
+   (void)OnXYStagePositionChanged(userPos.first, userPos.second);
    return DEVICE_OK;
 }
 
@@ -509,6 +517,24 @@ void CDemoXYStage::StopPollingThread()
       pollingThread_->wait();
       delete pollingThread_;
       pollingThread_ = nullptr;
+   }
+   // Thread is gone; commit any in-flight or expired move so posX_um_/posY_um_
+   // are correct and the timer is not leaked.
+   {
+      MMThreadGuard guard(moveLock_);
+      if (timeOutTimer_ != nullptr)
+      {
+         MM::MMTime now = GetCurrentMMTime();
+         if (!timeOutTimer_->expired(now))
+            ComputeIntermediatePosition(now, posX_um_, posY_um_);
+         else
+         {
+            posX_um_ = targetPosX_um_;
+            posY_um_ = targetPosY_um_;
+         }
+         delete timeOutTimer_;
+         timeOutTimer_ = nullptr;
+      }
    }
 }
 
@@ -626,7 +652,10 @@ int CDemoXYStage::PollingThread::svc()
          }
 
          if (report)
-            (void)stage_->OnXYStagePositionChanged(posX, posY);
+         {
+            auto userPos = stage_->ControllerUmToUserUm(posX, posY);
+            (void)stage_->OnXYStagePositionChanged(userPos.first, userPos.second);
+         }
 
          if (!moving)
             break;  // move finished; go back to waiting for the next one

--- a/DeviceAdapters/DemoCamera/DemoStages.cpp
+++ b/DeviceAdapters/DemoCamera/DemoStages.cpp
@@ -309,6 +309,10 @@ int CDemoXYStage::Initialize()
 
    initialized_ = true;
 
+   stopPollingThread_ = false;
+   pollingThread_ = new PollingThread(this);
+   pollingThread_->activate();
+
    return DEVICE_OK;
 }
 
@@ -316,6 +320,13 @@ int CDemoXYStage::Shutdown()
 {
    if (initialized_)
    {
+      stopPollingThread_ = true;
+      if (pollingThread_ != nullptr)
+      {
+         pollingThread_->wait();
+         delete pollingThread_;
+         pollingThread_ = nullptr;
+      }
       initialized_ = false;
    }
    return DEVICE_OK;
@@ -323,14 +334,10 @@ int CDemoXYStage::Shutdown()
 
 bool CDemoXYStage::Busy()
 {
-   if (timeOutTimer_ == 0)
+   MMThreadGuard guard(moveLock_);
+   if (timeOutTimer_ == nullptr)
       return false;
-   if (timeOutTimer_->expired(GetCurrentMMTime()))
-   {
-      // delete(timeOutTimer_);
-      return false;
-   }
-   return true;
+   return !timeOutTimer_->expired(GetCurrentMMTime());
 }
 
 int CDemoXYStage::SetPositionSteps(long x, long y)
@@ -339,48 +346,61 @@ int CDemoXYStage::SetPositionSteps(long x, long y)
    double newTargetX = x * stepSize_um_;
    double newTargetY = y * stepSize_um_;
 
-   // If a move is in progress, compute the intermediate position and cancel the old move.
-   if (timeOutTimer_ != nullptr && !timeOutTimer_->expired(currentTime))
+   double startX, startY;
    {
-      double currentPosX, currentPosY;
-      ComputeIntermediatePosition(currentTime, currentPosX, currentPosY);
-      startPosX_um_ = currentPosX;
-      startPosY_um_ = currentPosY;
-      delete timeOutTimer_;
-      timeOutTimer_ = nullptr;
+      MMThreadGuard guard(moveLock_);
+
+      // If a move is in progress, compute the intermediate position and cancel the old move.
+      if (timeOutTimer_ != nullptr && !timeOutTimer_->expired(currentTime))
+      {
+         double currentPosX, currentPosY;
+         ComputeIntermediatePosition(currentTime, currentPosX, currentPosY);
+         startPosX_um_ = currentPosX;
+         startPosY_um_ = currentPosY;
+         delete timeOutTimer_;
+         timeOutTimer_ = nullptr;
+      }
+      else
+      {
+         // No move in progress; start from the last settled position.
+         startPosX_um_ = posX_um_;
+         startPosY_um_ = posY_um_;
+      }
+
+      // Set the new target.
+      targetPosX_um_ = newTargetX;
+      targetPosY_um_ = newTargetY;
+
+      // Calculate the distance and determine the move duration (in ms)
+      double difX = targetPosX_um_ - startPosX_um_;
+      double difY = targetPosY_um_ - startPosY_um_;
+      double distance = sqrt((difX * difX) + (difY * difY));
+      moveDuration_ms_ = (long)(distance / velocity_);
+      if (moveDuration_ms_ < 1)
+         moveDuration_ms_ = 1;  // enforce a minimum duration
+
+      moveStartTime_ = currentTime;
+      timeOutTimer_ = new MM::TimeoutMs(currentTime, moveDuration_ms_);
+
+      startX = startPosX_um_;
+      startY = startPosY_um_;
    }
-   else
-   {
-      // No move in progress; start from the last settled position.
-      startPosX_um_ = posX_um_;
-      startPosY_um_ = posY_um_;
-   }
 
-   // Set the new target.
-   targetPosX_um_ = newTargetX;
-   targetPosY_um_ = newTargetY;
-
-   // Calculate the distance and determine the move duration (in ms)
-   double difX = targetPosX_um_ - startPosX_um_;
-   double difY = targetPosY_um_ - startPosY_um_;
-   double distance = sqrt((difX * difX) + (difY * difY));
-   moveDuration_ms_ = (long)(distance / velocity_);
-   if (moveDuration_ms_ < 1)
-      moveDuration_ms_ = 1;  // enforce a minimum duration
-
-   moveStartTime_ = currentTime;
-   timeOutTimer_ = new MM::TimeoutMs(currentTime, moveDuration_ms_);
-
-   // Optionally, notify listeners of the starting position (as an acknowledgement)
-   int ret = OnXYStagePositionChanged(startPosX_um_, startPosY_um_);
+   // Notify listeners of the starting position (as an acknowledgement).
+   int ret = OnXYStagePositionChanged(startX, startY);
    if (ret != DEVICE_OK)
       return ret;
+
+   // Wake the polling thread immediately so it starts reporting mid-move positions.
+   if (pollingThread_ != nullptr)
+      pollingThread_->NotifyMoveStarted();
 
    return DEVICE_OK;
 }
 
 int CDemoXYStage::GetPositionSteps(long& x, long& y)
 {
+   MMThreadGuard guard(moveLock_);
    MM::MMTime currentTime = GetCurrentMMTime();
    if (timeOutTimer_ != nullptr && !timeOutTimer_->expired(currentTime))
    {
@@ -413,8 +433,21 @@ int CDemoXYStage::SetRelativePositionSteps(long x, long y)
    return this->SetPositionSteps(xSteps+x, ySteps+y);
 }
 
-// currentTime: the current time
-// currentPosX, currentPosY: output parameters for the computed position in microns
+int CDemoXYStage::SetRelativePositionUm(double dx, double dy)
+{
+   // The base-class xPos_/yPos_ cache is set to the target immediately on
+   // SetPositionUm, so it cannot be used for relative moves during a move.
+   // Route through GetPositionSteps to get the true interpolated position.
+   long xSteps, ySteps;
+   int ret = GetPositionSteps(xSteps, ySteps);
+   if (ret != DEVICE_OK)
+      return ret;
+   double currentX = xSteps * stepSize_um_;
+   double currentY = ySteps * stepSize_um_;
+   return SetPositionUm(currentX + dx, currentY + dy);
+}
+
+// Must be called with moveLock_ held.
 void CDemoXYStage::ComputeIntermediatePosition(
    const MM::MMTime& currentTime, double& currentPosX, double& currentPosY)
 {
@@ -426,24 +459,125 @@ void CDemoXYStage::ComputeIntermediatePosition(
    currentPosY = startPosY_um_ + fraction * (targetPosY_um_ - startPosY_um_);
 }
 
-void CDemoXYStage::CommitCurrentIntermediatePosition_(const MM::MMTime& now)
-{
-   if (timeOutTimer_ && !timeOutTimer_->expired(now))
-   {
-      // freeze where we *are* now
-      ComputeIntermediatePosition(now, posX_um_, posY_um_);
-      (void)OnXYStagePositionChanged(posX_um_, posY_um_);
-   }
-   // Drop the timer so Busy() instantly goes idle
-   delete timeOutTimer_;
-   timeOutTimer_ = nullptr;
-}
-
 int CDemoXYStage::Stop()
 {
-   MM::MMTime now = GetCurrentMMTime();
-   CommitCurrentIntermediatePosition_(now);
+   double posX, posY;
+   {
+      MMThreadGuard guard(moveLock_);
+      MM::MMTime now = GetCurrentMMTime();
+      if (timeOutTimer_ && !timeOutTimer_->expired(now))
+         ComputeIntermediatePosition(now, posX_um_, posY_um_);
+      delete timeOutTimer_;
+      timeOutTimer_ = nullptr;
+      posX = posX_um_;
+      posY = posY_um_;
+   }
+   // Call outside the lock to avoid re-entrancy issues with the core callback.
+   (void)OnXYStagePositionChanged(posX, posY);
    return DEVICE_OK;
+}
+
+CDemoXYStage::PollingThread::PollingThread(CDemoXYStage* stage) : stage_(stage)
+{
+#ifdef _WIN32
+   moveEvent_ = CreateEvent(NULL, FALSE, FALSE, NULL); // auto-reset
+#else
+   pthread_mutex_init(&eventMutex_, NULL);
+   pthread_cond_init(&eventCond_, NULL);
+   eventSignaled_ = false;
+#endif
+}
+
+CDemoXYStage::PollingThread::~PollingThread()
+{
+#ifdef _WIN32
+   CloseHandle(moveEvent_);
+#else
+   pthread_cond_destroy(&eventCond_);
+   pthread_mutex_destroy(&eventMutex_);
+#endif
+}
+
+void CDemoXYStage::PollingThread::NotifyMoveStarted()
+{
+#ifdef _WIN32
+   SetEvent(moveEvent_);
+#else
+   pthread_mutex_lock(&eventMutex_);
+   eventSignaled_ = true;
+   pthread_cond_signal(&eventCond_);
+   pthread_mutex_unlock(&eventMutex_);
+#endif
+}
+
+void CDemoXYStage::PollingThread::WaitForMoveOrTimeout(unsigned long timeoutMs)
+{
+#ifdef _WIN32
+   WaitForSingleObject(moveEvent_, timeoutMs);
+#else
+   struct timeval tv;
+   gettimeofday(&tv, NULL);
+   struct timespec ts;
+   ts.tv_sec  = tv.tv_sec + timeoutMs / 1000;
+   ts.tv_nsec = tv.tv_usec * 1000L + (timeoutMs % 1000) * 1000000L;
+   if (ts.tv_nsec >= 1000000000L) { ts.tv_sec++; ts.tv_nsec -= 1000000000L; }
+   pthread_mutex_lock(&eventMutex_);
+   while (!eventSignaled_)
+      if (pthread_cond_timedwait(&eventCond_, &eventMutex_, &ts) != 0)
+         break;
+   eventSignaled_ = false;
+   pthread_mutex_unlock(&eventMutex_);
+#endif
+}
+
+int CDemoXYStage::PollingThread::svc()
+{
+   while (!stage_->stopPollingThread_)
+   {
+      // When idle, sleep up to 1 s — NotifyMoveStarted() wakes us immediately.
+      WaitForMoveOrTimeout(1000);
+
+      // Drive position callbacks for the duration of the move.
+      while (!stage_->stopPollingThread_)
+      {
+         double posX = 0.0, posY = 0.0;
+         bool report = false;
+         bool moving = false;
+
+         {
+            MMThreadGuard guard(stage_->moveLock_);
+            if (stage_->timeOutTimer_ != nullptr)
+            {
+               MM::MMTime now = stage_->GetCurrentMMTime();
+               if (!stage_->timeOutTimer_->expired(now))
+               {
+                  stage_->ComputeIntermediatePosition(now, posX, posY);
+                  moving = true;
+               }
+               else
+               {
+                  // Move just completed — snap to target and fire one final callback.
+                  stage_->posX_um_ = stage_->targetPosX_um_;
+                  stage_->posY_um_ = stage_->targetPosY_um_;
+                  delete stage_->timeOutTimer_;
+                  stage_->timeOutTimer_ = nullptr;
+                  posX = stage_->posX_um_;
+                  posY = stage_->posY_um_;
+               }
+               report = true;
+            }
+         }
+
+         if (report)
+            (void)stage_->OnXYStagePositionChanged(posX, posY);
+
+         if (!moving)
+            break;  // move finished; go back to waiting for the next one
+
+         CDeviceUtils::SleepMs(50);
+      }
+   }
+   return 0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/DeviceAdapters/DemoCamera/DemoStages.cpp
+++ b/DeviceAdapters/DemoCamera/DemoStages.cpp
@@ -306,15 +306,20 @@ int CDemoXYStage::Initialize()
    if (ret != DEVICE_OK)
       return ret;
 
+   pAct = new CPropertyAction(this, &CDemoXYStage::OnUsesCallbacks);
+   ret = CreateStringProperty("UsesCallbacks", "Yes", false, pAct);
+   if (ret != DEVICE_OK)
+      return ret;
+   AddAllowedValue("UsesCallbacks", "Yes");
+   AddAllowedValue("UsesCallbacks", "No");
+
    ret = UpdateStatus();
    if (ret != DEVICE_OK)
       return ret;
 
    initialized_ = true;
 
-   stopPollingThread_ = false;
-   pollingThread_ = new PollingThread(this);
-   pollingThread_->activate();
+   StartPollingThread();
 
    return DEVICE_OK;
 }
@@ -323,14 +328,7 @@ int CDemoXYStage::Shutdown()
 {
    if (initialized_)
    {
-      stopPollingThread_ = true;
-      if (pollingThread_ != nullptr)
-      {
-         pollingThread_->NotifyMoveStarted();  // wake thread so it sees the stop flag immediately
-         pollingThread_->wait();
-         delete pollingThread_;
-         pollingThread_ = nullptr;
-      }
+      StopPollingThread();
       initialized_ = false;
    }
    return DEVICE_OK;
@@ -354,13 +352,20 @@ int CDemoXYStage::SetPositionSteps(long x, long y)
    {
       MMThreadGuard guard(moveLock_);
 
-      // If a move is in progress, compute the intermediate position and cancel the old move.
-      if (timeOutTimer_ != nullptr && !timeOutTimer_->expired(currentTime))
+      // Determine the current position to use as the start of the new move.
+      if (timeOutTimer_ != nullptr)
       {
-         double currentPosX, currentPosY;
-         ComputeIntermediatePosition(currentTime, currentPosX, currentPosY);
-         startPosX_um_ = currentPosX;
-         startPosY_um_ = currentPosY;
+         if (!timeOutTimer_->expired(currentTime))
+         {
+            // Move still in progress: interpolate current position.
+            ComputeIntermediatePosition(currentTime, startPosX_um_, startPosY_um_);
+         }
+         else
+         {
+            // Move completed but posX_um_/posY_um_ not yet updated (e.g. no polling).
+            startPosX_um_ = posX_um_ = targetPosX_um_;
+            startPosY_um_ = posY_um_ = targetPosY_um_;
+         }
          delete timeOutTimer_;
          timeOutTimer_ = nullptr;
       }
@@ -485,6 +490,47 @@ int CDemoXYStage::Stop()
    }
    // Call outside the lock to avoid re-entrancy issues with the core callback.
    (void)OnXYStagePositionChanged(posX, posY);
+   return DEVICE_OK;
+}
+
+void CDemoXYStage::StartPollingThread()
+{
+   stopPollingThread_ = false;
+   pollingThread_ = new PollingThread(this);
+   pollingThread_->activate();
+}
+
+void CDemoXYStage::StopPollingThread()
+{
+   if (pollingThread_ != nullptr)
+   {
+      stopPollingThread_ = true;
+      pollingThread_->NotifyMoveStarted();  // wake thread so it sees the stop flag immediately
+      pollingThread_->wait();
+      delete pollingThread_;
+      pollingThread_ = nullptr;
+   }
+}
+
+int CDemoXYStage::OnUsesCallbacks(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(usesCallbacks_ ? "Yes" : "No");
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      std::string val;
+      pProp->Get(val);
+      bool enable = (val == "Yes");
+      if (enable == usesCallbacks_)
+         return DEVICE_OK;
+      usesCallbacks_ = enable;
+      if (enable)
+         StartPollingThread();
+      else
+         StopPollingThread();
+   }
    return DEVICE_OK;
 }
 

--- a/DeviceAdapters/DemoCamera/DemoStages.cpp
+++ b/DeviceAdapters/DemoCamera/DemoStages.cpp
@@ -25,6 +25,9 @@
 #include <sstream>
 #include <cmath>
 #include <algorithm>
+#ifndef _WIN32
+#include <sys/time.h>
+#endif
 
 // External names used by the rest of the system
 extern const char* g_StageDeviceName;
@@ -323,6 +326,7 @@ int CDemoXYStage::Shutdown()
       stopPollingThread_ = true;
       if (pollingThread_ != nullptr)
       {
+         pollingThread_->NotifyMoveStarted();  // wake thread so it sees the stop flag immediately
          pollingThread_->wait();
          delete pollingThread_;
          pollingThread_ = nullptr;
@@ -435,15 +439,14 @@ int CDemoXYStage::SetRelativePositionSteps(long x, long y)
 
 int CDemoXYStage::SetRelativePositionUm(double dx, double dy)
 {
-   // The base-class xPos_/yPos_ cache is set to the target immediately on
-   // SetPositionUm, so it cannot be used for relative moves during a move.
-   // Route through GetPositionSteps to get the true interpolated position.
-   long xSteps, ySteps;
-   int ret = GetPositionSteps(xSteps, ySteps);
+   // GetPositionUm routes through GetPositionSteps + ConvertPositionStepsToUm,
+   // so it returns the true interpolated position in adapter/user coordinates
+   // (with origin and mirroring applied), matching the coordinate space that
+   // SetPositionUm expects.
+   double currentX, currentY;
+   int ret = GetPositionUm(currentX, currentY);
    if (ret != DEVICE_OK)
       return ret;
-   double currentX = xSteps * stepSize_um_;
-   double currentY = ySteps * stepSize_um_;
    return SetPositionUm(currentX + dx, currentY + dy);
 }
 
@@ -465,10 +468,18 @@ int CDemoXYStage::Stop()
    {
       MMThreadGuard guard(moveLock_);
       MM::MMTime now = GetCurrentMMTime();
-      if (timeOutTimer_ && !timeOutTimer_->expired(now))
-         ComputeIntermediatePosition(now, posX_um_, posY_um_);
-      delete timeOutTimer_;
-      timeOutTimer_ = nullptr;
+      if (timeOutTimer_ != nullptr)
+      {
+         if (!timeOutTimer_->expired(now))
+            ComputeIntermediatePosition(now, posX_um_, posY_um_);
+         else
+         {
+            posX_um_ = targetPosX_um_;
+            posY_um_ = targetPosY_um_;
+         }
+         delete timeOutTimer_;
+         timeOutTimer_ = nullptr;
+      }
       posX = posX_um_;
       posY = posY_um_;
    }


### PR DESCRIPTION
Polling thread fires OnXYStagePositionChanged callbacks during moves. The thread now wakes immediately when a move starts via a condition variable.