### PR TITLE
SpinnakerC: Fix bits-per-pixel query

### DIFF
--- a/DeviceAdapters/SpinnakerC/SpinnakerCCamera.cpp
+++ b/DeviceAdapters/SpinnakerC/SpinnakerCCamera.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <sstream>
 
@@ -863,14 +864,22 @@ int64_t SpinnakerCCamera::getPixelFormatEnumValue() const
    return val;
 }
 
-int64_t SpinnakerCCamera::getPixelSizeEnumValue() const
+int SpinnakerCCamera::getPixelSizeBits() const
 {
    spinNodeHandle hNode = nullptr;
    if (getNodeHandle(NODE_PIXEL_SIZE, &hNode) != SPINNAKER_ERR_SUCCESS)
+   {
+      LogMessage("PixelSize node not available; cannot determine bit depth");
       return -1;
-   int64_t val = -1;
-   getEnumIntValue(hNode, val);
-   return val;
+   }
+   std::string sym;
+   if (getEnumSymbolic(hNode, sym) != SPINNAKER_ERR_SUCCESS ||
+       sym.compare(0, 3, "Bpp") != 0)
+   {
+      LogMessage("Unexpected PixelSize value: '" + sym + "'");
+      return -1;
+   }
+   return std::atoi(sym.c_str() + 3);   // "Bpp12" -> 12
 }
 
 
@@ -1013,33 +1022,10 @@ unsigned SpinnakerCCamera::GetImageBytesPerPixel() const
    if (pixFmt == PixelFormat_RGB8 || pixFmt == PixelFormat_RGB8Packed || pixFmt == PixelFormat_BGRa8)
       return 4;
 
-   int64_t pixSize = getPixelSizeEnumValue();
-   switch (pixSize)
-   {
-   case PixelSize_Bpp1:
-   case PixelSize_Bpp2:
-   case PixelSize_Bpp4:
-   case PixelSize_Bpp8:
-      return 1;
-   case PixelSize_Bpp10:
-   case PixelSize_Bpp12:
-   case PixelSize_Bpp14:
-   case PixelSize_Bpp16:
-      return 2;
-   case PixelSize_Bpp20:
-   case PixelSize_Bpp24:
-      return 3;
-   case PixelSize_Bpp30:
-   case PixelSize_Bpp32:
-      return 4;
-   case PixelSize_Bpp48:
-      return 6;
-   case PixelSize_Bpp64:
-      return 8;
-   case PixelSize_Bpp96:
-      return 12;
-   }
-   return 0;
+   int bits = getPixelSizeBits();
+   if (bits <= 0)
+      return 2;                  // fallback: assume 16-bit (warning already logged)
+   return static_cast<unsigned>((bits + 7) / 8);
 }
 
 unsigned SpinnakerCCamera::GetNumberOfComponents() const
@@ -1056,26 +1042,10 @@ unsigned SpinnakerCCamera::GetBitDepth() const
    if (pixFmt == PixelFormat_RGB8 || pixFmt == PixelFormat_RGB8Packed || pixFmt == PixelFormat_BGRa8)
       return 8;
 
-   int64_t pixSize = getPixelSizeEnumValue();
-   switch (pixSize)
-   {
-   case PixelSize_Bpp1:  return 1;
-   case PixelSize_Bpp2:  return 2;
-   case PixelSize_Bpp4:  return 4;
-   case PixelSize_Bpp8:  return 8;
-   case PixelSize_Bpp10: return 10;
-   case PixelSize_Bpp12: return 12;
-   case PixelSize_Bpp14: return 14;
-   case PixelSize_Bpp16: return 16;
-   case PixelSize_Bpp20: return 20;
-   case PixelSize_Bpp24: return 24;
-   case PixelSize_Bpp30: return 30;
-   case PixelSize_Bpp32: return 32;
-   case PixelSize_Bpp48: return 48;
-   case PixelSize_Bpp64: return 64;
-   case PixelSize_Bpp96: return 96;
-   }
-   return 0;
+   int bits = getPixelSizeBits();
+   if (bits <= 0)
+      return 16;
+   return static_cast<unsigned>(bits);
 }
 
 long SpinnakerCCamera::GetImageBufferSize() const

--- a/DeviceAdapters/SpinnakerC/SpinnakerCCamera.h
+++ b/DeviceAdapters/SpinnakerC/SpinnakerCCamera.h
@@ -143,7 +143,7 @@ private:
    void RGBtoBGRA(uint8_t* data, size_t imageBuffLength);
 
    int64_t getPixelFormatEnumValue() const;
-   int64_t getPixelSizeEnumValue() const;
+   int getPixelSizeBits() const;   // bits-per-pixel from PixelSize symbolic, or -1
 
    std::string m_deviceName;
    std::string m_serialNumber;


### PR DESCRIPTION
Likely fix for https://forum.image.sc/t/micro-manager-and-spinnakercamera/64076/17

Avoid the enum int value (which can depend on device) and use the symbolic name, as was done in the original Spinnaker adapter.

- [x] Test on Windows that it builds and works