### PR TITLE
ASITiger: fix OnSaveCardSettings for PLogic, XYStage, and DacXYStage

### DIFF
--- a/DeviceAdapters/ASITiger/ASIDac.cpp
+++ b/DeviceAdapters/ASITiger/ASIDac.cpp
@@ -34,336 +34,326 @@
 #include <vector>
 
 CDAC::CDAC(const char* name) :
-	ASIPeripheralBase< ::CSignalIOBase, CDAC >(name) {
-	// only set up these properties if we have the required information in the name
-	if (IsExtendedName(name)) {
-		axisLetter_ = GetAxisLetterFromExtName(name);
-		CreateProperty(g_AxisLetterPropertyName, axisLetter_.c_str(), MM::String, true);
-	}
+    ASIPeripheralBase< ::CSignalIOBase, CDAC >(name) {
+    // only set up these properties if we have the required information in the name
+    if (IsExtendedName(name)) {
+        axisLetter_ = GetAxisLetterFromExtName(name);
+        CreateProperty(g_AxisLetterPropertyName, axisLetter_.c_str(), MM::String, true);
+    }
 }
 
 int CDAC::Initialize() {
-	if (const int status = PeripheralInitialize(); status != DEVICE_OK) {
-		return status;
-	}
+    if (const int status = PeripheralInitialize(); status != DEVICE_OK) {
+        return status;
+    }
 
-	std::ostringstream command;
-	CPropertyAction* pAct;
-	double tmp;
+    std::ostringstream command;
+    CPropertyAction* pAct;
+    double tmp;
 
-	// create MM description; this doesn't work during hardware configuration wizard but will work afterwards
-	command << g_DacDeviceDescription << " Axis=" << axisLetter_ << " HexAddr=" << addressString_;
-	CreateProperty(MM::g_Keyword_Description, command.str().c_str(), MM::String, true);
+    // create MM description; this doesn't work during hardware configuration wizard but will work afterwards
+    command << g_DacDeviceDescription << " Axis=" << axisLetter_ << " HexAddr=" << addressString_;
+    CreateProperty(MM::g_Keyword_Description, command.str().c_str(), MM::String, true);
 
-	// read the unit multiplier
-	// ASI's unit multiplier is how many units per volt, so divide by 1 here to get units per volt, divide by 1000 to get units in millivolts
-	// except for GetSignal() and SetSignal() which deals in Volts, we will make all properties units millivolt
-	command.str("");
-	command << "UM " << axisLetter_ << "?";
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":"));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-	unitMult_ = tmp / 1000;
-	command.str("");
+    // read the unit multiplier
+    // ASI's unit multiplier is how many units per volt, so divide by 1 here to get units per volt, divide by 1000 to get units in millivolts
+    // except for GetSignal() and SetSignal() which deals in Volts, we will make all properties units millivolt
+    command.str("");
+    command << "UM " << axisLetter_ << "?";
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":"));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+    unitMult_ = tmp / 1000;
+    command.str("");
 
-	// refresh properties from controller every time; default is false = no refresh (speeds things up by not redoing so much serial comm)
-	pAct = new CPropertyAction(this, &CDAC::OnRefreshProperties);
-	CreateProperty(g_RefreshPropValsPropertyName, g_NoState, MM::String, false, pAct);
-	AddAllowedValue(g_RefreshPropValsPropertyName, g_NoState);
-	AddAllowedValue(g_RefreshPropValsPropertyName, g_YesState);
+    // refresh properties from controller every time; default is false = no refresh (speeds things up by not redoing so much serial comm)
+    pAct = new CPropertyAction(this, &CDAC::OnRefreshProperties);
+    CreateProperty(g_RefreshPropValsPropertyName, g_NoState, MM::String, false, pAct);
+    AddAllowedValue(g_RefreshPropValsPropertyName, g_NoState);
+    AddAllowedValue(g_RefreshPropValsPropertyName, g_YesState);
 
-	// save settings to controller if requested
-	pAct = new CPropertyAction(this, &CDAC::OnSaveCardSettings);
-	CreateProperty(g_SaveSettingsPropertyName, g_SaveSettingsOrig, MM::String, false, pAct);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsX);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsY);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsZ);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsOrig);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsDone);
+    // save settings to controller if requested
+    pAct = new CPropertyAction(this, &CDAC::OnSaveCardSettings);
+    CreateProperty(g_SaveSettingsPropertyName, g_SaveSettingsOrig, MM::String, false, pAct);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsX);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsY);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsZ);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsOrig);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsDone);
 
-	//Getting limits
-	maxvolts_ = 2.048;
-	minvolts_ = 0;
-	GetMaxVolts(maxvolts_);
-	GetMinVolts(minvolts_);
+    //Getting limits
+    maxvolts_ = 2.048;
+    minvolts_ = 0;
+    GetMaxVolts(maxvolts_);
+    GetMinVolts(minvolts_);
 
-	//Set DAC card voltage range 0 to 2.048V or -10 to +10V
-	pAct = new CPropertyAction(this, &CDAC::OnDACMode);
-	CreateProperty(g_DACModePropertyName, "0", MM::String, false, pAct);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_0);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_1);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_2);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_4);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_5);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_6);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_7);
-	UpdateProperty(g_DACModePropertyName);
+    //Set DAC card voltage range 0 to 2.048V or -10 to +10V
+    pAct = new CPropertyAction(this, &CDAC::OnDACMode);
+    CreateProperty(g_DACModePropertyName, "0", MM::String, false, pAct);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_0);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_1);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_2);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_4);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_5);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_6);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_7);
+    UpdateProperty(g_DACModePropertyName);
 
-	//Max and Min Voltages as read only property
-	command.str("");
-	command << maxvolts_;
-	CreateProperty(g_DACMaxVoltsPropertyName, command.str().c_str(), MM::Float, true);
+    //Max and Min Voltages as read only property
+    command.str("");
+    command << maxvolts_;
+    CreateProperty(g_DACMaxVoltsPropertyName, command.str().c_str(), MM::Float, true);
 
-	command.str("");
-	command << minvolts_;
-	CreateProperty(g_DACMinVoltsPropertyName, command.str().c_str(), MM::Float, true);
+    command.str("");
+    command << minvolts_;
+    CreateProperty(g_DACMinVoltsPropertyName, command.str().c_str(), MM::Float, true);
 
-	//DAC gate open or closed
-	pAct = new CPropertyAction(this, &CDAC::OnDACGate);
-	CreateProperty(g_DACGatePropertyName, "0", MM::String, false, pAct);
-	AddAllowedValue(g_DACGatePropertyName, g_OpenState);
-	AddAllowedValue(g_DACGatePropertyName, g_ClosedState);
-	UpdateProperty(g_DACGatePropertyName);
+    //DAC gate open or closed
+    pAct = new CPropertyAction(this, &CDAC::OnDACGate);
+    CreateProperty(g_DACGatePropertyName, "0", MM::String, false, pAct);
+    AddAllowedValue(g_DACGatePropertyName, g_OpenState);
+    AddAllowedValue(g_DACGatePropertyName, g_ClosedState);
+    UpdateProperty(g_DACGatePropertyName);
 
-	// filter cut-off frequency
-	pAct = new CPropertyAction(this, &CDAC::OnCutoffFreq);
-	CreateProperty(g_ScannerCutoffFilterPropertyName, "0", MM::Float, false, pAct);
-	SetPropertyLimits(g_ScannerCutoffFilterPropertyName, 0.1, 650);
-	UpdateProperty(g_ScannerCutoffFilterPropertyName);
+    // filter cut-off frequency
+    pAct = new CPropertyAction(this, &CDAC::OnCutoffFreq);
+    CreateProperty(g_ScannerCutoffFilterPropertyName, "0", MM::Float, false, pAct);
+    SetPropertyLimits(g_ScannerCutoffFilterPropertyName, 0.1, 650);
+    UpdateProperty(g_ScannerCutoffFilterPropertyName);
 
-	//DAC Voltage set 
-	pAct = new CPropertyAction(this, &CDAC::OnDACVoltage);
-	CreateProperty(g_DACVoltageName, "0", MM::Float, false, pAct);
-	SetPropertyLimits(g_DACVoltageName, minvolts_ * 1000, maxvolts_ * 1000);
-	UpdateProperty(g_DACVoltageName);
+    // DAC Voltage set
+    pAct = new CPropertyAction(this, &CDAC::OnDACVoltage);
+    CreateProperty(g_DACVoltageName, "0", MM::Float, false, pAct);
+    SetPropertyLimits(g_DACVoltageName, minvolts_ * 1000, maxvolts_ * 1000);
+    UpdateProperty(g_DACVoltageName);
 
-	///////////////////// Optional Modules ////////////////////////////////////
+    ///////////////////// Optional Modules ////////////////////////////////////
 
    // get build info so we can add optional properties
-	FirmwareBuild build;
-	RETURN_ON_MM_ERROR(hub_->GetBuildInfo(addressChar_, build));
+    FirmwareBuild build;
+    RETURN_ON_MM_ERROR(hub_->GetBuildInfo(addressChar_, build));
 
-	// add single-axis properties if supported
-	// Normally we check for version, but this card is always going to have v3.30 and above
-	if (build.vAxesProps[0] & BIT5)//     
-	{
-		// copied from ASIMMirror.cpp
-		pAct = new CPropertyAction(this, &CDAC::OnSAAmplitude);
-		CreateProperty(g_SAAmplitudeDACPropertyName, "0", MM::Float, false, pAct);
-		SetPropertyLimits(g_SAAmplitudeDACPropertyName, 0, (maxvolts_ - minvolts_) * 1000);
-		UpdateProperty(g_SAAmplitudeDACPropertyName);
+    // add single-axis properties if supported
+    // Normally we check for version, but this card is always going to have v3.30 and above
+    if (build.vAxesProps[0] & BIT5) {
+        // copied from ASIMMirror.cpp
+        pAct = new CPropertyAction(this, &CDAC::OnSAAmplitude);
+        CreateProperty(g_SAAmplitudeDACPropertyName, "0", MM::Float, false, pAct);
+        SetPropertyLimits(g_SAAmplitudeDACPropertyName, 0, (maxvolts_ - minvolts_) * 1000);
+        UpdateProperty(g_SAAmplitudeDACPropertyName);
 
-		pAct = new CPropertyAction(this, &CDAC::OnSAOffset);
-		CreateProperty(g_SAOffsetDACPropertyName, "0", MM::Float, false, pAct);
-		SetPropertyLimits(g_SAOffsetDACPropertyName, minvolts_ * 1000, maxvolts_ * 1000);
-		UpdateProperty(g_SAOffsetDACPropertyName);
+        pAct = new CPropertyAction(this, &CDAC::OnSAOffset);
+        CreateProperty(g_SAOffsetDACPropertyName, "0", MM::Float, false, pAct);
+        SetPropertyLimits(g_SAOffsetDACPropertyName, minvolts_ * 1000, maxvolts_ * 1000);
+        UpdateProperty(g_SAOffsetDACPropertyName);
 
-		pAct = new CPropertyAction(this, &CDAC::OnSAPeriod);
-		CreateProperty(g_SAPeriodPropertyName, "0", MM::Integer, false, pAct);
-		UpdateProperty(g_SAPeriodPropertyName);
+        pAct = new CPropertyAction(this, &CDAC::OnSAPeriod);
+        CreateProperty(g_SAPeriodPropertyName, "0", MM::Integer, false, pAct);
+        UpdateProperty(g_SAPeriodPropertyName);
 
-		pAct = new CPropertyAction(this, &CDAC::OnSAMode);
-		CreateProperty(g_SAModePropertyName, g_SAMode_0, MM::String, false, pAct);
-		AddAllowedValue(g_SAModePropertyName, g_SAMode_0);
-		AddAllowedValue(g_SAModePropertyName, g_SAMode_1);
-		AddAllowedValue(g_SAModePropertyName, g_SAMode_2);
-		AddAllowedValue(g_SAModePropertyName, g_SAMode_3);
-		UpdateProperty(g_SAModePropertyName);
+        pAct = new CPropertyAction(this, &CDAC::OnSAMode);
+        CreateProperty(g_SAModePropertyName, g_SAMode_0, MM::String, false, pAct);
+        AddAllowedValue(g_SAModePropertyName, g_SAMode_0);
+        AddAllowedValue(g_SAModePropertyName, g_SAMode_1);
+        AddAllowedValue(g_SAModePropertyName, g_SAMode_2);
+        AddAllowedValue(g_SAModePropertyName, g_SAMode_3);
+        UpdateProperty(g_SAModePropertyName);
 
-		pAct = new CPropertyAction(this, &CDAC::OnSAPattern);
-		CreateProperty(g_SAPatternPropertyName, g_SAPattern_0, MM::String, false, pAct);
-		AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_0);
-		AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_1);
-		AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_2);
-		if (FirmwareVersionAtLeast(3.14)) {
-			AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_3);
-		}
-		if (FirmwareVersionAtLeast(3.55)) {
-			AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_4);
-		}
-		UpdateProperty(g_SAPatternPropertyName);
+        pAct = new CPropertyAction(this, &CDAC::OnSAPattern);
+        CreateProperty(g_SAPatternPropertyName, g_SAPattern_0, MM::String, false, pAct);
+        AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_0);
+        AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_1);
+        AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_2);
+        if (FirmwareVersionAtLeast(3.14)) {
+            AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_3);
+        }
+        if (FirmwareVersionAtLeast(3.55)) {
+            AddAllowedValue(g_SAPatternPropertyName, g_SAPattern_4);
+        }
+        UpdateProperty(g_SAPatternPropertyName);
 
-		// rise time is used by variable waveforms
-		if (FirmwareVersionAtLeast(3.55)) {
-			CreateSingleAxisRiseTimeProperty();
-		}
+        // rise time is used by variable waveforms
+        if (FirmwareVersionAtLeast(3.55)) {
+            CreateSingleAxisRiseTimeProperty();
+        }
 
-		// generates a set of additional advanced properties that are rarely used
-		pAct = new CPropertyAction(this, &CDAC::OnSAAdvanced);
-		CreateProperty(g_AdvancedSAPropertiesPropertyName, g_NoState, MM::String, false, pAct);
-		AddAllowedValue(g_AdvancedSAPropertiesPropertyName, g_NoState);
-		AddAllowedValue(g_AdvancedSAPropertiesPropertyName, g_YesState);
-		UpdateProperty(g_AdvancedSAPropertiesPropertyName);
-	}
+        // generates a set of additional advanced properties that are rarely used
+        pAct = new CPropertyAction(this, &CDAC::OnSAAdvanced);
+        CreateProperty(g_AdvancedSAPropertiesPropertyName, g_NoState, MM::String, false, pAct);
+        AddAllowedValue(g_AdvancedSAPropertiesPropertyName, g_NoState);
+        AddAllowedValue(g_AdvancedSAPropertiesPropertyName, g_YesState);
+        UpdateProperty(g_AdvancedSAPropertiesPropertyName);
+    }
 
-	// add ring buffer properties if supported (starting version 2.81)
-	// Normally we check for version, but this card is always going to have v3.30 and above
-	if (build.vAxesProps[0] & BIT1)
-	{
-		// get the number of ring buffer positions from the BU X output
-		std::string rb_define = hub_->GetDefineString(build, "RING BUFFER");
+    // add ring buffer properties if supported (starting version 2.81)
+    // Normally we check for version, but this card is always going to have v3.30 and above
+    if (build.vAxesProps[0] & BIT1) {
+        // get the number of ring buffer positions from the BU X output
+        std::string rb_define = hub_->GetDefineString(build, "RING BUFFER");
 
-		ring_buffer_capacity_ = 0;
-		if (rb_define.size() > 12)
-		{
-			ring_buffer_capacity_ = atol(rb_define.substr(11).c_str());
-		}
+        ring_buffer_capacity_ = 0;
+        if (rb_define.size() > 12) {
+            ring_buffer_capacity_ = atol(rb_define.substr(11).c_str());
+        }
 
-		if (ring_buffer_capacity_ != 0)
-		{
-			ring_buffer_supported_ = true;
+        if (ring_buffer_capacity_ != 0) {
+            ring_buffer_supported_ = true;
 
-			pAct = new CPropertyAction(this, &CDAC::OnRBMode);
-			CreateProperty(g_RB_ModePropertyName, g_RB_OnePoint_1, MM::String, false, pAct);
-			AddAllowedValue(g_RB_ModePropertyName, g_RB_OnePoint_1);
-			AddAllowedValue(g_RB_ModePropertyName, g_RB_PlayOnce_2);
-			AddAllowedValue(g_RB_ModePropertyName, g_RB_PlayRepeat_3);
-			UpdateProperty(g_RB_ModePropertyName);
+            pAct = new CPropertyAction(this, &CDAC::OnRBMode);
+            CreateProperty(g_RB_ModePropertyName, g_RB_OnePoint_1, MM::String, false, pAct);
+            AddAllowedValue(g_RB_ModePropertyName, g_RB_OnePoint_1);
+            AddAllowedValue(g_RB_ModePropertyName, g_RB_PlayOnce_2);
+            AddAllowedValue(g_RB_ModePropertyName, g_RB_PlayRepeat_3);
+            UpdateProperty(g_RB_ModePropertyName);
 
-			pAct = new CPropertyAction(this, &CDAC::OnRBDelayBetweenPoints);
-			CreateProperty(g_RB_DelayPropertyName, "0", MM::Integer, false, pAct);
-			UpdateProperty(g_RB_DelayPropertyName);
+            pAct = new CPropertyAction(this, &CDAC::OnRBDelayBetweenPoints);
+            CreateProperty(g_RB_DelayPropertyName, "0", MM::Integer, false, pAct);
+            UpdateProperty(g_RB_DelayPropertyName);
 
-			// "do it" property to do TTL trigger via serial
-			pAct = new CPropertyAction(this, &CDAC::OnRBTrigger);
-			CreateProperty(g_RB_TriggerPropertyName, g_IdleState, MM::String, false, pAct);
-			AddAllowedValue(g_RB_TriggerPropertyName, g_IdleState, 0);
-			AddAllowedValue(g_RB_TriggerPropertyName, g_DoItState, 1);
-			AddAllowedValue(g_RB_TriggerPropertyName, g_DoneState, 2);
-			UpdateProperty(g_RB_TriggerPropertyName);
+            // "do it" property to do TTL trigger via serial
+            pAct = new CPropertyAction(this, &CDAC::OnRBTrigger);
+            CreateProperty(g_RB_TriggerPropertyName, g_IdleState, MM::String, false, pAct);
+            AddAllowedValue(g_RB_TriggerPropertyName, g_IdleState, 0);
+            AddAllowedValue(g_RB_TriggerPropertyName, g_DoItState, 1);
+            AddAllowedValue(g_RB_TriggerPropertyName, g_DoneState, 2);
+            UpdateProperty(g_RB_TriggerPropertyName);
 
-			pAct = new CPropertyAction(this, &CDAC::OnRBRunning);
-			CreateProperty(g_RB_AutoplayRunningPropertyName, g_NoState, MM::String, false, pAct);
-			AddAllowedValue(g_RB_AutoplayRunningPropertyName, g_NoState);
-			AddAllowedValue(g_RB_AutoplayRunningPropertyName, g_YesState);
-			UpdateProperty(g_RB_AutoplayRunningPropertyName);
+            pAct = new CPropertyAction(this, &CDAC::OnRBRunning);
+            CreateProperty(g_RB_AutoplayRunningPropertyName, g_NoState, MM::String, false, pAct);
+            AddAllowedValue(g_RB_AutoplayRunningPropertyName, g_NoState);
+            AddAllowedValue(g_RB_AutoplayRunningPropertyName, g_YesState);
+            UpdateProperty(g_RB_AutoplayRunningPropertyName);
 
-			pAct = new CPropertyAction(this, &CDAC::OnUseSequence);
-			CreateProperty(g_UseSequencePropertyName, g_NoState, MM::String, false, pAct);
-			AddAllowedValue(g_UseSequencePropertyName, g_NoState);
-			AddAllowedValue(g_UseSequencePropertyName, g_YesState);
-			ttl_trigger_enabled_ = false;
+            pAct = new CPropertyAction(this, &CDAC::OnUseSequence);
+            CreateProperty(g_UseSequencePropertyName, g_NoState, MM::String, false, pAct);
+            AddAllowedValue(g_UseSequencePropertyName, g_NoState);
+            AddAllowedValue(g_UseSequencePropertyName, g_YesState);
+            ttl_trigger_enabled_ = false;
 
-			//Because DASequence API for SignalIO devices isn't exposed thru MMDEvices, we are adding a few extra properties to make this feature more accessible
+            //Because DASequence API for SignalIO devices isn't exposed thru MMDEvices, we are adding a few extra properties to make this feature more accessible
 
-			//This prop lets user execute StartDASequence(), StopDASequence(),ClearDASequence(),SendDASequence()
-			pAct = new CPropertyAction(this, &CDAC::OnRBSequenceState);
-			CreateProperty(g_RBSequenceStatePropertyName, g_IdleState, MM::String, false, pAct);
-			AddAllowedValue(g_RBSequenceStatePropertyName, g_IdleState, 0);
-			AddAllowedValue(g_RBSequenceStatePropertyName, g_RBSequenceStart, 1);
-			AddAllowedValue(g_RBSequenceStatePropertyName, g_RBSequenceStop, 2);
-			AddAllowedValue(g_RBSequenceStatePropertyName, g_RBSequenceClearSeq, 3);
-			AddAllowedValue(g_RBSequenceStatePropertyName, g_RBSequenceSendSeq, 4);
-			AddAllowedValue(g_RBSequenceStatePropertyName, g_DoneState, 5);
-			
-			
-			// this prop lets user do AddToDASequence()
-			pAct = new CPropertyAction(this, &CDAC::OnAddtoRBSequence);
-			CreateProperty(g_AddtoRBSequencePropertyName, "0", MM::Float, false, pAct);
-			SetPropertyLimits(g_AddtoRBSequencePropertyName, minvolts_*1000, maxvolts_ * 1000);
-		}
-	}
+            //This prop lets user execute StartDASequence(), StopDASequence(),ClearDASequence(),SendDASequence()
+            pAct = new CPropertyAction(this, &CDAC::OnRBSequenceState);
+            CreateProperty(g_RBSequenceStatePropertyName, g_IdleState, MM::String, false, pAct);
+            AddAllowedValue(g_RBSequenceStatePropertyName, g_IdleState, 0);
+            AddAllowedValue(g_RBSequenceStatePropertyName, g_RBSequenceStart, 1);
+            AddAllowedValue(g_RBSequenceStatePropertyName, g_RBSequenceStop, 2);
+            AddAllowedValue(g_RBSequenceStatePropertyName, g_RBSequenceClearSeq, 3);
+            AddAllowedValue(g_RBSequenceStatePropertyName, g_RBSequenceSendSeq, 4);
+            AddAllowedValue(g_RBSequenceStatePropertyName, g_DoneState, 5);
 
-	// Normally we check for version, but this card is always going to have v3.30 and above
-	if (hub_->IsDefinePresent(build, "IN0_INT") && ring_buffer_supported_)
-	{
-		ttl_trigger_supported_ = true;
+            // this prop lets user do AddToDASequence()
+            pAct = new CPropertyAction(this, &CDAC::OnAddtoRBSequence);
+            CreateProperty(g_AddtoRBSequencePropertyName, "0", MM::Float, false, pAct);
+            SetPropertyLimits(g_AddtoRBSequencePropertyName, minvolts_*1000, maxvolts_ * 1000);
+        }
+    }
 
-		//TTL IN mode
-		pAct = new CPropertyAction(this, &CDAC::OnTTLin);
-		CreateProperty(g_TTLinName, "0", MM::Integer, false, pAct);
-		SetPropertyLimits(g_TTLinName, 0, 30);
-		UpdateProperty(g_TTLinName);
+    // Normally we check for version, but this card is always going to have v3.30 and above
+    if (hub_->IsDefinePresent(build, "IN0_INT") && ring_buffer_supported_) {
+        ttl_trigger_supported_ = true;
 
-		//TTL Out Mode
-		pAct = new CPropertyAction(this, &CDAC::OnTTLout);
-		CreateProperty(g_TTLoutName, "0", MM::Integer, false, pAct);
-		SetPropertyLimits(g_TTLoutName, 0, 30);
-		UpdateProperty(g_TTLoutName);
-	}
+        //TTL IN mode
+        pAct = new CPropertyAction(this, &CDAC::OnTTLin);
+        CreateProperty(g_TTLinName, "0", MM::Integer, false, pAct);
+        SetPropertyLimits(g_TTLinName, 0, 30);
+        UpdateProperty(g_TTLinName);
 
-	initialized_ = true;
-	return DEVICE_OK;
+        //TTL Out Mode
+        pAct = new CPropertyAction(this, &CDAC::OnTTLout);
+        CreateProperty(g_TTLoutName, "0", MM::Integer, false, pAct);
+        SetPropertyLimits(g_TTLoutName, 0, 30);
+        UpdateProperty(g_TTLoutName);
+    }
+
+    initialized_ = true;
+    return DEVICE_OK;
 }
 
 int CDAC::SetSignalmv(double millivolts)
 {
-	std::ostringstream command;
-	command << "M " << axisLetter_ << "=" << millivolts * unitMult_;
-	return hub_->QueryCommandVerify(command.str(), ":A");
+    std::ostringstream command;
+    command << "M " << axisLetter_ << "=" << millivolts * unitMult_;
+    return hub_->QueryCommandVerify(command.str(), ":A");
 }
 
 int CDAC::SetSignal(double volts)
 {
-	return SetSignalmv(volts * 1000);
+    return SetSignalmv(volts * 1000);
 }
 
 int CDAC::GetSignalmv(double &millivolts)
 {
-	std::ostringstream command;
-	command << "W " << axisLetter_;
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition2(millivolts));
-	millivolts = millivolts / unitMult_;
-	return DEVICE_OK;
+    std::ostringstream command;
+    command << "W " << axisLetter_;
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition2(millivolts));
+    millivolts = millivolts / unitMult_;
+    return DEVICE_OK;
 }
 
 int CDAC::GetSignal(double &volts)
 {
-	double mvolts;
-	RETURN_ON_MM_ERROR(GetSignalmv(mvolts));
-	volts = mvolts / 1000;
-	return DEVICE_OK;
+    double mvolts;
+    RETURN_ON_MM_ERROR(GetSignalmv(mvolts));
+    volts = mvolts / 1000;
+    return DEVICE_OK;
 }
 
 int CDAC::GetLimits(double& minVolts, double& maxVolts)
 {
-	minVolts = minvolts_;
-	maxVolts = maxvolts_;
-	return DEVICE_OK;
+    minVolts = minvolts_;
+    maxVolts = maxvolts_;
+    return DEVICE_OK;
 }
 
 int CDAC::SetGateOpen(bool open)
 {
-	std::ostringstream command;
-	if (open)
-	{
-		command.str("");
-		command << "MC " << axisLetter_ << "+";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	else
-	{
-		command.str("");
-		command << "MC " << axisLetter_ << "-";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (open) {
+        command.str("");
+        command << "MC " << axisLetter_ << "+";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    } else {
+        command.str("");
+        command << "MC " << axisLetter_ << "-";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::GetGateOpen(bool &open)
 {
-	std::ostringstream command;
-	long tmp;
-	command << "MC " << axisLetter_ << "?";
+    std::ostringstream command;
+    long tmp;
+    command << "MC " << axisLetter_ << "?";
 
-	open = false;//incase of error we return that gate is closed
-	// "MC <Axis>?" replies look like ":A 1"
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition(3, tmp));
+    open = false;//incase of error we return that gate is closed
+    // "MC <Axis>?" replies look like ":A 1"
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition(3, tmp));
 
-	if (tmp == 1)
-	{
-		open = true;
-	}
-	return DEVICE_OK;
+    if (tmp == 1) {
+        open = true;
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::GetMaxVolts(double &volts)
 {
-	std::ostringstream command;
-	command << "SU " << axisLetter_ << "?";
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(volts));
-	return DEVICE_OK;
+    std::ostringstream command;
+    command << "SU " << axisLetter_ << "?";
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(volts));
+    return DEVICE_OK;
 }
 
 int CDAC::GetMinVolts(double &volts)
 {
-	std::ostringstream command;
-	command << "SL " << axisLetter_ << "?";
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(volts));
-	return DEVICE_OK;
+    std::ostringstream command;
+    command << "SL " << axisLetter_ << "?";
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(volts));
+    return DEVICE_OK;
 }
 
 //////////////// Sequence Stuff/////////////////////////////
@@ -371,248 +361,231 @@ int CDAC::GetMinVolts(double &volts)
 // enables TTL triggering; doesn't actually start anything going on controller
 int CDAC::StartDASequence()
 {
-	std::ostringstream command;
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	// ensure that ringbuffer pointer points to first entry and
-	// that we only trigger the first axis (assume only 1 axis on piezo card)
-	command << addressChar_ << "RM Y=1 Z=0";
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    std::ostringstream command;
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    // ensure that ringbuffer pointer points to first entry and
+    // that we only trigger the first axis (assume only 1 axis on piezo card)
+    command << addressChar_ << "RM Y=1 Z=0";
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
 
-	command.str("");
-	command << addressChar_ << "TTL X=1";  // switch on TTL triggering
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	return DEVICE_OK;
+    command.str("");
+    command << addressChar_ << "TTL X=1";  // switch on TTL triggering
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    return DEVICE_OK;
 }
 
 // disables TTL triggering; doesn't actually stop anything already happening on controller
 int CDAC::StopDASequence()
 {
-	std::ostringstream command;
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	command << addressChar_ << "TTL X=0";  // switch off TTL triggering
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    command << addressChar_ << "TTL X=0";  // switch off TTL triggering
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    return DEVICE_OK;
 }
 
 int CDAC::ClearDASequence()
 {
-	std::ostringstream command;
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	sequence_.clear();
-	command << addressChar_ << "RM X=0";  // clear ring buffer
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    sequence_.clear();
+    command << addressChar_ << "RM X=0";  // clear ring buffer
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    return DEVICE_OK;
 }
 
 int CDAC::AddToDASequence(double voltage)
 {
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	sequence_.push_back(voltage);
-	return DEVICE_OK;
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    sequence_.push_back(voltage);
+    return DEVICE_OK;
 }
 
 int CDAC::SendDASequence()
 {
-	std::ostringstream command;
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	command << addressChar_ << "RM X=0"; // clear ring buffer
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	for (unsigned i = 0; i < sequence_.size(); i++)  // send new points
-	{
-		command.str("");
-		command << "LD " << axisLetter_ << "=" << sequence_[i] * 1000 * unitMult_;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    command << addressChar_ << "RM X=0"; // clear ring buffer
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    for (unsigned i = 0; i < sequence_.size(); i++) { // send new points
+        command.str("");
+        command << "LD " << axisLetter_ << "=" << sequence_[i] * 1000 * unitMult_;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 // action handlers
 
 int CDAC::OnDACVoltage(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	double tmp = 0.0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		RETURN_ON_MM_ERROR(GetSignalmv(tmp));
-		pProp->Set(tmp);
-		return DEVICE_OK;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(tmp);
-		RETURN_ON_MM_ERROR(SetSignalmv(tmp));
-	}
-	return DEVICE_OK;
+    double tmp = 0.0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        RETURN_ON_MM_ERROR(GetSignalmv(tmp));
+        pProp->Set(tmp);
+        return DEVICE_OK;
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        RETURN_ON_MM_ERROR(SetSignalmv(tmp));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnDACGate(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	bool gtmp;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		RETURN_ON_MM_ERROR(GetGateOpen(gtmp));
-		if (gtmp)
-		{
-			pProp->Set(g_OpenState);
-		}
-		else
-		{
-			pProp->Set(g_ClosedState);
-		}
-		return DEVICE_OK;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_OpenState) {
-			gtmp = true;
-		}
-		else
-		{
-			gtmp = false;
-		}
-		RETURN_ON_MM_ERROR(SetGateOpen(gtmp));
-	}
-	return DEVICE_OK;
+    bool gtmp;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        RETURN_ON_MM_ERROR(GetGateOpen(gtmp));
+        if (gtmp) {
+            pProp->Set(g_OpenState);
+        } else {
+            pProp->Set(g_ClosedState);
+        }
+        return DEVICE_OK;
+    }
+    else if (eAct == MM::AfterSet)
+    {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_OpenState) {
+            gtmp = true;
+        } else {
+            gtmp = false;
+        }
+        RETURN_ON_MM_ERROR(SetGateOpen(gtmp));
+    }
+    return DEVICE_OK;
 }
 
 // Needs controller restart for settings to take effect
 int CDAC::OnDACMode(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		std::ostringstream response;
-		command << "PR " << axisLetter_ << "?"; //On SIGNAL_DAC this is on PR(system flag) instead of PM because I needed upper and lower limits to change too 
-		response << ":A " << axisLetter_ << "="; // Reply for PR command is ":A H=6 <CR><LF>"
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+    std::ostringstream command;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        std::ostringstream response;
+        command << "PR " << axisLetter_ << "?"; //On SIGNAL_DAC this is on PR(system flag) instead of PM because I needed upper and lower limits to change too 
+        response << ":A " << axisLetter_ << "="; // Reply for PR command is ":A H=6 <CR><LF>"
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
 
-		bool success = 0;
-		switch (tmp)
-		{
-		case 1: success = pProp->Set(g_DACOutputMode_1); break;
-		case 0: success = pProp->Set(g_DACOutputMode_0); break;
-		case 2: success = pProp->Set(g_DACOutputMode_2);  break;
-		case 4: success = pProp->Set(g_DACOutputMode_4);  break;
-		case 5: success = pProp->Set(g_DACOutputMode_5);  break;
-		case 6: success = pProp->Set(g_DACOutputMode_6);  break;
-		case 7: success = pProp->Set(g_DACOutputMode_7);  break;
-		default: success = 0; break;
-		}
-		if (!success)
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_DACOutputMode_0)
-			tmp = 0;
-		else if (tmpstr == g_DACOutputMode_1)
-			tmp = 1;
-		else if (tmpstr == g_DACOutputMode_2)
-			tmp = 2;
-		else if (tmpstr == g_DACOutputMode_4)
-			tmp = 4;
-		else if (tmpstr == g_DACOutputMode_5)
-			tmp = 5;
-		else if (tmpstr == g_DACOutputMode_6)
-			tmp = 6;
-		else if (tmpstr == g_DACOutputMode_7)
-			tmp = 7;
-		else
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		command << "PR " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+        bool success = 0;
+        switch (tmp) {
+        case 1: success = pProp->Set(g_DACOutputMode_1); break;
+        case 0: success = pProp->Set(g_DACOutputMode_0); break;
+        case 2: success = pProp->Set(g_DACOutputMode_2);  break;
+        case 4: success = pProp->Set(g_DACOutputMode_4);  break;
+        case 5: success = pProp->Set(g_DACOutputMode_5);  break;
+        case 6: success = pProp->Set(g_DACOutputMode_6);  break;
+        case 7: success = pProp->Set(g_DACOutputMode_7);  break;
+        default: success = 0; break;
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    }
+    else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_DACOutputMode_0)
+            tmp = 0;
+        else if (tmpstr == g_DACOutputMode_1)
+            tmp = 1;
+        else if (tmpstr == g_DACOutputMode_2)
+            tmp = 2;
+        else if (tmpstr == g_DACOutputMode_4)
+            tmp = 4;
+        else if (tmpstr == g_DACOutputMode_5)
+            tmp = 5;
+        else if (tmpstr == g_DACOutputMode_6)
+            tmp = 6;
+        else if (tmpstr == g_DACOutputMode_7)
+            tmp = 7;
+        else
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        command << "PR " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnCutoffFreq(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << "B " << axisLetter_ << "?";
-		response << ":" << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		pProp->Get(tmp);
-		command << "B " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << "B " << axisLetter_ << "?";
+        response << ":" << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp))
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "B " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSaveCardSettings(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::string tmpstr;
-	std::ostringstream command;
-	if (eAct == MM::AfterSet) {
-		if (hub_->UpdatingSharedProperties())
-			return DEVICE_OK;
-		pProp->Get(tmpstr);
-		command << addressChar_ << "SS ";
-		if (tmpstr == g_SaveSettingsOrig)
-			return DEVICE_OK;
-		if (tmpstr == g_SaveSettingsDone)
-			return DEVICE_OK;
-		if (tmpstr == g_SaveSettingsX)
-			command << 'X';
-		else if (tmpstr == g_SaveSettingsY)
-			command << 'Y';
-		else if (tmpstr == g_SaveSettingsZ)
-			command << 'Z';
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A", (long)200));  // note 200ms delay added
-		pProp->Set(g_SaveSettingsDone);
-		command.str(""); command << g_SaveSettingsDone;
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
-	}
-	return DEVICE_OK;
+    std::string tmpstr;
+    std::ostringstream command;
+    if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties()) {
+            return DEVICE_OK;
+        }
+        pProp->Get(tmpstr);
+        command << addressChar_ << "SS ";
+        if (tmpstr == g_SaveSettingsOrig)
+            return DEVICE_OK;
+        if (tmpstr == g_SaveSettingsDone)
+            return DEVICE_OK;
+        if (tmpstr == g_SaveSettingsX)
+            command << 'X';
+        else if (tmpstr == g_SaveSettingsY)
+            command << 'Y';
+        else if (tmpstr == g_SaveSettingsZ)
+            command << 'Z';
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A", (long)200));  // note 200ms delay added
+        pProp->Set(g_SaveSettingsDone);
+        command.str(""); command << g_SaveSettingsDone;
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnRefreshProperties(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	if (eAct == MM::AfterSet)
-	{
-		std::string tmp;
-		pProp->Get(tmp);
-		refreshProps_ = (tmp == g_YesState);
-	}
-	return DEVICE_OK;
+    if (eAct == MM::AfterSet) {
+        std::string tmp;
+        pProp->Get(tmp);
+        refreshProps_ = (tmp == g_YesState);
+    }
+    return DEVICE_OK;
 }
 
 ///////////////////////////////////// Single Axis Functions/////////////////////////////
@@ -620,736 +593,676 @@ int CDAC::OnRefreshProperties(MM::PropertyBase* pProp, MM::ActionType eAct)
 // special property, when set to "yes" it creates a set of little-used properties that can be manipulated thereafter
 int CDAC::OnSAAdvanced(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	if (eAct == MM::BeforeGet)
-	{
-		return DEVICE_OK; // do nothing
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_YesState)
-		{
-			CPropertyAction* pAct;
+    if (eAct == MM::BeforeGet) {
+        return DEVICE_OK; // do nothing
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_YesState) {
+            CPropertyAction* pAct;
 
-			pAct = new CPropertyAction(this, &CDAC::OnSAClkSrc);
-			CreateProperty(g_SAClkSrcPropertyName, g_SAClkSrc_0, MM::String, false, pAct);
-			AddAllowedValue(g_SAClkSrcPropertyName, g_SAClkSrc_0);
-			AddAllowedValue(g_SAClkSrcPropertyName, g_SAClkSrc_1);
-			UpdateProperty(g_SAClkSrcPropertyName);
+            pAct = new CPropertyAction(this, &CDAC::OnSAClkSrc);
+            CreateProperty(g_SAClkSrcPropertyName, g_SAClkSrc_0, MM::String, false, pAct);
+            AddAllowedValue(g_SAClkSrcPropertyName, g_SAClkSrc_0);
+            AddAllowedValue(g_SAClkSrcPropertyName, g_SAClkSrc_1);
+            UpdateProperty(g_SAClkSrcPropertyName);
 
-			pAct = new CPropertyAction(this, &CDAC::OnSAClkPol);
-			CreateProperty(g_SAClkPolPropertyName, g_SAClkPol_0, MM::String, false, pAct);
-			AddAllowedValue(g_SAClkPolPropertyName, g_SAClkPol_0);
-			AddAllowedValue(g_SAClkPolPropertyName, g_SAClkPol_1);
-			UpdateProperty(g_SAClkPolPropertyName);
+            pAct = new CPropertyAction(this, &CDAC::OnSAClkPol);
+            CreateProperty(g_SAClkPolPropertyName, g_SAClkPol_0, MM::String, false, pAct);
+            AddAllowedValue(g_SAClkPolPropertyName, g_SAClkPol_0);
+            AddAllowedValue(g_SAClkPolPropertyName, g_SAClkPol_1);
+            UpdateProperty(g_SAClkPolPropertyName);
 
-			pAct = new CPropertyAction(this, &CDAC::OnSATTLOut);
-			CreateProperty(g_SATTLOutPropertyName, g_SATTLOut_0, MM::String, false, pAct);
-			AddAllowedValue(g_SATTLOutPropertyName, g_SATTLOut_0);
-			AddAllowedValue(g_SATTLOutPropertyName, g_SATTLOut_1);
-			UpdateProperty(g_SATTLOutPropertyName);
+            pAct = new CPropertyAction(this, &CDAC::OnSATTLOut);
+            CreateProperty(g_SATTLOutPropertyName, g_SATTLOut_0, MM::String, false, pAct);
+            AddAllowedValue(g_SATTLOutPropertyName, g_SATTLOut_0);
+            AddAllowedValue(g_SATTLOutPropertyName, g_SATTLOut_1);
+            UpdateProperty(g_SATTLOutPropertyName);
 
-			pAct = new CPropertyAction(this, &CDAC::OnSATTLPol);
-			CreateProperty(g_SATTLPolPropertyName, g_SATTLPol_0, MM::String, false, pAct);
-			AddAllowedValue(g_SATTLPolPropertyName, g_SATTLPol_0);
-			AddAllowedValue(g_SATTLPolPropertyName, g_SATTLPol_1);
-			UpdateProperty(g_SATTLPolPropertyName);
+            pAct = new CPropertyAction(this, &CDAC::OnSATTLPol);
+            CreateProperty(g_SATTLPolPropertyName, g_SATTLPol_0, MM::String, false, pAct);
+            AddAllowedValue(g_SATTLPolPropertyName, g_SATTLPol_0);
+            AddAllowedValue(g_SATTLPolPropertyName, g_SATTLPol_1);
+            UpdateProperty(g_SATTLPolPropertyName);
 
-			pAct = new CPropertyAction(this, &CDAC::OnSAPatternByte);
-			CreateProperty(g_SAPatternModePropertyName, "0", MM::Integer, false, pAct);
-			SetPropertyLimits(g_SAPatternModePropertyName, 0, 255);
-			UpdateProperty(g_SAPatternModePropertyName);
-		}
-	}
-	return DEVICE_OK;
+            pAct = new CPropertyAction(this, &CDAC::OnSAPatternByte);
+            CreateProperty(g_SAPatternModePropertyName, "0", MM::Integer, false, pAct);
+            SetPropertyLimits(g_SAPatternModePropertyName, 0, 255);
+            UpdateProperty(g_SAPatternModePropertyName);
+        }
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSAAmplitude(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << "SAA " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		tmp = tmp / unitMult_;
-		if (!pProp->Set(tmp))
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		pProp->Get(tmp);
-		command << "SAA " << axisLetter_ << "=" << tmp * unitMult_;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << "SAA " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        tmp = tmp / unitMult_;
+        if (!pProp->Set(tmp))
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "SAA " << axisLetter_ << "=" << tmp * unitMult_;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSAOffset(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << "SAO " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		tmp = tmp / unitMult_;
-		if (!pProp->Set(tmp))
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		pProp->Get(tmp);
-		command << "SAO " << axisLetter_ << "=" << tmp * unitMult_;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << "SAO " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        tmp = tmp / unitMult_;
+        if (!pProp->Set(tmp))
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "SAO " << axisLetter_ << "=" << tmp * unitMult_;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSAPeriod(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << "SAF " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		pProp->Get(tmp);
-		command << "SAF " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << "SAF " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp))
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "SAF " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSAMode(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	static bool justSet = false;
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_ && !justSet)
-			return DEVICE_OK;
-		command << "SAM " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SAMode_0); break;
-		case 1: success = pProp->Set(g_SAMode_1); break;
-		case 2: success = pProp->Set(g_SAMode_2); break;
-		case 3: success = pProp->Set(g_SAMode_3); break;
-		default:success = 0;                      break;
-		}
-		if (!success)
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		justSet = false;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SAMode_0)
-			tmp = 0;
-		else if (tmpstr == g_SAMode_1)
-			tmp = 1;
-		else if (tmpstr == g_SAMode_2)
-			tmp = 2;
-		else if (tmpstr == g_SAMode_3)
-			tmp = 3;
-		else
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		command << "SAM " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		// get the updated value right away
-		justSet = true;
-		return OnSAMode(pProp, MM::BeforeGet);
-	}
-	return DEVICE_OK;
+    static bool justSet = false;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_ && !justSet)
+            return DEVICE_OK;
+        command << "SAM " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        switch (tmp)
+        {
+        case 0: success = pProp->Set(g_SAMode_0); break;
+        case 1: success = pProp->Set(g_SAMode_1); break;
+        case 2: success = pProp->Set(g_SAMode_2); break;
+        case 3: success = pProp->Set(g_SAMode_3); break;
+        default:success = 0;                      break;
+        }
+        if (!success)
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        justSet = false;
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SAMode_0)
+            tmp = 0;
+        else if (tmpstr == g_SAMode_1)
+            tmp = 1;
+        else if (tmpstr == g_SAMode_2)
+            tmp = 2;
+        else if (tmpstr == g_SAMode_3)
+            tmp = 3;
+        else
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        command << "SAM " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        // get the updated value right away
+        justSet = true;
+        return OnSAMode(pProp, MM::BeforeGet);
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSAPattern(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT2 | BIT1 | BIT0));  // zero all but the lowest 3 bits
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SAPattern_0); break;
-		case 1: success = pProp->Set(g_SAPattern_1); break;
-		case 2: success = pProp->Set(g_SAPattern_2); break;
-		case 3: success = pProp->Set(g_SAPattern_3); break;
-		case 4: success = pProp->Set(g_SAPattern_4); break;
-		default:success = 0;                      break;
-		}
-		if (!success)
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SAPattern_0)
-			tmp = 0;
-		else if (tmpstr == g_SAPattern_1)
-			tmp = 1;
-		else if (tmpstr == g_SAPattern_2)
-			tmp = 2;
-		else if (tmpstr == g_SAPattern_3)
-			tmp = 3;
-		else if (tmpstr == g_SAPattern_4)
-			tmp = 4;
-		else
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		// have to get current settings and then modify bits 0-2 from there
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT2 | BIT1 | BIT0));  // set lowest 3 bits to zero
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT2 | BIT1 | BIT0));  // zero all but the lowest 3 bits
+        switch (tmp)
+        {
+        case 0: success = pProp->Set(g_SAPattern_0); break;
+        case 1: success = pProp->Set(g_SAPattern_1); break;
+        case 2: success = pProp->Set(g_SAPattern_2); break;
+        case 3: success = pProp->Set(g_SAPattern_3); break;
+        case 4: success = pProp->Set(g_SAPattern_4); break;
+        default:success = 0;                      break;
+        }
+        if (!success)
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SAPattern_0)
+            tmp = 0;
+        else if (tmpstr == g_SAPattern_1)
+            tmp = 1;
+        else if (tmpstr == g_SAPattern_2)
+            tmp = 2;
+        else if (tmpstr == g_SAPattern_3)
+            tmp = 3;
+        else if (tmpstr == g_SAPattern_4)
+            tmp = 4;
+        else
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        // have to get current settings and then modify bits 0-2 from there
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT2 | BIT1 | BIT0));  // set lowest 3 bits to zero
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 // always read
 int CDAC::OnSAPatternByte(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		pProp->Get(tmp);
-		command << "SAP " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp))
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "SAP " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSAClkSrc(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT7));  // zero all but bit 7
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SAClkSrc_0); break;
-		case BIT7: success = pProp->Set(g_SAClkSrc_1); break;
-		default:success = 0;                      break;
-		}
-		if (!success)
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SAClkSrc_0)
-			tmp = 0;
-		else if (tmpstr == g_SAClkSrc_1)
-			tmp = BIT7;
-		else
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		// have to get current settings and then modify bit 7 from there
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT7));  // clear bit 7
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT7));  // zero all but bit 7
+        switch (tmp)
+        {
+        case 0: success = pProp->Set(g_SAClkSrc_0); break;
+        case BIT7: success = pProp->Set(g_SAClkSrc_1); break;
+        default:success = 0;                      break;
+        }
+        if (!success)
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SAClkSrc_0)
+            tmp = 0;
+        else if (tmpstr == g_SAClkSrc_1)
+            tmp = BIT7;
+        else
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        // have to get current settings and then modify bit 7 from there
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT7));  // clear bit 7
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSAClkPol(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT6));  // zero all but bit 6
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SAClkPol_0); break;
-		case BIT6: success = pProp->Set(g_SAClkPol_1); break;
-		default:success = 0;                      break;
-		}
-		if (!success)
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SAClkPol_0)
-			tmp = 0;
-		else if (tmpstr == g_SAClkPol_1)
-			tmp = BIT6;
-		else
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		// have to get current settings and then modify bit 6 from there
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT6));  // clear bit 6
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT6));  // zero all but bit 6
+        switch (tmp)
+        {
+        case 0: success = pProp->Set(g_SAClkPol_0); break;
+        case BIT6: success = pProp->Set(g_SAClkPol_1); break;
+        default:success = 0;                      break;
+        }
+        if (!success)
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SAClkPol_0)
+            tmp = 0;
+        else if (tmpstr == g_SAClkPol_1)
+            tmp = BIT6;
+        else
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        // have to get current settings and then modify bit 6 from there
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT6));  // clear bit 6
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSATTLOut(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT5));  // zero all but bit 5
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SATTLOut_0); break;
-		case BIT5: success = pProp->Set(g_SATTLOut_1); break;
-		default:success = 0;                      break;
-		}
-		if (!success)
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SATTLOut_0)
-			tmp = 0;
-		else if (tmpstr == g_SATTLOut_1)
-			tmp = BIT5;
-		else
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		// have to get current settings and then modify bit 5 from there
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT5));  // clear bit 5
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT5));  // zero all but bit 5
+        switch (tmp)
+        {
+        case 0: success = pProp->Set(g_SATTLOut_0); break;
+        case BIT5: success = pProp->Set(g_SATTLOut_1); break;
+        default:success = 0;                      break;
+        }
+        if (!success)
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SATTLOut_0)
+            tmp = 0;
+        else if (tmpstr == g_SATTLOut_1)
+            tmp = BIT5;
+        else
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        // have to get current settings and then modify bit 5 from there
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT5));  // clear bit 5
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnSATTLPol(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT4));  // zero all but bit 4
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SATTLPol_0); break;
-		case BIT4: success = pProp->Set(g_SATTLPol_1); break;
-		default:success = 0;                      break;
-		}
-		if (!success)
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SATTLPol_0)
-			tmp = 0;
-		else if (tmpstr == g_SATTLPol_1)
-			tmp = BIT4;
-		else
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		// have to get current settings and then modify bit 4 from there
-		command << "SAP " << axisLetter_ << "?";
-		response << ":A " << axisLetter_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT4));  // clear bit 4
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter_ << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT4));  // zero all but bit 4
+        switch (tmp)
+        {
+        case 0: success = pProp->Set(g_SATTLPol_0); break;
+        case BIT4: success = pProp->Set(g_SATTLPol_1); break;
+        default:success = 0;                      break;
+        }
+        if (!success)
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SATTLPol_0)
+            tmp = 0;
+        else if (tmpstr == g_SATTLPol_1)
+            tmp = BIT4;
+        else
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        // have to get current settings and then modify bit 4 from there
+        command << "SAP " << axisLetter_ << "?";
+        response << ":A " << axisLetter_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT4));  // clear bit 4
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter_ << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 /////////////////////////////////////// RING BUFFER //////////////////////////
 
 int CDAC::OnRBMode(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	std::string pseudoAxisChar = FirmwareVersionAtLeast(2.89) ? "F" : "X";
-	long tmp;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << addressChar_ << "RM " << pseudoAxisChar << "?";
-		response << ":A " << pseudoAxisChar << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (tmp >= 128)
-		{
-			tmp -= 128;  // remove the "running now" code if present
-		}
-		bool success;
-		switch (tmp)
-		{
-		case 1: success = pProp->Set(g_RB_OnePoint_1); break;
-		case 2: success = pProp->Set(g_RB_PlayOnce_2); break;
-		case 3: success = pProp->Set(g_RB_PlayRepeat_3); break;
-		default: success = false;
-		}
-		if (!success)
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		if (hub_->UpdatingSharedProperties())
-			return DEVICE_OK;
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_RB_OnePoint_1)
-			tmp = 1;
-		else if (tmpstr == g_RB_PlayOnce_2)
-			tmp = 2;
-		else if (tmpstr == g_RB_PlayRepeat_3)
-			tmp = 3;
-		else
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		command << addressChar_ << "RM " << pseudoAxisChar << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), tmpstr.c_str()));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    std::string pseudoAxisChar = FirmwareVersionAtLeast(2.89) ? "F" : "X";
+    long tmp;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << addressChar_ << "RM " << pseudoAxisChar << "?";
+        response << ":A " << pseudoAxisChar << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (tmp >= 128)
+        {
+            tmp -= 128;  // remove the "running now" code if present
+        }
+        bool success;
+        switch (tmp)
+        {
+        case 1: success = pProp->Set(g_RB_OnePoint_1); break;
+        case 2: success = pProp->Set(g_RB_PlayOnce_2); break;
+        case 3: success = pProp->Set(g_RB_PlayRepeat_3); break;
+        default: success = false;
+        }
+        if (!success)
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties())
+            return DEVICE_OK;
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_RB_OnePoint_1)
+            tmp = 1;
+        else if (tmpstr == g_RB_PlayOnce_2)
+            tmp = 2;
+        else if (tmpstr == g_RB_PlayRepeat_3)
+            tmp = 3;
+        else
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        command << addressChar_ << "RM " << pseudoAxisChar << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), tmpstr.c_str()));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnRBTrigger(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	if (eAct == MM::BeforeGet) {
-		pProp->Set(g_IdleState);
-	}
-	else  if (eAct == MM::AfterSet) {
-		if (hub_->UpdatingSharedProperties())
-			return DEVICE_OK;
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_DoItState)
-		{
-			command << addressChar_ << "RM";
-			RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-			pProp->Set(g_DoneState);
-		}
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (eAct == MM::BeforeGet) {
+        pProp->Set(g_IdleState);
+    } else  if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties())
+            return DEVICE_OK;
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_DoItState) {
+            command << addressChar_ << "RM";
+            RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+            pProp->Set(g_DoneState);
+        }
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnRBRunning(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	std::string pseudoAxisChar = FirmwareVersionAtLeast(2.89) ? "F" : "X";
-	long tmp = 0;
-	static bool justSet;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_ && !justSet)
-			return DEVICE_OK;
-		command << addressChar_ << "RM " << pseudoAxisChar << "?";
-		response << ":A " << pseudoAxisChar << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		if (tmp >= 128)
-		{
-			success = pProp->Set(g_YesState);
-		}
-		else
-		{
-			success = pProp->Set(g_NoState);
-		}
-		if (!success)
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		justSet = false;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		justSet = true;
-		return OnRBRunning(pProp, MM::BeforeGet);
-		// TODO determine how to handle this with shared properties since ring buffer is per-card and not per-axis
-		// the reason this property exists (and why it's not a read-only property) are a bit hazy as of mid-2017
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    std::string pseudoAxisChar = FirmwareVersionAtLeast(2.89) ? "F" : "X";
+    long tmp = 0;
+    static bool justSet;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_ && !justSet)
+            return DEVICE_OK;
+        command << addressChar_ << "RM " << pseudoAxisChar << "?";
+        response << ":A " << pseudoAxisChar << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        if (tmp >= 128) {
+            success = pProp->Set(g_YesState);
+        } else {
+            success = pProp->Set(g_NoState);
+        }
+        if (!success)
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        justSet = false;
+    }
+    else if (eAct == MM::AfterSet)
+    {
+        justSet = true;
+        return OnRBRunning(pProp, MM::BeforeGet);
+        // TODO determine how to handle this with shared properties since ring buffer is per-card and not per-axis
+        // the reason this property exists (and why it's not a read-only property) are a bit hazy as of mid-2017
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnRBDelayBetweenPoints(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << addressChar_ << "RT Z?";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A Z="));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		if (hub_->UpdatingSharedProperties())
-			return DEVICE_OK;
-		pProp->Get(tmp);
-		command << addressChar_ << "RT Z=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		command.str(""); command << tmp;
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << addressChar_ << "RT Z?";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A Z="));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp))
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties())
+            return DEVICE_OK;
+        pProp->Get(tmp);
+        command << addressChar_ << "RT Z=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        command.str(""); command << tmp;
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnUseSequence(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	if (eAct == MM::BeforeGet)
-	{
-		if (ttl_trigger_enabled_)
-			pProp->Set(g_YesState);
-		else
-			pProp->Set(g_NoState);
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		ttl_trigger_enabled_ = ttl_trigger_supported_ && (tmpstr == g_YesState);
-		return OnUseSequence(pProp, MM::BeforeGet);  // refresh value
-	}
-	return DEVICE_OK;
+    if (eAct == MM::BeforeGet) {
+        if (ttl_trigger_enabled_)
+            pProp->Set(g_YesState);
+        else
+            pProp->Set(g_NoState);
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        ttl_trigger_enabled_ = ttl_trigger_supported_ && (tmpstr == g_YesState);
+        return OnUseSequence(pProp, MM::BeforeGet);  // refresh value
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnRBSequenceState(MM::PropertyBase* pProp, MM::ActionType eAct) {
-	if (eAct == MM::BeforeGet)
-	{
-		pProp->Set(g_IdleState);
-	}
-	else  if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_RBSequenceStart)
-		{
-			RETURN_ON_MM_ERROR(StartDASequence());
-		}
-		else if (tmpstr == g_RBSequenceStop)
-		{
-			RETURN_ON_MM_ERROR(StopDASequence());
-		}
-		else if (tmpstr == g_RBSequenceClearSeq)
-		{
-			RETURN_ON_MM_ERROR(ClearDASequence());
-		}
-		else if (tmpstr == g_RBSequenceSendSeq)
-		{
-			RETURN_ON_MM_ERROR(SendDASequence());
-		}
-		pProp->Set(g_DoneState);
-	}
-	return DEVICE_OK;
+    if (eAct == MM::BeforeGet) {
+        pProp->Set(g_IdleState);
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_RBSequenceStart) {
+            RETURN_ON_MM_ERROR(StartDASequence());
+        } else if (tmpstr == g_RBSequenceStop) {
+            RETURN_ON_MM_ERROR(StopDASequence());
+        } else if (tmpstr == g_RBSequenceClearSeq) {
+            RETURN_ON_MM_ERROR(ClearDASequence());
+        } else if (tmpstr == g_RBSequenceSendSeq) {
+            RETURN_ON_MM_ERROR(SendDASequence());
+        }
+        pProp->Set(g_DoneState);
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnAddtoRBSequence(MM::PropertyBase* pProp, MM::ActionType eAct) {
-	if (eAct == MM::BeforeGet)
-	{
-		pProp->Set(0.00);
-	}
-	else  if (eAct == MM::AfterSet)
-	{
-		double tmp;
-		pProp->Get(tmp);
-		tmp = tmp / 1000; //to go from mv to volts
-		RETURN_ON_MM_ERROR(AddToDASequence(tmp));
-	}
-	return DEVICE_OK;
+    if (eAct == MM::BeforeGet) {
+        pProp->Set(0.00);
+    } else if (eAct == MM::AfterSet) {
+        double tmp;
+        pProp->Get(tmp);
+        tmp = tmp / 1000; //to go from mv to volts
+        RETURN_ON_MM_ERROR(AddToDASequence(tmp));
+    }
+    return DEVICE_OK;
 }
 
 ////////////////////////////////////// TTL ////////////////////////////////
 
 int CDAC::OnTTLin(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << addressChar_ << "TTL X?";
-		response << ":A X=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		if (hub_->UpdatingSharedProperties())
-			return DEVICE_OK;
-		pProp->Get(tmp);
-		command << addressChar_ << "TTL X=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		command.str(""); command << tmp;
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << addressChar_ << "TTL X?";
+        response << ":A X=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp))
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties())
+            return DEVICE_OK;
+        pProp->Get(tmp);
+        command << addressChar_ << "TTL X=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        command.str(""); command << tmp;
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
+    }
+    return DEVICE_OK;
 }
 
 int CDAC::OnTTLout(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-			return DEVICE_OK;
-		command << addressChar_ << "TTL Y?";
-		response << ":A Y=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-			return DEVICE_INVALID_PROPERTY_VALUE;
-	}
-	else if (eAct == MM::AfterSet) {
-		if (hub_->UpdatingSharedProperties())
-			return DEVICE_OK;
-		pProp->Get(tmp);
-		command << addressChar_ << "TTL Y=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		command.str(""); command << tmp;
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_)
+            return DEVICE_OK;
+        command << addressChar_ << "TTL Y?";
+        response << ":A Y=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp))
+            return DEVICE_INVALID_PROPERTY_VALUE;
+    } else if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties())
+            return DEVICE_OK;
+        pProp->Get(tmp);
+        command << addressChar_ << "TTL Y=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        command.str(""); command << tmp;
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
+    }
+    return DEVICE_OK;
 }
 
 void CDAC::CreateSingleAxisRiseTimeProperty() {
-	const char* const propertyName = "SingleAxisRiseTime(ms)";
+    const char* const propertyName = "SingleAxisRiseTime(ms)";
 
-	CreateFloatProperty(
-		propertyName, 0.0, false,
-		new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
-			double tmp = 0.0;
-			if (eAct == MM::BeforeGet) {
-				if (!refreshProps_ && initialized_) {
-					return DEVICE_OK;
-				}
-				const std::string query = "OS " + axisLetter_ + "?";
-				const std::string response = ":A " + axisLetter_ + "=";
-				RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(query, response));
-				RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-				if (!pProp->Set(tmp)) {
-					return DEVICE_INVALID_PROPERTY_VALUE;
-				}
-			} else if (eAct == MM::AfterSet) {
-				pProp->Get(tmp);
-				const std::string command = "OS " + axisLetter_ + "=";
-				RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command + std::to_string(tmp), ":A"));
-			}
-			return DEVICE_OK;
-		})
-	);
+    CreateFloatProperty(
+        propertyName, 0.0, false,
+        new MM::ActionLambda([this](MM::PropertyBase* pProp, MM::ActionType eAct) {
+            double tmp = 0.0;
+            if (eAct == MM::BeforeGet) {
+                if (!refreshProps_ && initialized_) {
+                    return DEVICE_OK;
+                }
+                const std::string query = "OS " + axisLetter_ + "?";
+                const std::string response = ":A " + axisLetter_ + "=";
+                RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(query, response));
+                RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+                if (!pProp->Set(tmp)) {
+                    return DEVICE_INVALID_PROPERTY_VALUE;
+                }
+            } else if (eAct == MM::AfterSet) {
+                pProp->Get(tmp);
+                const std::string command = "OS " + axisLetter_ + "=";
+                RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command + std::to_string(tmp), ":A"));
+            }
+            return DEVICE_OK;
+        })
+    );
 
-	UpdateProperty(propertyName);
+    UpdateProperty(propertyName);
 }

--- a/DeviceAdapters/ASITiger/ASIDacXYStage.cpp
+++ b/DeviceAdapters/ASITiger/ASIDacXYStage.cpp
@@ -31,501 +31,487 @@
 #include <string>
 
 CDACXYStage::CDACXYStage(const char* name) :
-	ASIPeripheralBase< ::CXYStageBase, CDACXYStage >(name) {
-	// only set up these properties if we have the required information in the name
-	if (IsExtendedName(name)) {
-		axisLetterX_ = GetAxisLetterFromExtName(name);
-		CreateProperty(g_AxisLetterXPropertyName, axisLetterX_.c_str(), MM::String, true);
-		axisLetterY_ = GetAxisLetterFromExtName(name, 1);
-		CreateProperty(g_AxisLetterYPropertyName, axisLetterY_.c_str(), MM::String, true);
-	}
-	
-	// pre-init properties => sets the conversion factor for microns to millivolts on x and y
-	CPropertyAction* pAct;
+    ASIPeripheralBase< ::CXYStageBase, CDACXYStage >(name) {
+    // only set up these properties if we have the required information in the name
+    if (IsExtendedName(name)) {
+        axisLetterX_ = GetAxisLetterFromExtName(name);
+        CreateProperty(g_AxisLetterXPropertyName, axisLetterX_.c_str(), MM::String, true);
+        axisLetterY_ = GetAxisLetterFromExtName(name, 1);
+        CreateProperty(g_AxisLetterYPropertyName, axisLetterY_.c_str(), MM::String, true);
+    }
 
-	pAct = new CPropertyAction(this, &CDACXYStage::OnConversionFactorX);
-	CreateProperty(g_DACMicronsPerMvXPropertyName, "1", MM::Integer, false, pAct, true);
-	SetPropertyLimits(g_DACMicronsPerMvXPropertyName, 1, LONG_MAX);
-	UpdateProperty(g_DACMicronsPerMvXPropertyName);
+    // pre-init properties => sets the conversion factor for microns to millivolts on x and y
+    CPropertyAction* pAct;
 
-	pAct = new CPropertyAction(this, &CDACXYStage::OnConversionFactorY);
-	CreateProperty(g_DACMicronsPerMvYPropertyName, "1", MM::Integer, false, pAct, true);
-	SetPropertyLimits(g_DACMicronsPerMvYPropertyName, 1, LONG_MAX);
-	UpdateProperty(g_DACMicronsPerMvYPropertyName);
+    pAct = new CPropertyAction(this, &CDACXYStage::OnConversionFactorX);
+    CreateProperty(g_DACMicronsPerMvXPropertyName, "1", MM::Integer, false, pAct, true);
+    SetPropertyLimits(g_DACMicronsPerMvXPropertyName, 1, LONG_MAX);
+    UpdateProperty(g_DACMicronsPerMvXPropertyName);
+
+    pAct = new CPropertyAction(this, &CDACXYStage::OnConversionFactorY);
+    CreateProperty(g_DACMicronsPerMvYPropertyName, "1", MM::Integer, false, pAct, true);
+    SetPropertyLimits(g_DACMicronsPerMvYPropertyName, 1, LONG_MAX);
+    UpdateProperty(g_DACMicronsPerMvYPropertyName);
 }
 
 int CDACXYStage::Initialize() {
-	// call generic Initialize first, this gets the hub
-	if (const int status = PeripheralInitialize(); status != DEVICE_OK) {
-		return status;
-	}
+    // call generic Initialize first, this gets the hub
+    if (const int status = PeripheralInitialize(); status != DEVICE_OK) {
+        return status;
+    }
 
-	CPropertyAction* pAct;
+    CPropertyAction* pAct;
 
-	// create MM description; this doesn't work during hardware configuration wizard but will work afterwards
-	std::ostringstream command;
-	command << g_DacXYStageDeviceDescription << " Xaxis=" << axisLetterX_ << " Yaxis=" << axisLetterY_ << " HexAddr=" << addressString_;
-	CreateProperty(MM::g_Keyword_Description, command.str().c_str(), MM::String, true);
+    // create MM description; this doesn't work during hardware configuration wizard but will work afterwards
+    std::ostringstream command;
+    command << g_DacXYStageDeviceDescription << " Xaxis=" << axisLetterX_ << " Yaxis=" << axisLetterY_ << " HexAddr=" << addressString_;
+    CreateProperty(MM::g_Keyword_Description, command.str().c_str(), MM::String, true);
 
-	// refresh properties from controller every time - default is not to refresh (speeds things up by not redoing so much serial comm)
-	pAct = new CPropertyAction(this, &CDACXYStage::OnRefreshProperties);
-	CreateProperty(g_RefreshPropValsPropertyName, g_NoState, MM::String, false, pAct);
-	AddAllowedValue(g_RefreshPropValsPropertyName, g_NoState);
-	AddAllowedValue(g_RefreshPropValsPropertyName, g_YesState);
+    // refresh properties from controller every time - default is not to refresh (speeds things up by not redoing so much serial comm)
+    pAct = new CPropertyAction(this, &CDACXYStage::OnRefreshProperties);
+    CreateProperty(g_RefreshPropValsPropertyName, g_NoState, MM::String, false, pAct);
+    AddAllowedValue(g_RefreshPropValsPropertyName, g_NoState);
+    AddAllowedValue(g_RefreshPropValsPropertyName, g_YesState);
 
-	// save settings to controller if requested
-	pAct = new CPropertyAction(this, &CDACXYStage::OnSaveCardSettings);
-	CreateProperty(g_SaveSettingsPropertyName, g_SaveSettingsOrig, MM::String, false, pAct);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsX);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsY);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsZ);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsZJoystick);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsOrig);
-	AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsDone);
+    // save settings to controller if requested
+    pAct = new CPropertyAction(this, &CDACXYStage::OnSaveCardSettings);
+    CreateProperty(g_SaveSettingsPropertyName, g_SaveSettingsOrig, MM::String, false, pAct);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsX);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsY);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsZ);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsZJoystick);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsOrig);
+    AddAllowedValue(g_SaveSettingsPropertyName, g_SaveSettingsDone);
 
-	// get voltage limits
-	GetMaxVolts(maxvoltsX_, axisLetterX_);
-	GetMinVolts(minvoltsX_, axisLetterX_);
-	GetMaxVolts(maxvoltsY_, axisLetterY_);
-	GetMinVolts(minvoltsY_, axisLetterY_);
+    // get voltage limits
+    GetMaxVolts(maxvoltsX_, axisLetterX_);
+    GetMinVolts(minvoltsX_, axisLetterX_);
+    GetMaxVolts(maxvoltsY_, axisLetterY_);
+    GetMinVolts(minvoltsY_, axisLetterY_);
 
-	// min and max voltages for both axes as read only property
-	command.str("");
-	command << maxvoltsX_;
-	CreateProperty(g_DACMaxVoltsXPropertyName, command.str().c_str(), MM::Float, true);
-	command.str("");
-	command << minvoltsX_;
-	CreateProperty(g_DACMinVoltsXPropertyName, command.str().c_str(), MM::Float, true);
-	command.str("");
-	command << maxvoltsY_;
-	CreateProperty(g_DACMaxVoltsYPropertyName, command.str().c_str(), MM::Float, true);
-	command.str("");
-	command << minvoltsY_;
-	CreateProperty(g_DACMinVoltsYPropertyName, command.str().c_str(), MM::Float, true);
+    // min and max voltages for both axes as read only property
+    command.str("");
+    command << maxvoltsX_;
+    CreateProperty(g_DACMaxVoltsXPropertyName, command.str().c_str(), MM::Float, true);
+    command.str("");
+    command << minvoltsX_;
+    CreateProperty(g_DACMinVoltsXPropertyName, command.str().c_str(), MM::Float, true);
+    command.str("");
+    command << maxvoltsY_;
+    CreateProperty(g_DACMaxVoltsYPropertyName, command.str().c_str(), MM::Float, true);
+    command.str("");
+    command << minvoltsY_;
+    CreateProperty(g_DACMinVoltsYPropertyName, command.str().c_str(), MM::Float, true);
 
-	// signal DAC properties
-	pAct = new CPropertyAction(this, &CDACXYStage::OnDACModeX);
-	CreateProperty(g_DACModeXPropertyName, "0", MM::String, false, pAct);
-	AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_0);
-	AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_1);
-	AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_2);
-	AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_4);
-	AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_5);
-	AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_6);
-	AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_7);
-	UpdateProperty(g_DACModeXPropertyName);
+    // signal DAC properties
+    pAct = new CPropertyAction(this, &CDACXYStage::OnDACModeX);
+    CreateProperty(g_DACModeXPropertyName, "0", MM::String, false, pAct);
+    AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_0);
+    AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_1);
+    AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_2);
+    AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_4);
+    AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_5);
+    AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_6);
+    AddAllowedValue(g_DACModeXPropertyName, g_DACOutputMode_7);
+    UpdateProperty(g_DACModeXPropertyName);
 
-	pAct = new CPropertyAction(this, &CDACXYStage::OnDACModeY);
-	CreateProperty(g_DACModeYPropertyName, "0", MM::String, false, pAct);
-	AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_0);
-	AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_1);
-	AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_2);
-	AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_4);
-	AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_5);
-	AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_6);
-	AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_7);
-	UpdateProperty(g_DACModeYPropertyName);
+    pAct = new CPropertyAction(this, &CDACXYStage::OnDACModeY);
+    CreateProperty(g_DACModeYPropertyName, "0", MM::String, false, pAct);
+    AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_0);
+    AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_1);
+    AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_2);
+    AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_4);
+    AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_5);
+    AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_6);
+    AddAllowedValue(g_DACModeYPropertyName, g_DACOutputMode_7);
+    UpdateProperty(g_DACModeYPropertyName);
 
-	// DAC gate open or closed
-	pAct = new CPropertyAction(this, &CDACXYStage::OnDACGateX);
-	CreateProperty(g_DACGateXPropertyName, "0", MM::String, false, pAct);
-	AddAllowedValue(g_DACGateXPropertyName, g_OpenState);
-	AddAllowedValue(g_DACGateXPropertyName, g_ClosedState);
-	UpdateProperty(g_DACGateXPropertyName);
+    // DAC gate open or closed
+    pAct = new CPropertyAction(this, &CDACXYStage::OnDACGateX);
+    CreateProperty(g_DACGateXPropertyName, "0", MM::String, false, pAct);
+    AddAllowedValue(g_DACGateXPropertyName, g_OpenState);
+    AddAllowedValue(g_DACGateXPropertyName, g_ClosedState);
+    UpdateProperty(g_DACGateXPropertyName);
 
-	pAct = new CPropertyAction(this, &CDACXYStage::OnDACGateY);
-	CreateProperty(g_DACGateYPropertyName, "0", MM::String, false, pAct);
-	AddAllowedValue(g_DACGateYPropertyName, g_OpenState);
-	AddAllowedValue(g_DACGateYPropertyName, g_ClosedState);
-	UpdateProperty(g_DACGateYPropertyName);
+    pAct = new CPropertyAction(this, &CDACXYStage::OnDACGateY);
+    CreateProperty(g_DACGateYPropertyName, "0", MM::String, false, pAct);
+    AddAllowedValue(g_DACGateYPropertyName, g_OpenState);
+    AddAllowedValue(g_DACGateYPropertyName, g_ClosedState);
+    UpdateProperty(g_DACGateYPropertyName);
 
-	// filter cut-off frequency
-	pAct = new CPropertyAction(this, &CDACXYStage::OnCutoffFreqX);
-	CreateProperty(g_ScannerCutoffFilterXPropertyName, "0", MM::Float, false, pAct);
-	SetPropertyLimits(g_ScannerCutoffFilterXPropertyName, 0.1, 650);
-	UpdateProperty(g_ScannerCutoffFilterXPropertyName);
+    // filter cut-off frequency
+    pAct = new CPropertyAction(this, &CDACXYStage::OnCutoffFreqX);
+    CreateProperty(g_ScannerCutoffFilterXPropertyName, "0", MM::Float, false, pAct);
+    SetPropertyLimits(g_ScannerCutoffFilterXPropertyName, 0.1, 650);
+    UpdateProperty(g_ScannerCutoffFilterXPropertyName);
 
-	pAct = new CPropertyAction(this, &CDACXYStage::OnCutoffFreqY);
-	CreateProperty(g_ScannerCutoffFilterYPropertyName, "0", MM::Float, false, pAct);
-	SetPropertyLimits(g_ScannerCutoffFilterYPropertyName, 0.1, 650);
-	UpdateProperty(g_ScannerCutoffFilterYPropertyName);
+    pAct = new CPropertyAction(this, &CDACXYStage::OnCutoffFreqY);
+    CreateProperty(g_ScannerCutoffFilterYPropertyName, "0", MM::Float, false, pAct);
+    SetPropertyLimits(g_ScannerCutoffFilterYPropertyName, 0.1, 650);
+    UpdateProperty(g_ScannerCutoffFilterYPropertyName);
 
-	// joystick fast speed (JS X=)
-	pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickFastSpeed);
-	CreateProperty(g_JoystickFastSpeedPropertyName, "100", MM::Float, false, pAct);
-	SetPropertyLimits(g_JoystickFastSpeedPropertyName, 0, 100);
-	UpdateProperty(g_JoystickFastSpeedPropertyName);
+    // joystick fast speed (JS X=)
+    pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickFastSpeed);
+    CreateProperty(g_JoystickFastSpeedPropertyName, "100", MM::Float, false, pAct);
+    SetPropertyLimits(g_JoystickFastSpeedPropertyName, 0, 100);
+    UpdateProperty(g_JoystickFastSpeedPropertyName);
 
-	// joystick slow speed (JS Y=)
-	pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickSlowSpeed);
-	CreateProperty(g_JoystickSlowSpeedPropertyName, "10", MM::Float, false, pAct);
-	SetPropertyLimits(g_JoystickSlowSpeedPropertyName, 0, 100);
-	UpdateProperty(g_JoystickSlowSpeedPropertyName);
+    // joystick slow speed (JS Y=)
+    pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickSlowSpeed);
+    CreateProperty(g_JoystickSlowSpeedPropertyName, "10", MM::Float, false, pAct);
+    SetPropertyLimits(g_JoystickSlowSpeedPropertyName, 0, 100);
+    UpdateProperty(g_JoystickSlowSpeedPropertyName);
 
-	// joystick mirror (changes joystick fast/slow speeds to negative)
-	pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickMirror);
-	CreateProperty(g_JoystickMirrorPropertyName, g_NoState, MM::String, false, pAct);
-	AddAllowedValue(g_JoystickMirrorPropertyName, g_NoState);
-	AddAllowedValue(g_JoystickMirrorPropertyName, g_YesState);
-	UpdateProperty(g_JoystickMirrorPropertyName);
+    // joystick mirror (changes joystick fast/slow speeds to negative)
+    pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickMirror);
+    CreateProperty(g_JoystickMirrorPropertyName, g_NoState, MM::String, false, pAct);
+    AddAllowedValue(g_JoystickMirrorPropertyName, g_NoState);
+    AddAllowedValue(g_JoystickMirrorPropertyName, g_YesState);
+    UpdateProperty(g_JoystickMirrorPropertyName);
 
-	// joystick rotate (interchanges X and Y axes, useful if camera is rotated
-	pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickRotate);
-	CreateProperty(g_JoystickRotatePropertyName, g_NoState, MM::String, false, pAct);
-	AddAllowedValue(g_JoystickRotatePropertyName, g_NoState);
-	AddAllowedValue(g_JoystickRotatePropertyName, g_YesState);
-	UpdateProperty(g_JoystickRotatePropertyName);
+    // joystick rotate (interchanges X and Y axes, useful if camera is rotated
+    pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickRotate);
+    CreateProperty(g_JoystickRotatePropertyName, g_NoState, MM::String, false, pAct);
+    AddAllowedValue(g_JoystickRotatePropertyName, g_NoState);
+    AddAllowedValue(g_JoystickRotatePropertyName, g_YesState);
+    UpdateProperty(g_JoystickRotatePropertyName);
 
-	// joystick enable/disable
-	pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickEnableDisable);
-	CreateProperty(g_JoystickEnabledPropertyName, g_YesState, MM::String, false, pAct);
-	AddAllowedValue(g_JoystickEnabledPropertyName, g_NoState);
-	AddAllowedValue(g_JoystickEnabledPropertyName, g_YesState);
-	UpdateProperty(g_JoystickEnabledPropertyName);
+    // joystick enable/disable
+    pAct = new CPropertyAction(this, &CDACXYStage::OnJoystickEnableDisable);
+    CreateProperty(g_JoystickEnabledPropertyName, g_YesState, MM::String, false, pAct);
+    AddAllowedValue(g_JoystickEnabledPropertyName, g_NoState);
+    AddAllowedValue(g_JoystickEnabledPropertyName, g_YesState);
+    UpdateProperty(g_JoystickEnabledPropertyName);
 
-	// get build info so we can add optional properties
-	FirmwareBuild build;
-	RETURN_ON_MM_ERROR(hub_->GetBuildInfo(addressChar_, build));
+    // get build info so we can add optional properties
+    FirmwareBuild build;
+    RETURN_ON_MM_ERROR(hub_->GetBuildInfo(addressChar_, build));
 
-	// add single-axis properties if supported
-	// Normally we check for version, but this card is always going to have v3.39 and above
-	if (build.vAxesProps[0] & BIT5)
-	{
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAAmplitudeX);
-		CreateProperty(g_SAAmplitudeXDACPropertyName, "0", MM::Float, false, pAct);
-		SetPropertyLimits(g_SAAmplitudeXDACPropertyName, 0, (maxvoltsX_ - minvoltsX_) * 1000);
-		UpdateProperty(g_SAAmplitudeXDACPropertyName);
+    // add single-axis properties if supported
+    // Normally we check for version, but this card is always going to have v3.39 and above
+    if (build.vAxesProps[0] & BIT5) {
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAAmplitudeX);
+        CreateProperty(g_SAAmplitudeXDACPropertyName, "0", MM::Float, false, pAct);
+        SetPropertyLimits(g_SAAmplitudeXDACPropertyName, 0, (maxvoltsX_ - minvoltsX_) * 1000);
+        UpdateProperty(g_SAAmplitudeXDACPropertyName);
 
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAAmplitudeY);
-		CreateProperty(g_SAAmplitudeYDACPropertyName, "0", MM::Float, false, pAct);
-		SetPropertyLimits(g_SAAmplitudeYDACPropertyName, 0, (maxvoltsY_ - minvoltsY_) * 1000);
-		UpdateProperty(g_SAAmplitudeYDACPropertyName);
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAAmplitudeY);
+        CreateProperty(g_SAAmplitudeYDACPropertyName, "0", MM::Float, false, pAct);
+        SetPropertyLimits(g_SAAmplitudeYDACPropertyName, 0, (maxvoltsY_ - minvoltsY_) * 1000);
+        UpdateProperty(g_SAAmplitudeYDACPropertyName);
 
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAOffsetX);
-		CreateProperty(g_SAOffsetDACXPropertyName, "0", MM::Float, false, pAct);
-		SetPropertyLimits(g_SAOffsetDACXPropertyName, minvoltsX_ * 1000, maxvoltsX_ * 1000);
-		UpdateProperty(g_SAOffsetDACXPropertyName);
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAOffsetX);
+        CreateProperty(g_SAOffsetDACXPropertyName, "0", MM::Float, false, pAct);
+        SetPropertyLimits(g_SAOffsetDACXPropertyName, minvoltsX_ * 1000, maxvoltsX_ * 1000);
+        UpdateProperty(g_SAOffsetDACXPropertyName);
 
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAOffsetY);
-		CreateProperty(g_SAOffsetDACYPropertyName, "0", MM::Float, false, pAct);
-		SetPropertyLimits(g_SAOffsetDACYPropertyName, minvoltsY_ * 1000, maxvoltsY_ * 1000);
-		UpdateProperty(g_SAOffsetDACYPropertyName);
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAOffsetY);
+        CreateProperty(g_SAOffsetDACYPropertyName, "0", MM::Float, false, pAct);
+        SetPropertyLimits(g_SAOffsetDACYPropertyName, minvoltsY_ * 1000, maxvoltsY_ * 1000);
+        UpdateProperty(g_SAOffsetDACYPropertyName);
 
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAPeriodX);
-		CreateProperty(g_SAPeriodXPropertyName, "0", MM::Integer, false, pAct);
-		UpdateProperty(g_SAPeriodXPropertyName);
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAPeriodX);
+        CreateProperty(g_SAPeriodXPropertyName, "0", MM::Integer, false, pAct);
+        UpdateProperty(g_SAPeriodXPropertyName);
 
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAPeriodY);
-		CreateProperty(g_SAPeriodYPropertyName, "0", MM::Integer, false, pAct);
-		UpdateProperty(g_SAPeriodYPropertyName);
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAPeriodY);
+        CreateProperty(g_SAPeriodYPropertyName, "0", MM::Integer, false, pAct);
+        UpdateProperty(g_SAPeriodYPropertyName);
 
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAModeX);
-		CreateProperty(g_SAModeXPropertyName, g_SAMode_0, MM::String, false, pAct);
-		AddAllowedValue(g_SAModeXPropertyName, g_SAMode_0);
-		AddAllowedValue(g_SAModeXPropertyName, g_SAMode_1);
-		AddAllowedValue(g_SAModeXPropertyName, g_SAMode_2);
-		AddAllowedValue(g_SAModeXPropertyName, g_SAMode_3);
-		UpdateProperty(g_SAModeXPropertyName);
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAModeX);
+        CreateProperty(g_SAModeXPropertyName, g_SAMode_0, MM::String, false, pAct);
+        AddAllowedValue(g_SAModeXPropertyName, g_SAMode_0);
+        AddAllowedValue(g_SAModeXPropertyName, g_SAMode_1);
+        AddAllowedValue(g_SAModeXPropertyName, g_SAMode_2);
+        AddAllowedValue(g_SAModeXPropertyName, g_SAMode_3);
+        UpdateProperty(g_SAModeXPropertyName);
 
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAModeY);
-		CreateProperty(g_SAModeYPropertyName, g_SAMode_0, MM::String, false, pAct);
-		AddAllowedValue(g_SAModeYPropertyName, g_SAMode_0);
-		AddAllowedValue(g_SAModeYPropertyName, g_SAMode_1);
-		AddAllowedValue(g_SAModeYPropertyName, g_SAMode_2);
-		AddAllowedValue(g_SAModeYPropertyName, g_SAMode_3);
-		UpdateProperty(g_SAModeYPropertyName);
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAModeY);
+        CreateProperty(g_SAModeYPropertyName, g_SAMode_0, MM::String, false, pAct);
+        AddAllowedValue(g_SAModeYPropertyName, g_SAMode_0);
+        AddAllowedValue(g_SAModeYPropertyName, g_SAMode_1);
+        AddAllowedValue(g_SAModeYPropertyName, g_SAMode_2);
+        AddAllowedValue(g_SAModeYPropertyName, g_SAMode_3);
+        UpdateProperty(g_SAModeYPropertyName);
 
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAPatternX);
-		CreateProperty(g_SAPatternXPropertyName, g_SAPattern_0, MM::String, false, pAct);
-		AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_0);
-		AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_1);
-		AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_2);
-		if (FirmwareVersionAtLeast(3.14)) {
-			AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_3);
-		}
-		if (FirmwareVersionAtLeast(3.55)) {
-			AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_4);
-		}
-		UpdateProperty(g_SAPatternXPropertyName);
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAPatternX);
+        CreateProperty(g_SAPatternXPropertyName, g_SAPattern_0, MM::String, false, pAct);
+        AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_0);
+        AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_1);
+        AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_2);
+        if (FirmwareVersionAtLeast(3.14)) {
+            AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_3);
+        }
+        if (FirmwareVersionAtLeast(3.55)) {
+            AddAllowedValue(g_SAPatternXPropertyName, g_SAPattern_4);
+        }
+        UpdateProperty(g_SAPatternXPropertyName);
 
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAPatternY);
-		CreateProperty(g_SAPatternYPropertyName, g_SAPattern_0, MM::String, false, pAct);
-		AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_0);
-		AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_1);
-		AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_2);
-		if (FirmwareVersionAtLeast(3.14)) {
-			AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_3);
-		}
-		if (FirmwareVersionAtLeast(3.55)) {
-			AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_4);
-		}
-		UpdateProperty(g_SAPatternYPropertyName);
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAPatternY);
+        CreateProperty(g_SAPatternYPropertyName, g_SAPattern_0, MM::String, false, pAct);
+        AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_0);
+        AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_1);
+        AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_2);
+        if (FirmwareVersionAtLeast(3.14)) {
+            AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_3);
+        }
+        if (FirmwareVersionAtLeast(3.55)) {
+            AddAllowedValue(g_SAPatternYPropertyName, g_SAPattern_4);
+        }
+        UpdateProperty(g_SAPatternYPropertyName);
 
-		// rise time is used by variable waveforms
-		if (FirmwareVersionAtLeast(3.55)) {
-			CreateSingleAxisRiseTimeProperty('X', axisLetterX_);
-			CreateSingleAxisRiseTimeProperty('Y', axisLetterY_);
-		}
+        // rise time is used by variable waveforms
+        if (FirmwareVersionAtLeast(3.55)) {
+            CreateSingleAxisRiseTimeProperty('X', axisLetterX_);
+            CreateSingleAxisRiseTimeProperty('Y', axisLetterY_);
+        }
 
-		// generates a set of additional advanced properties that are rarely used
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAAdvancedX);
-		CreateProperty(g_AdvancedSAPropertiesXPropertyName, g_NoState, MM::String, false, pAct);
-		AddAllowedValue(g_AdvancedSAPropertiesXPropertyName, g_NoState);
-		AddAllowedValue(g_AdvancedSAPropertiesXPropertyName, g_YesState);
-		UpdateProperty(g_AdvancedSAPropertiesXPropertyName);
+        // generates a set of additional advanced properties that are rarely used
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAAdvancedX);
+        CreateProperty(g_AdvancedSAPropertiesXPropertyName, g_NoState, MM::String, false, pAct);
+        AddAllowedValue(g_AdvancedSAPropertiesXPropertyName, g_NoState);
+        AddAllowedValue(g_AdvancedSAPropertiesXPropertyName, g_YesState);
+        UpdateProperty(g_AdvancedSAPropertiesXPropertyName);
 
-		// generates a set of additional advanced properties that are rarely used
-		pAct = new CPropertyAction(this, &CDACXYStage::OnSAAdvancedY);
-		CreateProperty(g_AdvancedSAPropertiesYPropertyName, g_NoState, MM::String, false, pAct);
-		AddAllowedValue(g_AdvancedSAPropertiesYPropertyName, g_NoState);
-		AddAllowedValue(g_AdvancedSAPropertiesYPropertyName, g_YesState);
-		UpdateProperty(g_AdvancedSAPropertiesYPropertyName);
-	}
+        // generates a set of additional advanced properties that are rarely used
+        pAct = new CPropertyAction(this, &CDACXYStage::OnSAAdvancedY);
+        CreateProperty(g_AdvancedSAPropertiesYPropertyName, g_NoState, MM::String, false, pAct);
+        AddAllowedValue(g_AdvancedSAPropertiesYPropertyName, g_NoState);
+        AddAllowedValue(g_AdvancedSAPropertiesYPropertyName, g_YesState);
+        UpdateProperty(g_AdvancedSAPropertiesYPropertyName);
+    }
 
-	// add ring buffer properties if supported
-	if (build.vAxesProps[0] & BIT1)
-	{
-		// get the number of ring buffer positions from the BU X output
-		std::string rb_define = hub_->GetDefineString(build, "RING BUFFER");
+    // add ring buffer properties if supported
+    if (build.vAxesProps[0] & BIT1) {
+        // get the number of ring buffer positions from the BU X output
+        std::string rb_define = hub_->GetDefineString(build, "RING BUFFER");
 
-		ring_buffer_capacity_ = 0;
-		if (rb_define.size() > 12)
-		{
-			ring_buffer_capacity_ = atol(rb_define.substr(11).c_str());
-		}
+        ring_buffer_capacity_ = 0;
+        if (rb_define.size() > 12) {
+            ring_buffer_capacity_ = atol(rb_define.substr(11).c_str());
+        }
 
-		if (ring_buffer_capacity_ != 0)
-		{
-			ring_buffer_supported_ = true;
+        if (ring_buffer_capacity_ != 0) {
+            ring_buffer_supported_ = true;
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnRBMode);
-			CreateProperty(g_RB_ModePropertyName, g_RB_OnePoint_1, MM::String, false, pAct);
-			AddAllowedValue(g_RB_ModePropertyName, g_RB_OnePoint_1);
-			AddAllowedValue(g_RB_ModePropertyName, g_RB_PlayOnce_2);
-			AddAllowedValue(g_RB_ModePropertyName, g_RB_PlayRepeat_3);
-			UpdateProperty(g_RB_ModePropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnRBMode);
+            CreateProperty(g_RB_ModePropertyName, g_RB_OnePoint_1, MM::String, false, pAct);
+            AddAllowedValue(g_RB_ModePropertyName, g_RB_OnePoint_1);
+            AddAllowedValue(g_RB_ModePropertyName, g_RB_PlayOnce_2);
+            AddAllowedValue(g_RB_ModePropertyName, g_RB_PlayRepeat_3);
+            UpdateProperty(g_RB_ModePropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnRBDelayBetweenPoints);
-			CreateProperty(g_RB_DelayPropertyName, "0", MM::Integer, false, pAct);
-			UpdateProperty(g_RB_DelayPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnRBDelayBetweenPoints);
+            CreateProperty(g_RB_DelayPropertyName, "0", MM::Integer, false, pAct);
+            UpdateProperty(g_RB_DelayPropertyName);
 
-			// "do it" property to do TTL trigger via serial
-			pAct = new CPropertyAction(this, &CDACXYStage::OnRBTrigger);
-			CreateProperty(g_RB_TriggerPropertyName, g_IdleState, MM::String, false, pAct);
-			AddAllowedValue(g_RB_TriggerPropertyName, g_IdleState, 0);
-			AddAllowedValue(g_RB_TriggerPropertyName, g_DoItState, 1);
-			AddAllowedValue(g_RB_TriggerPropertyName, g_DoneState, 2);
-			UpdateProperty(g_RB_TriggerPropertyName);
+            // "do it" property to do TTL trigger via serial
+            pAct = new CPropertyAction(this, &CDACXYStage::OnRBTrigger);
+            CreateProperty(g_RB_TriggerPropertyName, g_IdleState, MM::String, false, pAct);
+            AddAllowedValue(g_RB_TriggerPropertyName, g_IdleState, 0);
+            AddAllowedValue(g_RB_TriggerPropertyName, g_DoItState, 1);
+            AddAllowedValue(g_RB_TriggerPropertyName, g_DoneState, 2);
+            UpdateProperty(g_RB_TriggerPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnRBRunning);
-			CreateProperty(g_RB_AutoplayRunningPropertyName, g_NoState, MM::String, false, pAct);
-			AddAllowedValue(g_RB_AutoplayRunningPropertyName, g_NoState);
-			AddAllowedValue(g_RB_AutoplayRunningPropertyName, g_YesState);
-			UpdateProperty(g_RB_AutoplayRunningPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnRBRunning);
+            CreateProperty(g_RB_AutoplayRunningPropertyName, g_NoState, MM::String, false, pAct);
+            AddAllowedValue(g_RB_AutoplayRunningPropertyName, g_NoState);
+            AddAllowedValue(g_RB_AutoplayRunningPropertyName, g_YesState);
+            UpdateProperty(g_RB_AutoplayRunningPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnUseSequence);
-			CreateProperty(g_UseSequencePropertyName, g_NoState, MM::String, false, pAct);
-			AddAllowedValue(g_UseSequencePropertyName, g_NoState);
-			AddAllowedValue(g_UseSequencePropertyName, g_YesState);
-			ttl_trigger_enabled_ = false;
-		}
+            pAct = new CPropertyAction(this, &CDACXYStage::OnUseSequence);
+            CreateProperty(g_UseSequencePropertyName, g_NoState, MM::String, false, pAct);
+            AddAllowedValue(g_UseSequencePropertyName, g_NoState);
+            AddAllowedValue(g_UseSequencePropertyName, g_YesState);
+            ttl_trigger_enabled_ = false;
+        }
 
-		if ((hub_->IsDefinePresent(build, "IN0_INT")) && ring_buffer_supported_)
-		{
-			ttl_trigger_supported_ = true;
-			
-			// TTL In Mode
-			pAct = new CPropertyAction(this, &CDACXYStage::OnTTLin);
-			CreateProperty(g_TTLinName, "0", MM::Integer, false, pAct);
-			SetPropertyLimits(g_TTLinName, 0, 30);
-			UpdateProperty(g_TTLinName);
+        if ((hub_->IsDefinePresent(build, "IN0_INT")) && ring_buffer_supported_) {
+            ttl_trigger_supported_ = true;
 
-			// TTL Out Mode
-			pAct = new CPropertyAction(this, &CDACXYStage::OnTTLout);
-			CreateProperty(g_TTLoutName, "0", MM::Integer, false, pAct);
-			SetPropertyLimits(g_TTLoutName, 0, 30);
-			UpdateProperty(g_TTLoutName);
-		}
-	}
+            // TTL In Mode
+            pAct = new CPropertyAction(this, &CDACXYStage::OnTTLin);
+            CreateProperty(g_TTLinName, "0", MM::Integer, false, pAct);
+            SetPropertyLimits(g_TTLinName, 0, 30);
+            UpdateProperty(g_TTLinName);
 
-	initialized_ = true;
-	return DEVICE_OK;
+            // TTL Out Mode
+            pAct = new CPropertyAction(this, &CDACXYStage::OnTTLout);
+            CreateProperty(g_TTLoutName, "0", MM::Integer, false, pAct);
+            SetPropertyLimits(g_TTLoutName, 0, 30);
+            UpdateProperty(g_TTLoutName);
+        }
+    }
+
+    initialized_ = true;
+    return DEVICE_OK;
 }
 
 // XYStage API
 
 int CDACXYStage::Stop()
 {
-	// note this stops the card which usually is synonymous with the stage, \ stops all stages
-	std::ostringstream command;
-	command << addressChar_ << "HALT";
-	RETURN_ON_MM_ERROR(hub_->QueryCommand(command.str()));
-	return DEVICE_OK;
+    // note this stops the card which usually is synonymous with the stage, \ stops all stages
+    std::ostringstream command;
+    command << addressChar_ << "HALT";
+    RETURN_ON_MM_ERROR(hub_->QueryCommand(command.str()));
+    return DEVICE_OK;
 }
 
 int CDACXYStage::GetPositionSteps(long& x, long& y)
 {
-	std::ostringstream command;
-	command << "W " << axisLetterX_;
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	double tmp;
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition2(tmp));
-	x = (long)(tmp * umToMvX_);
-	command.str("");
-	command << "W " << axisLetterY_;
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition2(tmp));
-	y = (long)(tmp * umToMvY_);
-	return DEVICE_OK;
+    std::ostringstream command;
+    command << "W " << axisLetterX_;
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    double tmp;
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition2(tmp));
+    x = (long)(tmp * umToMvX_);
+    command.str("");
+    command << "W " << axisLetterY_;
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition2(tmp));
+    y = (long)(tmp * umToMvY_);
+    return DEVICE_OK;
 }
 
 int CDACXYStage::SetPositionSteps(long x, long y)
 {
-	std::ostringstream command;
-	command << "M " << axisLetterX_ << "=" << (x / umToMvX_) << " " << axisLetterY_ << "=" << (y / umToMvY_);
-	return hub_->QueryCommandVerify(command.str(), ":A");
+    std::ostringstream command;
+    command << "M " << axisLetterX_ << "=" << (x / umToMvX_) << " " << axisLetterY_ << "=" << (y / umToMvY_);
+    return hub_->QueryCommandVerify(command.str(), ":A");
 }
 
 int CDACXYStage::SetRelativePositionSteps(long x, long y)
 {
-	std::ostringstream command;
-	if ((x == 0) && (y != 0))
-	{
-		command << "R " << axisLetterY_ << "=" << (y / umToMvY_);
-	}
-	else if ((x != 0) && (y == 0))
-	{
-		command << "R " << axisLetterX_ << "=" << (x / umToMvX_);
-	}
-	else
-	{
-		command << "R " << axisLetterX_ << "=" << (x / umToMvX_) << " " << axisLetterY_ << "=" << (y / umToMvY_);
-	}
-	return hub_->QueryCommandVerify(command.str(), ":A");
+    std::ostringstream command;
+    if ((x == 0) && (y != 0)) {
+        command << "R " << axisLetterY_ << "=" << (y / umToMvY_);
+    } else if ((x != 0) && (y == 0)) {
+        command << "R " << axisLetterX_ << "=" << (x / umToMvX_);
+    } else {
+        command << "R " << axisLetterX_ << "=" << (x / umToMvX_) << " " << axisLetterY_ << "=" << (y / umToMvY_);
+    }
+    return hub_->QueryCommandVerify(command.str(), ":A");
 }
 
 // FIXME: is this correct?
 int CDACXYStage::GetStepLimits(long& xMin, long& xMax, long& yMin, long& yMax)
 {
-	double minVoltsX = 0.0;
-	double minVoltsY = 0.0;
-	double maxVoltsX = 0.0;
-	double maxVoltsY = 0.0;
-	// get limits in volts
-	GetMinVolts(minVoltsX, axisLetterX_);
-	GetMinVolts(minVoltsY, axisLetterY_);
-	GetMaxVolts(maxVoltsX, axisLetterX_);
-	GetMaxVolts(maxVoltsY, axisLetterY_);
-	// convert to millivolts
-	xMin = (long)(minVoltsX * 1000);
-	yMin = (long)(minVoltsY * 1000);
-	xMax = (long)(maxVoltsX * 1000);
-	yMax = (long)(maxVoltsY * 1000);
-	// convert to microns
-	xMin *= umToMvX_;
-	yMin *= umToMvY_;
-	xMax *= umToMvX_;
-	yMax *= umToMvY_;
-	return DEVICE_OK;
+    double minVoltsX = 0.0;
+    double minVoltsY = 0.0;
+    double maxVoltsX = 0.0;
+    double maxVoltsY = 0.0;
+    // get limits in volts
+    GetMinVolts(minVoltsX, axisLetterX_);
+    GetMinVolts(minVoltsY, axisLetterY_);
+    GetMaxVolts(maxVoltsX, axisLetterX_);
+    GetMaxVolts(maxVoltsY, axisLetterY_);
+    // convert to millivolts
+    xMin = (long)(minVoltsX * 1000);
+    yMin = (long)(minVoltsY * 1000);
+    xMax = (long)(maxVoltsX * 1000);
+    yMax = (long)(maxVoltsY * 1000);
+    // convert to microns
+    xMin *= umToMvX_;
+    yMin *= umToMvY_;
+    xMax *= umToMvX_;
+    yMax *= umToMvY_;
+    return DEVICE_OK;
 }
 
 int CDACXYStage::SetOrigin()
 {
-	std::ostringstream command;
-	command << "H " << axisLetterX_ << "=0 " << axisLetterY_ << "=0";
-	return hub_->QueryCommandVerify(command.str(), ":A");
+    std::ostringstream command;
+    command << "H " << axisLetterX_ << "=0 " << axisLetterY_ << "=0";
+    return hub_->QueryCommandVerify(command.str(), ":A");
 }
 
 int CDACXYStage::SetXOrigin()
 {
-	std::ostringstream command; 
-	command << "H " << axisLetterX_ << "=0";;
-	return hub_->QueryCommandVerify(command.str(), ":A");
+    std::ostringstream command;
+    command << "H " << axisLetterX_ << "=0";;
+    return hub_->QueryCommandVerify(command.str(), ":A");
 }
 
 int CDACXYStage::SetYOrigin()
 {
-	std::ostringstream command;
-	command << "H " << axisLetterY_ << "=0";;
-	return hub_->QueryCommandVerify(command.str(), ":A");
+    std::ostringstream command;
+    command << "H " << axisLetterY_ << "=0";;
+    return hub_->QueryCommandVerify(command.str(), ":A");
 }
 
 int CDACXYStage::Home()
 {
-	std::ostringstream command;
-	command << "! " << axisLetterX_ << " " << axisLetterY_;
-	return hub_->QueryCommandVerify(command.str(), ":A");
+    std::ostringstream command;
+    command << "! " << axisLetterX_ << " " << axisLetterY_;
+    return hub_->QueryCommandVerify(command.str(), ":A");
 }
 
 int CDACXYStage::SetHome()
 {
-	std::ostringstream command;
-	command << "HM " << axisLetterX_ << "+" << " " << axisLetterY_ << "+";
-	return hub_->QueryCommandVerify(command.str(), ":A");
+    std::ostringstream command;
+    command << "HM " << axisLetterX_ << "+" << " " << axisLetterY_ << "+";
+    return hub_->QueryCommandVerify(command.str(), ":A");
 }
 
 int CDACXYStage::Move(double vx, double vy)
 {
-	std::ostringstream command;
+    std::ostringstream command;
 
-	command << "VE " << axisLetterX_ << "=" << vx << " " << axisLetterY_ << "=" << vy;
-	return hub_->QueryCommandVerify(command.str(), ":A");
+    command << "VE " << axisLetterX_ << "=" << vx << " " << axisLetterY_ << "=" << vy;
+    return hub_->QueryCommandVerify(command.str(), ":A");
 }
 
 // DAC API
 
 int CDACXYStage::SetGateOpen(bool open, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	if (open)
-	{
-		command << "MC " << axisLetter << "+";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	else
-	{
-		command << "MC " << axisLetter << "-";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (open) {
+        command << "MC " << axisLetter << "+";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    } else {
+        command << "MC " << axisLetter << "-";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::GetGateOpen(bool& open, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	long tmp;
-	command << "MC " << axisLetter << "?";
+    std::ostringstream command;
+    long tmp;
+    command << "MC " << axisLetter << "?";
 
-	open = false; // in case of error we return that the gate is closed
-	// "MC <Axis>?" replies look like ":A 1"
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition(3, tmp));
+    open = false; // in case of error we return that the gate is closed
+    // "MC <Axis>?" replies look like ":A 1"
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterPosition(3, tmp));
 
-	if (tmp == 1)
-	{
-		open = true;
-	}
-	return DEVICE_OK;
+    if (tmp == 1) {
+        open = true;
+    }
+    return DEVICE_OK;
 }
 
 // DAC Helpers
 
 int CDACXYStage::GetMaxVolts(double& volts, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	command << "SU " << axisLetter << "?";
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(volts));
-	return DEVICE_OK;
+    std::ostringstream command;
+    command << "SU " << axisLetter << "?";
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(volts));
+    return DEVICE_OK;
 }
 
 int CDACXYStage::GetMinVolts(double& volts, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	command << "SL " << axisLetter << "?";
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(volts));
-	return DEVICE_OK;
+    std::ostringstream command;
+    command << "SL " << axisLetter << "?";
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(volts));
+    return DEVICE_OK;
 }
 
 // action handlers
@@ -533,83 +519,72 @@ int CDACXYStage::GetMinVolts(double& volts, const std::string& axisLetter)
 // redoes the joystick settings so they can be saved using SS Z
 int CDACXYStage::OnSaveJoystickSettings()
 {
-	long tmp;
-	std::string tmpstr;
-	std::ostringstream command;
-	std::ostringstream response;
-	command << "J " << axisLetterX_ << "?";
-	response << ":A " << axisLetterX_ << "=";
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-	tmp += 100;
-	command.str("");
-	command << "J " << axisLetterX_ << "=" << tmp;
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	command.str("");
-	response.str("");
-	command << "J " << axisLetterY_ << "?";
-	response << ":A " << axisLetterY_ << "=";
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-	RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-	tmp += 100;
-	command.str("");
-	command << "J " << axisLetterY_ << "=" << tmp;
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	return DEVICE_OK;
+    long tmp;
+    std::string tmpstr;
+    std::ostringstream command;
+    std::ostringstream response;
+    command << "J " << axisLetterX_ << "?";
+    response << ":A " << axisLetterX_ << "=";
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+    tmp += 100;
+    command.str("");
+    command << "J " << axisLetterX_ << "=" << tmp;
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    command.str("");
+    response.str("");
+    command << "J " << axisLetterY_ << "?";
+    response << ":A " << axisLetterY_ << "=";
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+    RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+    tmp += 100;
+    command.str("");
+    command << "J " << axisLetterY_ << "=" << tmp;
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnRefreshProperties(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	if (eAct == MM::AfterSet)
-	{
-		std::string tmp;
-		pProp->Get(tmp);
-		refreshProps_ = (tmp == g_YesState);
-	}
-	return DEVICE_OK;
+    if (eAct == MM::AfterSet) {
+        std::string tmp;
+        pProp->Get(tmp);
+        refreshProps_ = (tmp == g_YesState);
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnSaveCardSettings(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::string tmpstr;
-	std::ostringstream command;
-	if (eAct == MM::AfterSet)
-	{
-		command << addressChar_ << "SS ";
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SaveSettingsOrig)
-		{
-			return DEVICE_OK;
-		}
-		if (tmpstr == g_SaveSettingsDone)
-		{
-			return DEVICE_OK;
-		}
-		if (tmpstr == g_SaveSettingsX)
-		{
-			command << 'X';
-		}
-		else if (tmpstr == g_SaveSettingsY)
-		{
-			command << 'Y';
-		}
-		else if (tmpstr == g_SaveSettingsZ)
-		{
-			command << 'Z';
-		}
-		else if (tmpstr == g_SaveSettingsZJoystick)
-		{
-			command << 'Z';
-			// do save joystick settings first
-			RETURN_ON_MM_ERROR(OnSaveJoystickSettings());
-		}
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A", (long)200));  // note added 200ms delay
-		pProp->Set(g_SaveSettingsDone);
-		command.str("");
-		command << g_SaveSettingsDone;
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
-	}
-	return DEVICE_OK;
+    std::string tmpstr;
+    std::ostringstream command;
+    if (eAct == MM::AfterSet) {
+        command << addressChar_ << "SS ";
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SaveSettingsOrig) {
+            return DEVICE_OK;
+        }
+        if (tmpstr == g_SaveSettingsDone) {
+            return DEVICE_OK;
+        }
+        if (tmpstr == g_SaveSettingsX) {
+            command << 'X';
+        } else if (tmpstr == g_SaveSettingsY) {
+            command << 'Y';
+        } else if (tmpstr == g_SaveSettingsZ) {
+            command << 'Z';
+        } else if (tmpstr == g_SaveSettingsZJoystick) {
+            command << 'Z';
+            // do save joystick settings first
+            RETURN_ON_MM_ERROR(OnSaveJoystickSettings());
+        }
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A", (long)200));  // note added 200ms delay
+        pProp->Set(g_SaveSettingsDone);
+        command.str("");
+        command << g_SaveSettingsDone;
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
+    }
+    return DEVICE_OK;
 }
 
 /////////////// DAC PROPERTIES ///////////////
@@ -617,309 +592,239 @@ int CDACXYStage::OnSaveCardSettings(MM::PropertyBase* pProp, MM::ActionType eAct
 // will need to restart the controller for settings to take effect
 int CDACXYStage::OnDACModeGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		std::ostringstream response;
-		command << "PR " << axisLetter << "?"; // On SIGNAL_DAC this is on PR(system flag) instead of PM because I needed upper and lower limits to change too 
-		response << ":A " << axisLetter << "="; // Reply for PR command is ":A H=6 <CR><LF>"
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+    std::ostringstream command;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        std::ostringstream response;
+        command << "PR " << axisLetter << "?"; // On SIGNAL_DAC this is on PR(system flag) instead of PM because I needed upper and lower limits to change too
+        response << ":A " << axisLetter << "="; // Reply for PR command is ":A H=6 <CR><LF>"
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
 
-		bool success = 0;
-		switch (tmp)
-		{
-		case 1: success = pProp->Set(g_DACOutputMode_1); break;
-		case 0: success = pProp->Set(g_DACOutputMode_0); break;
-		case 2: success = pProp->Set(g_DACOutputMode_2);  break;
-		case 4: success = pProp->Set(g_DACOutputMode_4);  break;
-		case 5: success = pProp->Set(g_DACOutputMode_5);  break;
-		case 6: success = pProp->Set(g_DACOutputMode_6);  break;
-		case 7: success = pProp->Set(g_DACOutputMode_7);  break;
-		default: success = 0; break;
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_DACOutputMode_0)
-		{
-			tmp = 0;
-		}
-		else if (tmpstr == g_DACOutputMode_1)
-		{
-			tmp = 1;
-		}
-		else if (tmpstr == g_DACOutputMode_2)
-		{
-			tmp = 2;
-		}
-		else if (tmpstr == g_DACOutputMode_4)
-		{
-			tmp = 4;
-		}
-		else if (tmpstr == g_DACOutputMode_5)
-		{
-			tmp = 5;
-		}
-		else if (tmpstr == g_DACOutputMode_6)
-		{
-			tmp = 6;
-		}
-		else if (tmpstr == g_DACOutputMode_7)
-		{
-			tmp = 7;
-		}
-		else
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		command << "PR " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+        bool success = 0;
+        switch (tmp) {
+        case 1: success = pProp->Set(g_DACOutputMode_1); break;
+        case 0: success = pProp->Set(g_DACOutputMode_0); break;
+        case 2: success = pProp->Set(g_DACOutputMode_2);  break;
+        case 4: success = pProp->Set(g_DACOutputMode_4);  break;
+        case 5: success = pProp->Set(g_DACOutputMode_5);  break;
+        case 6: success = pProp->Set(g_DACOutputMode_6);  break;
+        case 7: success = pProp->Set(g_DACOutputMode_7);  break;
+        default: success = 0; break;
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_DACOutputMode_0) {
+            tmp = 0;
+        } else if (tmpstr == g_DACOutputMode_1) {
+            tmp = 1;
+        } else if (tmpstr == g_DACOutputMode_2) {
+            tmp = 2;
+        } else if (tmpstr == g_DACOutputMode_4) {
+            tmp = 4;
+        } else if (tmpstr == g_DACOutputMode_5) {
+            tmp = 5;
+        } else if (tmpstr == g_DACOutputMode_6) {
+            tmp = 6;
+        } else if (tmpstr == g_DACOutputMode_7) {
+            tmp = 7;
+        } else {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        command << "PR " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnDACGateGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	bool tmp;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		RETURN_ON_MM_ERROR(GetGateOpen(tmp, axisLetter));
+    bool tmp;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        RETURN_ON_MM_ERROR(GetGateOpen(tmp, axisLetter));
 
-		if (tmp) // true
-		{
-			pProp->Set(g_OpenState);
-		}
-		else
-		{
-			pProp->Set(g_ClosedState);
-		}
-		return DEVICE_OK;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_OpenState)
-		{
-			tmp = true;
-		}
-		else
-		{
-			tmp = false;
-		}
-		RETURN_ON_MM_ERROR(SetGateOpen(tmp, axisLetter));
-	}
-	return DEVICE_OK;
+        if (tmp) {
+            pProp->Set(g_OpenState);
+        } else {
+            pProp->Set(g_ClosedState);
+        }
+        return DEVICE_OK;
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_OpenState) {
+            tmp = true;
+        } else {
+            tmp = false;
+        }
+        RETURN_ON_MM_ERROR(SetGateOpen(tmp, axisLetter));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnCutoffFreqGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "B " << axisLetter << "?";
-		response << ":" << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(tmp);
-		command << "B " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "B " << axisLetter << "?";
+        response << ":" << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp)) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "B " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 /////////////// RING BUFFER ///////////////
 
 int CDACXYStage::OnRBMode(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << addressChar_ << "RM F?";
-		response << ":A F=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (tmp >= 128)
-		{
-			tmp -= 128;  // remove the "running now" code if present
-		}
-		bool success;
-		switch (tmp)
-		{
-		case 1: success = pProp->Set(g_RB_OnePoint_1); break;
-		case 2: success = pProp->Set(g_RB_PlayOnce_2); break;
-		case 3: success = pProp->Set(g_RB_PlayRepeat_3); break;
-		default: success = false;
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		if (hub_->UpdatingSharedProperties())
-		{
-			return DEVICE_OK;
-		}
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_RB_OnePoint_1)
-		{
-			tmp = 1;
-		}
-		else if (tmpstr == g_RB_PlayOnce_2)
-		{
-			tmp = 2;
-		}
-		else if (tmpstr == g_RB_PlayRepeat_3)
-		{
-			tmp = 3;
-		}
-		else
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		command << addressChar_ << "RM F=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), tmpstr.c_str()));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << addressChar_ << "RM F?";
+        response << ":A F=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (tmp >= 128) {
+            tmp -= 128;  // remove the "running now" code if present
+        }
+        bool success;
+        switch (tmp) {
+        case 1: success = pProp->Set(g_RB_OnePoint_1); break;
+        case 2: success = pProp->Set(g_RB_PlayOnce_2); break;
+        case 3: success = pProp->Set(g_RB_PlayRepeat_3); break;
+        default: success = false;
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties()) {
+            return DEVICE_OK;
+        }
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_RB_OnePoint_1) {
+            tmp = 1;
+        } else if (tmpstr == g_RB_PlayOnce_2) {
+            tmp = 2;
+        } else if (tmpstr == g_RB_PlayRepeat_3) {
+            tmp = 3;
+        } else {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        command << addressChar_ << "RM F=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), tmpstr.c_str()));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnRBTrigger(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	if (eAct == MM::BeforeGet)
-	{
-		pProp->Set(g_IdleState);
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		if (hub_->UpdatingSharedProperties())
-		{
-			return DEVICE_OK;
-		}
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_DoItState)
-		{
-			command << addressChar_ << "RM";
-			RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-			pProp->Set(g_DoneState);
-		}
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (eAct == MM::BeforeGet) {
+        pProp->Set(g_IdleState);
+    } else if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties()) {
+            return DEVICE_OK;
+        }
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_DoItState) {
+            command << addressChar_ << "RM";
+            RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+            pProp->Set(g_DoneState);
+        }
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnRBRunning(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	static bool justSet;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_ && !justSet)
-		{
-			return DEVICE_OK;
-		}
-		command << addressChar_ << "RM F?";
-		response << ":A F=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		if (tmp >= 128)
-		{
-			success = pProp->Set(g_YesState);
-		}
-		else
-		{
-			success = pProp->Set(g_NoState);
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		justSet = false;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		justSet = true;
-		return OnRBRunning(pProp, MM::BeforeGet);
-		// TODO determine how to handle this with shared properties since ring buffer is per-card and not per-axis
-		// the reason this property exists (and why it's not a read-only property) are a bit hazy as of mid-2017
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    static bool justSet;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_ && !justSet) {
+            return DEVICE_OK;
+        }
+        command << addressChar_ << "RM F?";
+        response << ":A F=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        if (tmp >= 128) {
+            success = pProp->Set(g_YesState);
+        } else {
+            success = pProp->Set(g_NoState);
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        justSet = false;
+    } else if (eAct == MM::AfterSet) {
+        justSet = true;
+        return OnRBRunning(pProp, MM::BeforeGet);
+        // TODO determine how to handle this with shared properties since ring buffer is per-card and not per-axis
+        // the reason this property exists (and why it's not a read-only property) are a bit hazy as of mid-2017
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnRBDelayBetweenPoints(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << addressChar_ << "RT Z?";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A Z="));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		if (hub_->UpdatingSharedProperties())
-		{
-			return DEVICE_OK;
-		}
-		pProp->Get(tmp);
-		command << addressChar_ << "RT Z=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		command.str("");
-		command << tmp;
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << addressChar_ << "RT Z?";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A Z="));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp)) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties()) {
+            return DEVICE_OK;
+        }
+        pProp->Get(tmp);
+        command << addressChar_ << "RT Z=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        command.str("");
+        command << tmp;
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
+    }
+    return DEVICE_OK;
 }
 
 // Joystick
@@ -928,1057 +833,873 @@ int CDACXYStage::OnRBDelayBetweenPoints(MM::PropertyBase* pProp, MM::ActionType 
 //   and for speed (which is strictly positive)... that makes this code a bit odd
 int CDACXYStage::OnJoystickFastSpeed(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << addressChar_ << "JS X?";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A X="));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		tmp = abs(tmp);
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(tmp);
-		char joystickMirror[MM::MaxStrLength];
-		RETURN_ON_MM_ERROR(GetProperty(g_JoystickMirrorPropertyName, joystickMirror));
-		if (strcmp(joystickMirror, g_YesState) == 0)
-		{
-			command << addressChar_ << "JS X=-" << tmp;
-		}
-		else
-		{
-			command << addressChar_ << "JS X=" << tmp;
-		}
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << addressChar_ << "JS X?";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A X="));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        tmp = abs(tmp);
+        if (!pProp->Set(tmp)) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        char joystickMirror[MM::MaxStrLength];
+        RETURN_ON_MM_ERROR(GetProperty(g_JoystickMirrorPropertyName, joystickMirror));
+        if (strcmp(joystickMirror, g_YesState) == 0) {
+            command << addressChar_ << "JS X=-" << tmp;
+        } else {
+            command << addressChar_ << "JS X=" << tmp;
+        }
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 // ASI controller mirrors by having negative speed, but here we have separate property for mirroring
 //   and for speed (which is strictly positive)... that makes this code a bit odd
 int CDACXYStage::OnJoystickSlowSpeed(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << addressChar_ << "JS Y?";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A Y="));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(tmp);
-		char joystickMirror[MM::MaxStrLength];
-		RETURN_ON_MM_ERROR(GetProperty(g_JoystickMirrorPropertyName, joystickMirror));
-		if (strcmp(joystickMirror, g_YesState) == 0)
-		{
-			command << addressChar_ << "JS Y=-" << tmp;
-		}
-		else
-		{
-			command << addressChar_ << "JS Y=" << tmp;
-		}
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << addressChar_ << "JS Y?";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A Y="));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp)) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        char joystickMirror[MM::MaxStrLength];
+        RETURN_ON_MM_ERROR(GetProperty(g_JoystickMirrorPropertyName, joystickMirror));
+        if (strcmp(joystickMirror, g_YesState) == 0) {
+            command << addressChar_ << "JS Y=-" << tmp;
+        } else {
+            command << addressChar_ << "JS Y=" << tmp;
+        }
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 // ASI controller mirrors by having negative speed, but here we have separate property for mirroring
 //   and for speed (which is strictly positive)... that makes this code a bit odd
 int CDACXYStage::OnJoystickMirror(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << addressChar_ << "JS X?";  // query only the fast setting to see if already mirrored
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A X="));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success = 0;
-		if (tmp < 0) // speed negative <=> mirrored
-		{
-			success = pProp->Set(g_YesState);
-		}
-		else
-		{
-			success = pProp->Set(g_NoState);
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		double joystickFast = 0.0;
-		RETURN_ON_MM_ERROR(GetProperty(g_JoystickFastSpeedPropertyName, joystickFast));
-		double joystickSlow = 0.0;
-		RETURN_ON_MM_ERROR(GetProperty(g_JoystickSlowSpeedPropertyName, joystickSlow));
-		if (tmpstr == g_YesState)
-		{
-			command << addressChar_ << "JS X=-" << joystickFast << " Y=-" << joystickSlow;
-		}
-		else
-		{
-			command << addressChar_ << "JS X=" << joystickFast << " Y=" << joystickSlow;
-		}
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << addressChar_ << "JS X?";  // query only the fast setting to see if already mirrored
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A X="));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success = 0;
+        if (tmp < 0) { // speed negative <=> mirrored
+            success = pProp->Set(g_YesState);
+        } else {
+            success = pProp->Set(g_NoState);
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        double joystickFast = 0.0;
+        RETURN_ON_MM_ERROR(GetProperty(g_JoystickFastSpeedPropertyName, joystickFast));
+        double joystickSlow = 0.0;
+        RETURN_ON_MM_ERROR(GetProperty(g_JoystickSlowSpeedPropertyName, joystickSlow));
+        if (tmpstr == g_YesState) {
+            command << addressChar_ << "JS X=-" << joystickFast << " Y=-" << joystickSlow;
+        } else {
+            command << addressChar_ << "JS X=" << joystickFast << " Y=" << joystickSlow;
+        }
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 // interchanges axes for X and Y on the joystick
 int CDACXYStage::OnJoystickRotate(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "J " << axisLetterX_ << "?";  // only look at X axis for joystick
-		response << ":A " << axisLetterX_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success = 0;
-		if (tmp == 3) // if set to be Y joystick direction then we are rotated, otherwise assume not rotated
-		{
-			success = pProp->Set(g_YesState);
-		}
-		else
-		{
-			success = pProp->Set(g_NoState);
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		// ideally would call OnJoystickEnableDisable but don't know how to get the appropriate pProp
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		char joystickEnabled[MM::MaxStrLength];
-		RETURN_ON_MM_ERROR(GetProperty(g_JoystickEnabledPropertyName, joystickEnabled));
-		if (strcmp(joystickEnabled, g_YesState) == 0)
-		{
-			if (tmpstr == g_YesState)
-			{
-				command << "J " << axisLetterX_ << "=3" << " " << axisLetterY_ << "=2";  // rotated
-			}
-			else
-			{
-				command << "J " << axisLetterX_ << "=2" << " " << axisLetterY_ << "=3";
-			}
-		}
-		else  // No = disabled
-		{
-			command << "J " << axisLetterX_ << "=0" << " " << axisLetterY_ << "=0";
-		}
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "J " << axisLetterX_ << "?";  // only look at X axis for joystick
+        response << ":A " << axisLetterX_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success = 0;
+        // if set to be Y joystick direction then we are rotated, otherwise assume not rotated
+        if (tmp == 3) {
+            success = pProp->Set(g_YesState);
+        } else {
+            success = pProp->Set(g_NoState);
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        // ideally would call OnJoystickEnableDisable but don't know how to get the appropriate pProp
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        char joystickEnabled[MM::MaxStrLength];
+        RETURN_ON_MM_ERROR(GetProperty(g_JoystickEnabledPropertyName, joystickEnabled));
+        if (strcmp(joystickEnabled, g_YesState) == 0) {
+            if (tmpstr == g_YesState) {
+                command << "J " << axisLetterX_ << "=3" << " " << axisLetterY_ << "=2";  // rotated
+            } else {
+                command << "J " << axisLetterX_ << "=2" << " " << axisLetterY_ << "=3";
+            }
+        } else { // No = disabled
+            command << "J " << axisLetterX_ << "=0" << " " << axisLetterY_ << "=0";
+        }
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnJoystickEnableDisable(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "J " << axisLetterX_ << "?";
-		response << ":A " << axisLetterX_ << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success = 0;
-		if (tmp) // treat anything nozero as enabled when reading
-		{
-			success = pProp->Set(g_YesState);
-		}
-		else
-		{
-			success = pProp->Set(g_NoState);
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_YesState)
-		{
-			char joystickRotate[MM::MaxStrLength];
-			RETURN_ON_MM_ERROR(GetProperty(g_JoystickRotatePropertyName, joystickRotate));
-			if (strcmp(joystickRotate, g_YesState) == 0)
-			{
-				command << "J " << axisLetterX_ << "=3" << " " << axisLetterY_ << "=2";  // rotated
-			}
-			else
-			{
-				command << "J " << axisLetterX_ << "=2" << " " << axisLetterY_ << "=3";
-			}
-		}
-		else  // No = disabled
-		{
-			command << "J " << axisLetterX_ << "=0" << " " << axisLetterY_ << "=0";
-		}
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "J " << axisLetterX_ << "?";
+        response << ":A " << axisLetterX_ << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success = 0;
+        // treat anything nozero as enabled when reading
+        if (tmp) {
+            success = pProp->Set(g_YesState);
+        } else {
+            success = pProp->Set(g_NoState);
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_YesState) {
+            char joystickRotate[MM::MaxStrLength];
+            RETURN_ON_MM_ERROR(GetProperty(g_JoystickRotatePropertyName, joystickRotate));
+            if (strcmp(joystickRotate, g_YesState) == 0) {
+                command << "J " << axisLetterX_ << "=3" << " " << axisLetterY_ << "=2";  // rotated
+            } else {
+                command << "J " << axisLetterX_ << "=2" << " " << axisLetterY_ << "=3";
+            }
+        } else { // No = disabled
+            command << "J " << axisLetterX_ << "=0" << " " << axisLetterY_ << "=0";
+        }
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 // Single Axis Functions
 
 int CDACXYStage::OnSAAmplitudeGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "SAA " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(tmp);
-		command << "SAA " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "SAA " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp)) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "SAA " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnSAOffsetGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "SAO " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(tmp);
-		command << "SAO " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "SAO " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp))
+        {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "SAO " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnSAPeriodGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "SAF " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(tmp);
-		command << "SAF " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "SAF " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp)) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "SAF " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnSAModeGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	static bool justSet = false;
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_ && !justSet)
-		{
-			return DEVICE_OK;
-		}
-		command << "SAM " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SAMode_0); break;
-		case 1: success = pProp->Set(g_SAMode_1); break;
-		case 2: success = pProp->Set(g_SAMode_2); break;
-		case 3: success = pProp->Set(g_SAMode_3); break;
-		default:success = 0;                      break;
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		justSet = false;
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SAMode_0)
-		{
-			tmp = 0;
-		}
-		else if (tmpstr == g_SAMode_1)
-		{
-			tmp = 1;
-		}
-		else if (tmpstr == g_SAMode_2)
-		{
-			tmp = 2;
-		}
-		else if (tmpstr == g_SAMode_3)
-		{
-			tmp = 3;
-		}
-		else
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		command << "SAM " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		// get the updated value right away
-		justSet = true;
-		return OnSAModeGeneric(pProp, MM::BeforeGet, axisLetter);
-	}
-	return DEVICE_OK;
+    static bool justSet = false;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_ && !justSet) {
+            return DEVICE_OK;
+        }
+        command << "SAM " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        switch (tmp) {
+        case 0: success = pProp->Set(g_SAMode_0); break;
+        case 1: success = pProp->Set(g_SAMode_1); break;
+        case 2: success = pProp->Set(g_SAMode_2); break;
+        case 3: success = pProp->Set(g_SAMode_3); break;
+        default:success = 0;                      break;
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        justSet = false;
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SAMode_0) {
+            tmp = 0;
+        } else if (tmpstr == g_SAMode_1) {
+            tmp = 1;
+        } else if (tmpstr == g_SAMode_2) {
+            tmp = 2;
+        } else if (tmpstr == g_SAMode_3) {
+            tmp = 3;
+        } else {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        command << "SAM " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        // get the updated value right away
+        justSet = true;
+        return OnSAModeGeneric(pProp, MM::BeforeGet, axisLetter);
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnSAPatternGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT2 | BIT1 | BIT0));  // zero all but the lowest 3 bits
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SAPattern_0); break;
-		case 1: success = pProp->Set(g_SAPattern_1); break;
-		case 2: success = pProp->Set(g_SAPattern_2); break;
-		case 3: success = pProp->Set(g_SAPattern_3); break;
-		case 4: success = pProp->Set(g_SAPattern_4); break;
-		default:success = 0;                         break;
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SAPattern_0)
-		{
-			tmp = 0;
-		}
-		else if (tmpstr == g_SAPattern_1)
-		{
-			tmp = 1;
-		}
-		else if (tmpstr == g_SAPattern_2)
-		{
-			tmp = 2;
-		}
-		else if (tmpstr == g_SAPattern_3)
-		{
-			tmp = 3;
-		}
-		else if (tmpstr == g_SAPattern_4)
-		{
-			tmp = 4;
-		}
-		else
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		// have to get current settings and then modify bits 0-2 from there
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT2 | BIT1 | BIT0));  // set lowest 3 bits to zero
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT2 | BIT1 | BIT0));  // zero all but the lowest 3 bits
+        switch (tmp) {
+        case 0: success = pProp->Set(g_SAPattern_0); break;
+        case 1: success = pProp->Set(g_SAPattern_1); break;
+        case 2: success = pProp->Set(g_SAPattern_2); break;
+        case 3: success = pProp->Set(g_SAPattern_3); break;
+        case 4: success = pProp->Set(g_SAPattern_4); break;
+        default:success = 0;                         break;
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SAPattern_0) {
+            tmp = 0;
+        } else if (tmpstr == g_SAPattern_1) {
+            tmp = 1;
+        } else if (tmpstr == g_SAPattern_2) {
+            tmp = 2;
+        } else if (tmpstr == g_SAPattern_3) {
+            tmp = 3;
+        } else if (tmpstr == g_SAPattern_4) {
+            tmp = 4;
+        } else {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        // have to get current settings and then modify bits 0-2 from there
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT2 | BIT1 | BIT0));  // set lowest 3 bits to zero
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnSAClkSrcGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT7));  // zero all but bit 7
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SAClkSrc_0);    break;
-		case BIT7: success = pProp->Set(g_SAClkSrc_1); break;
-		default: success = 0;                          break;
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SAClkSrc_0)
-		{
-			tmp = 0;
-		}
-		else if (tmpstr == g_SAClkSrc_1)
-		{
-			tmp = BIT7;
-		}
-		else
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		// have to get current settings and then modify bit 7 from there
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT7));  // clear bit 7
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT7));  // zero all but bit 7
+        switch (tmp) {
+        case 0: success = pProp->Set(g_SAClkSrc_0);    break;
+        case BIT7: success = pProp->Set(g_SAClkSrc_1); break;
+        default: success = 0;                          break;
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SAClkSrc_0) {
+            tmp = 0;
+        } else if (tmpstr == g_SAClkSrc_1) {
+            tmp = BIT7;
+        } else {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        // have to get current settings and then modify bit 7 from there
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT7));  // clear bit 7
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnSAClkPolGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT6));  // zero all but bit 6
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SAClkPol_0);    break;
-		case BIT6: success = pProp->Set(g_SAClkPol_1); break;
-		default: success = 0;                          break;
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SAClkPol_0)
-		{
-			tmp = 0;
-		}
-		else if (tmpstr == g_SAClkPol_1)
-		{
-			tmp = BIT6;
-		}
-		else
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		// have to get current settings and then modify bit 6 from there
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT6));  // clear bit 6
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT6));  // zero all but bit 6
+        switch (tmp) {
+        case 0: success = pProp->Set(g_SAClkPol_0);    break;
+        case BIT6: success = pProp->Set(g_SAClkPol_1); break;
+        default: success = 0;                          break;
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SAClkPol_0) {
+            tmp = 0;
+        } else if (tmpstr == g_SAClkPol_1) {
+            tmp = BIT6;
+        } else {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        // have to get current settings and then modify bit 6 from there
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT6));  // clear bit 6
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 // get every single time
 int CDACXYStage::OnSAPatternByteGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(tmp);
-		command << "SAP " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp)) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(tmp);
+        command << "SAP " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnSATTLOutGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT5));  // zero all but bit 5
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SATTLOut_0);    break;
-		case BIT5: success = pProp->Set(g_SATTLOut_1); break;
-		default: success = 0;                          break;
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SATTLOut_0)
-		{
-			tmp = 0;
-		}
-		else if (tmpstr == g_SATTLOut_1)
-		{
-			tmp = BIT5;
-		}
-		else
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		// have to get current settings and then modify bit 5 from there
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT5));  // clear bit 5
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT5));  // zero all but bit 5
+        switch (tmp) {
+        case 0: success = pProp->Set(g_SATTLOut_0);    break;
+        case BIT5: success = pProp->Set(g_SATTLOut_1); break;
+        default: success = 0;                          break;
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SATTLOut_0) {
+            tmp = 0;
+        } else if (tmpstr == g_SATTLOut_1) {
+            tmp = BIT5;
+        } else {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        // have to get current settings and then modify bit 5 from there
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT5));  // clear bit 5
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnSATTLPolGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	long tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		bool success;
-		tmp = tmp & ((long)(BIT4));  // zero all but bit 4
-		switch (tmp)
-		{
-		case 0: success = pProp->Set(g_SATTLPol_0);    break;
-		case BIT4: success = pProp->Set(g_SATTLPol_1); break;
-		default: success = 0;                          break;
-		}
-		if (!success)
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_SATTLPol_0)
-		{
-			tmp = 0;
-		}
-		else if (tmpstr == g_SATTLPol_1)
-		{
-			tmp = BIT4;
-		}
-		else
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-		// have to get current settings and then modify bit 4 from there
-		command << "SAP " << axisLetter << "?";
-		response << ":A " << axisLetter << "=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		long current;
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
-		current = current & (~(long)(BIT4));  // clear bit 4
-		tmp += current;
-		command.str("");
-		command << "SAP " << axisLetter << "=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    long tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        bool success;
+        tmp = tmp & ((long)(BIT4));  // zero all but bit 4
+        switch (tmp) {
+        case 0: success = pProp->Set(g_SATTLPol_0);    break;
+        case BIT4: success = pProp->Set(g_SATTLPol_1); break;
+        default: success = 0;                          break;
+        }
+        if (!success) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_SATTLPol_0) {
+            tmp = 0;
+        } else if (tmpstr == g_SATTLPol_1) {
+            tmp = BIT4;
+        } else {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+        // have to get current settings and then modify bit 4 from there
+        command << "SAP " << axisLetter << "?";
+        response << ":A " << axisLetter << "=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        long current;
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(current));
+        current = current & (~(long)(BIT4));  // clear bit 4
+        tmp += current;
+        command.str("");
+        command << "SAP " << axisLetter << "=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 // special property, when set to "yes" it creates a set of little-used properties that can be manipulated thereafter
 int CDACXYStage::OnSAAdvancedX(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	if (eAct == MM::BeforeGet)
-	{
-		return DEVICE_OK; // do nothing
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_YesState)
-		{
-			CPropertyAction* pAct;
+    if (eAct == MM::BeforeGet) {
+        return DEVICE_OK; // do nothing
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_YesState) {
+            CPropertyAction* pAct;
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSAClkSrcX);
-			CreateProperty(g_SAClkSrcXPropertyName, g_SAClkSrc_0, MM::String, false, pAct);
-			AddAllowedValue(g_SAClkSrcXPropertyName, g_SAClkSrc_0);
-			AddAllowedValue(g_SAClkSrcXPropertyName, g_SAClkSrc_1);
-			UpdateProperty(g_SAClkSrcXPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSAClkSrcX);
+            CreateProperty(g_SAClkSrcXPropertyName, g_SAClkSrc_0, MM::String, false, pAct);
+            AddAllowedValue(g_SAClkSrcXPropertyName, g_SAClkSrc_0);
+            AddAllowedValue(g_SAClkSrcXPropertyName, g_SAClkSrc_1);
+            UpdateProperty(g_SAClkSrcXPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSAClkPolX);
-			CreateProperty(g_SAClkPolXPropertyName, g_SAClkPol_0, MM::String, false, pAct);
-			AddAllowedValue(g_SAClkPolXPropertyName, g_SAClkPol_0);
-			AddAllowedValue(g_SAClkPolXPropertyName, g_SAClkPol_1);
-			UpdateProperty(g_SAClkPolXPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSAClkPolX);
+            CreateProperty(g_SAClkPolXPropertyName, g_SAClkPol_0, MM::String, false, pAct);
+            AddAllowedValue(g_SAClkPolXPropertyName, g_SAClkPol_0);
+            AddAllowedValue(g_SAClkPolXPropertyName, g_SAClkPol_1);
+            UpdateProperty(g_SAClkPolXPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSATTLOutX);
-			CreateProperty(g_SATTLOutXPropertyName, g_SATTLOut_0, MM::String, false, pAct);
-			AddAllowedValue(g_SATTLOutXPropertyName, g_SATTLOut_0);
-			AddAllowedValue(g_SATTLOutXPropertyName, g_SATTLOut_1);
-			UpdateProperty(g_SATTLOutXPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSATTLOutX);
+            CreateProperty(g_SATTLOutXPropertyName, g_SATTLOut_0, MM::String, false, pAct);
+            AddAllowedValue(g_SATTLOutXPropertyName, g_SATTLOut_0);
+            AddAllowedValue(g_SATTLOutXPropertyName, g_SATTLOut_1);
+            UpdateProperty(g_SATTLOutXPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSATTLPolX);
-			CreateProperty(g_SATTLPolXPropertyName, g_SATTLPol_0, MM::String, false, pAct);
-			AddAllowedValue(g_SATTLPolXPropertyName, g_SATTLPol_0);
-			AddAllowedValue(g_SATTLPolXPropertyName, g_SATTLPol_1);
-			UpdateProperty(g_SATTLPolXPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSATTLPolX);
+            CreateProperty(g_SATTLPolXPropertyName, g_SATTLPol_0, MM::String, false, pAct);
+            AddAllowedValue(g_SATTLPolXPropertyName, g_SATTLPol_0);
+            AddAllowedValue(g_SATTLPolXPropertyName, g_SATTLPol_1);
+            UpdateProperty(g_SATTLPolXPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSAPatternByteX);
-			CreateProperty(g_SAPatternModeXPropertyName, "0", MM::Integer, false, pAct);
-			SetPropertyLimits(g_SAPatternModeXPropertyName, 0, 255);
-			UpdateProperty(g_SAPatternModeXPropertyName);
-		}
-	}
-	return DEVICE_OK;
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSAPatternByteX);
+            CreateProperty(g_SAPatternModeXPropertyName, "0", MM::Integer, false, pAct);
+            SetPropertyLimits(g_SAPatternModeXPropertyName, 0, 255);
+            UpdateProperty(g_SAPatternModeXPropertyName);
+        }
+    }
+    return DEVICE_OK;
 }
 
 // special property, when set to "yes" it creates a set of little-used properties that can be manipulated thereafter
 int CDACXYStage::OnSAAdvancedY(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	if (eAct == MM::BeforeGet)
-	{
-		return DEVICE_OK; // do nothing
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		if (tmpstr == g_YesState)
-		{
-			CPropertyAction* pAct;
+    if (eAct == MM::BeforeGet) {
+        return DEVICE_OK; // do nothing
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        if (tmpstr == g_YesState)
+        {
+            CPropertyAction* pAct;
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSAClkSrcY);
-			CreateProperty(g_SAClkSrcYPropertyName, g_SAClkSrc_0, MM::String, false, pAct);
-			AddAllowedValue(g_SAClkSrcYPropertyName, g_SAClkSrc_0);
-			AddAllowedValue(g_SAClkSrcYPropertyName, g_SAClkSrc_1);
-			UpdateProperty(g_SAClkSrcYPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSAClkSrcY);
+            CreateProperty(g_SAClkSrcYPropertyName, g_SAClkSrc_0, MM::String, false, pAct);
+            AddAllowedValue(g_SAClkSrcYPropertyName, g_SAClkSrc_0);
+            AddAllowedValue(g_SAClkSrcYPropertyName, g_SAClkSrc_1);
+            UpdateProperty(g_SAClkSrcYPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSAClkPolY);
-			CreateProperty(g_SAClkPolYPropertyName, g_SAClkPol_0, MM::String, false, pAct);
-			AddAllowedValue(g_SAClkPolYPropertyName, g_SAClkPol_0);
-			AddAllowedValue(g_SAClkPolYPropertyName, g_SAClkPol_1);
-			UpdateProperty(g_SAClkPolYPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSAClkPolY);
+            CreateProperty(g_SAClkPolYPropertyName, g_SAClkPol_0, MM::String, false, pAct);
+            AddAllowedValue(g_SAClkPolYPropertyName, g_SAClkPol_0);
+            AddAllowedValue(g_SAClkPolYPropertyName, g_SAClkPol_1);
+            UpdateProperty(g_SAClkPolYPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSATTLOutY);
-			CreateProperty(g_SATTLOutYPropertyName, g_SATTLOut_0, MM::String, false, pAct);
-			AddAllowedValue(g_SATTLOutYPropertyName, g_SATTLOut_0);
-			AddAllowedValue(g_SATTLOutYPropertyName, g_SATTLOut_1);
-			UpdateProperty(g_SATTLOutYPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSATTLOutY);
+            CreateProperty(g_SATTLOutYPropertyName, g_SATTLOut_0, MM::String, false, pAct);
+            AddAllowedValue(g_SATTLOutYPropertyName, g_SATTLOut_0);
+            AddAllowedValue(g_SATTLOutYPropertyName, g_SATTLOut_1);
+            UpdateProperty(g_SATTLOutYPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSATTLPolY);
-			CreateProperty(g_SATTLPolYPropertyName, g_SATTLPol_0, MM::String, false, pAct);
-			AddAllowedValue(g_SATTLPolYPropertyName, g_SATTLPol_0);
-			AddAllowedValue(g_SATTLPolYPropertyName, g_SATTLPol_1);
-			UpdateProperty(g_SATTLPolYPropertyName);
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSATTLPolY);
+            CreateProperty(g_SATTLPolYPropertyName, g_SATTLPol_0, MM::String, false, pAct);
+            AddAllowedValue(g_SATTLPolYPropertyName, g_SATTLPol_0);
+            AddAllowedValue(g_SATTLPolYPropertyName, g_SATTLPol_1);
+            UpdateProperty(g_SATTLPolYPropertyName);
 
-			pAct = new CPropertyAction(this, &CDACXYStage::OnSAPatternByteY);
-			CreateProperty(g_SAPatternModeYPropertyName, "0", MM::Integer, false, pAct);
-			SetPropertyLimits(g_SAPatternModeYPropertyName, 0, 255);
-			UpdateProperty(g_SAPatternModeYPropertyName);
-		}
-	}
-	return DEVICE_OK;
+            pAct = new CPropertyAction(this, &CDACXYStage::OnSAPatternByteY);
+            CreateProperty(g_SAPatternModeYPropertyName, "0", MM::Integer, false, pAct);
+            SetPropertyLimits(g_SAPatternModeYPropertyName, 0, 255);
+            UpdateProperty(g_SAPatternModeYPropertyName);
+        }
+    }
+    return DEVICE_OK;
 }
 
 // Sequencing
 
 int CDACXYStage::OnUseSequence(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	if (eAct == MM::BeforeGet)
-	{
-		if (ttl_trigger_enabled_)
-		{
-			pProp->Set(g_YesState);
-		}
-		else
-		{
-			pProp->Set(g_NoState);
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		std::string tmpstr;
-		pProp->Get(tmpstr);
-		ttl_trigger_enabled_ = ttl_trigger_supported_ && (tmpstr == g_YesState);
-		return OnUseSequence(pProp, MM::BeforeGet);  // refresh value
-	}
-	return DEVICE_OK;
+    if (eAct == MM::BeforeGet) {
+        if (ttl_trigger_enabled_) {
+            pProp->Set(g_YesState);
+        } else {
+            pProp->Set(g_NoState);
+        }
+    } else if (eAct == MM::AfterSet) {
+        std::string tmpstr;
+        pProp->Get(tmpstr);
+        ttl_trigger_enabled_ = ttl_trigger_supported_ && (tmpstr == g_YesState);
+        return OnUseSequence(pProp, MM::BeforeGet);  // refresh value
+    }
+    return DEVICE_OK;
 }
 
 // enables TTL triggering; doesn't actually start anything going on controller
 int CDACXYStage::StartXYStageSequence()
 {
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	// ensure that ringbuffer pointer points to first entry
-	// for now leave the axis_byte unchanged (hopefully default)
-	// for now leave mode (RM F) unchanged; would normally be set to 1 and is done in OnRBMode = property "RingBufferMode"
-	std::ostringstream command;
-	command << addressChar_ << "RM Z=0";
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    // ensure that ringbuffer pointer points to first entry
+    // for now leave the axis_byte unchanged (hopefully default)
+    // for now leave mode (RM F) unchanged; would normally be set to 1 and is done in OnRBMode = property "RingBufferMode"
+    std::ostringstream command;
+    command << addressChar_ << "RM Z=0";
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
 
-	command.str("");
-	command << addressChar_ << "TTL X=1";  // switch on TTL triggering
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	return DEVICE_OK;
+    command.str("");
+    command << addressChar_ << "TTL X=1";  // switch on TTL triggering
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    return DEVICE_OK;
 }
 
 // disables TTL triggering; doesn't actually stop anything already happening on controller
 int CDACXYStage::StopXYStageSequence()
 {
-	std::ostringstream command;
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	command << addressChar_ << "TTL X=0";  // switch off TTL triggering
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    command << addressChar_ << "TTL X=0";  // switch off TTL triggering
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    return DEVICE_OK;
 }
 
 int CDACXYStage::ClearXYStageSequence()
 {
-	std::ostringstream command;
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	sequenceX_.clear();
-	sequenceY_.clear();
-	command << addressChar_ << "RM X=0";  // clear ring buffer
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    sequenceX_.clear();
+    sequenceY_.clear();
+    command << addressChar_ << "RM X=0";  // clear ring buffer
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    return DEVICE_OK;
 }
 
 int CDACXYStage::AddToXYStageSequence(double positionX, double positionY)
 {
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	sequenceX_.push_back(positionX);
-	sequenceY_.push_back(positionY);
-	return DEVICE_OK;
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    sequenceX_.push_back(positionX);
+    sequenceY_.push_back(positionY);
+    return DEVICE_OK;
 }
 
 // TODO: unit conversion is needed
 int CDACXYStage::SendXYStageSequence()
 {
-	std::ostringstream command;
-	if (!ttl_trigger_supported_)
-	{
-		return DEVICE_UNSUPPORTED_COMMAND;
-	}
-	command << addressChar_ << "RM X=0"; // clear ring buffer
-	RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	for (unsigned i = 0; i < sequenceX_.size(); i++)  // send new points
-	{
-		command.str("");
-		command << "LD " << axisLetterX_ << "=" << sequenceX_[i] << " " << axisLetterY_ << "=" << sequenceY_[i];
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    if (!ttl_trigger_supported_) {
+        return DEVICE_UNSUPPORTED_COMMAND;
+    }
+    command << addressChar_ << "RM X=0"; // clear ring buffer
+    RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    for (unsigned i = 0; i < sequenceX_.size(); i++) { // send new points
+        command.str("");
+        command << "LD " << axisLetterX_ << "=" << sequenceX_[i] << " " << axisLetterY_ << "=" << sequenceY_[i];
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+    }
+    return DEVICE_OK;
 }
 
 /////////////// TTL ///////////////
 
 int CDACXYStage::OnTTLin(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << addressChar_ << "TTL X?";
-		response << ":A X=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		if (hub_->UpdatingSharedProperties())
-		{
-			return DEVICE_OK;
-		}
-		pProp->Get(tmp);
-		command << addressChar_ << "TTL X=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		command.str("");
-		command << tmp;
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << addressChar_ << "TTL X?";
+        response << ":A X=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp)) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties()) {
+            return DEVICE_OK;
+        }
+        pProp->Get(tmp);
+        command << addressChar_ << "TTL X=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        command.str("");
+        command << tmp;
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnTTLout(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	std::ostringstream command;
-	std::ostringstream response;
-	double tmp = 0;
-	if (eAct == MM::BeforeGet)
-	{
-		if (!refreshProps_ && initialized_)
-		{
-			return DEVICE_OK;
-		}
-		command << addressChar_ << "TTL Y?";
-		response << ":A Y=";
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
-		RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-		if (!pProp->Set(tmp))
-		{
-			return DEVICE_INVALID_PROPERTY_VALUE;
-		}
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		if (hub_->UpdatingSharedProperties())
-		{
-			return DEVICE_OK;
-		}
-		pProp->Get(tmp);
-		command << addressChar_ << "TTL Y=" << tmp;
-		RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
-		command.str("");
-		command << tmp;
-		RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
-	}
-	return DEVICE_OK;
+    std::ostringstream command;
+    std::ostringstream response;
+    double tmp = 0;
+    if (eAct == MM::BeforeGet) {
+        if (!refreshProps_ && initialized_) {
+            return DEVICE_OK;
+        }
+        command << addressChar_ << "TTL Y?";
+        response << ":A Y=";
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), response.str()));
+        RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+        if (!pProp->Set(tmp)) {
+            return DEVICE_INVALID_PROPERTY_VALUE;
+        }
+    } else if (eAct == MM::AfterSet) {
+        if (hub_->UpdatingSharedProperties()) {
+            return DEVICE_OK;
+        }
+        pProp->Get(tmp);
+        command << addressChar_ << "TTL Y=" << tmp;
+        RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command.str(), ":A"));
+        command.str("");
+        command << tmp;
+        RETURN_ON_MM_ERROR(hub_->UpdateSharedProperties(addressChar_, pProp->GetName(), command.str()));
+    }
+    return DEVICE_OK;
 }
 
 // Pre-init Properties
 
 int CDACXYStage::OnConversionFactorX(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	if (eAct == MM::BeforeGet)
-	{
-		// do nothing
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(umToMvX_);
-	}
-	return DEVICE_OK;
+    if (eAct == MM::BeforeGet) {
+        // do nothing
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(umToMvX_);
+    }
+    return DEVICE_OK;
 }
 
 int CDACXYStage::OnConversionFactorY(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-	if (eAct == MM::BeforeGet)
-	{
-		// do nothing
-	}
-	else if (eAct == MM::AfterSet)
-	{
-		pProp->Get(umToMvY_);
-	}
-	return DEVICE_OK;
+    if (eAct == MM::BeforeGet) {
+        // do nothing
+    } else if (eAct == MM::AfterSet) {
+        pProp->Get(umToMvY_);
+    }
+    return DEVICE_OK;
 }
 
 void CDACXYStage::CreateSingleAxisRiseTimeProperty(const char axisChar, std::string axisLetter) {
-	const std::string propertyName = std::string("SingleAxis") + axisChar + "RiseTime(ms)";
+    const std::string propertyName = std::string("SingleAxis") + axisChar + "RiseTime(ms)";
 
-	// axisLetter is captured by value so that the lambda owns it's own copy
-	CreateFloatProperty(
-		propertyName.c_str(), 0.0, false,
-		new MM::ActionLambda([this, axisLetter](MM::PropertyBase* pProp, MM::ActionType eAct) {
-			double tmp = 0.0;
-			if (eAct == MM::BeforeGet) {
-				if (!refreshProps_ && initialized_) {
-					return DEVICE_OK;
-				}
-				const std::string query = "OS " + axisLetter + "?";
-				const std::string response = ":A " + axisLetter + "=";
-				RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(query, response));
-				RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
-				if (!pProp->Set(tmp)) {
-					return DEVICE_INVALID_PROPERTY_VALUE;
-				}
-			} else if (eAct == MM::AfterSet) {
-				pProp->Get(tmp);
-				const std::string command = "OS " + axisLetter + "=";
-				RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command + std::to_string(tmp), ":A"));
-			}
-			return DEVICE_OK;
-		})
-	);
+    // axisLetter is captured by value so that the lambda owns it's own copy
+    CreateFloatProperty(
+        propertyName.c_str(), 0.0, false,
+        new MM::ActionLambda([this, axisLetter](MM::PropertyBase* pProp, MM::ActionType eAct) {
+            double tmp = 0.0;
+            if (eAct == MM::BeforeGet) {
+                if (!refreshProps_ && initialized_) {
+                    return DEVICE_OK;
+                }
+                const std::string query = "OS " + axisLetter + "?";
+                const std::string response = ":A " + axisLetter + "=";
+                RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(query, response));
+                RETURN_ON_MM_ERROR(hub_->ParseAnswerAfterEquals(tmp));
+                if (!pProp->Set(tmp)) {
+                    return DEVICE_INVALID_PROPERTY_VALUE;
+                }
+            } else if (eAct == MM::AfterSet) {
+                pProp->Get(tmp);
+                const std::string command = "OS " + axisLetter + "=";
+                RETURN_ON_MM_ERROR(hub_->QueryCommandVerify(command + std::to_string(tmp), ":A"));
+            }
+            return DEVICE_OK;
+        })
+    );
 
-	UpdateProperty(propertyName.c_str());
+    UpdateProperty(propertyName.c_str());
 }

--- a/DeviceAdapters/ASITiger/ASIDacXYStage.cpp
+++ b/DeviceAdapters/ASITiger/ASIDacXYStage.cpp
@@ -591,7 +591,7 @@ int CDACXYStage::OnSaveCardSettings(MM::PropertyBase* pProp, MM::ActionType eAct
 		}
 		else if (tmpstr == g_SaveSettingsY)
 		{
-			command << 'X';
+			command << 'Y';
 		}
 		else if (tmpstr == g_SaveSettingsZ)
 		{

--- a/DeviceAdapters/ASITiger/ASIDacXYStage.h
+++ b/DeviceAdapters/ASITiger/ASIDacXYStage.h
@@ -31,136 +31,136 @@ public:
     explicit CDACXYStage(const char* name);
     ~CDACXYStage() = default;
 
-	// Device API
-	int Initialize();
-	bool Busy() { return false; }
+    // Device API
+    int Initialize();
+    bool Busy() { return false; }
 
-	// DAC API
-	// Note: added axisLetter to deal with multiple axes
-	int SetGateOpen(bool open, const std::string& axisLetter);
-	int GetGateOpen(bool& open, const std::string& axisLetter);
+    // DAC API
+    // Note: added axisLetter to deal with multiple axes
+    int SetGateOpen(bool open, const std::string& axisLetter);
+    int GetGateOpen(bool& open, const std::string& axisLetter);
 
-	// XYStage API
-	double GetStepSizeXUm() { return 1.0; }
-	double GetStepSizeYUm() { return 1.0; }
-	int GetPositionSteps(long& x, long& y);
-	int SetPositionSteps(long x, long y);
-	int SetRelativePositionSteps(long x, long y);
-	int GetStepLimits(long& xMin, long& xMax, long& yMin, long& yMax);
-	int SetOrigin();
-	int SetXOrigin();
-	int SetYOrigin();
-	int Stop();
-	int Home();
-	int SetHome();
-	int Move(double vx, double vy);
+    // XYStage API
+    double GetStepSizeXUm() { return 1.0; }
+    double GetStepSizeYUm() { return 1.0; }
+    int GetPositionSteps(long& x, long& y);
+    int SetPositionSteps(long x, long y);
+    int SetRelativePositionSteps(long x, long y);
+    int GetStepLimits(long& xMin, long& xMax, long& yMin, long& yMax);
+    int SetOrigin();
+    int SetXOrigin();
+    int SetYOrigin();
+    int Stop();
+    int Home();
+    int SetHome();
+    int Move(double vx, double vy);
 
-	int IsXYStageSequenceable(bool& isSequenceable) const { isSequenceable = ttl_trigger_enabled_; return DEVICE_OK; }
-	int GetXYStageSequenceMaxLength(long& nrEvents) const { nrEvents = ring_buffer_capacity_; return DEVICE_OK; }
+    int IsXYStageSequenceable(bool& isSequenceable) const { isSequenceable = ttl_trigger_enabled_; return DEVICE_OK; }
+    int GetXYStageSequenceMaxLength(long& nrEvents) const { nrEvents = ring_buffer_capacity_; return DEVICE_OK; }
 
-	int StartXYStageSequence();
-	int StopXYStageSequence();
-	int ClearXYStageSequence();
-	int AddToXYStageSequence(double positionX, double positionY);
-	int SendXYStageSequence();
+    int StartXYStageSequence();
+    int StopXYStageSequence();
+    int ClearXYStageSequence();
+    int AddToXYStageSequence(double positionX, double positionY);
+    int SendXYStageSequence();
 
-	// not implemented yet
-	int GetLimitsUm(double& /*xMin*/, double& /*xMax*/, double& /*yMin*/, double& /*yMax*/) { return DEVICE_UNSUPPORTED_COMMAND; }
+    // not implemented yet
+    int GetLimitsUm(double& /*xMin*/, double& /*xMax*/, double& /*yMin*/, double& /*yMax*/) { return DEVICE_UNSUPPORTED_COMMAND; }
 
-	// action interface
-	int OnSaveCardSettings(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnRefreshProperties(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnConversionFactorX(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnConversionFactorY(MM::PropertyBase* pProp, MM::ActionType eAct);
+    // action interface
+    int OnSaveCardSettings(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnRefreshProperties(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnConversionFactorX(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnConversionFactorY(MM::PropertyBase* pProp, MM::ActionType eAct);
 
-	// joystick properties
-	int OnJoystickFastSpeed(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnJoystickSlowSpeed(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnJoystickMirror(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnJoystickRotate(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnJoystickEnableDisable(MM::PropertyBase* pProp, MM::ActionType eAct);
+    // joystick properties
+    int OnJoystickFastSpeed(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnJoystickSlowSpeed(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnJoystickMirror(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnJoystickRotate(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnJoystickEnableDisable(MM::PropertyBase* pProp, MM::ActionType eAct);
 
-	// ring buffer properties
-	int OnRBDelayBetweenPoints(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnRBMode(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnRBTrigger(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnRBRunning(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnUseSequence(MM::PropertyBase* pProp, MM::ActionType eAct);
+    // ring buffer properties
+    int OnRBDelayBetweenPoints(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnRBMode(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnRBTrigger(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnRBRunning(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnUseSequence(MM::PropertyBase* pProp, MM::ActionType eAct);
 
-	// signal DAC properties
-	int OnDACModeGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnDACGateGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnCutoffFreqGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnDACModeX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnDACModeGeneric(pProp, eAct, axisLetterX_); }
-	int OnDACModeY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnDACModeGeneric(pProp, eAct, axisLetterY_); }
-	int OnDACGateX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnDACGateGeneric(pProp, eAct, axisLetterX_); }
-	int OnDACGateY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnDACGateGeneric(pProp, eAct, axisLetterY_); }
-	int OnCutoffFreqX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnCutoffFreqGeneric(pProp, eAct, axisLetterX_); }
-	int OnCutoffFreqY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnCutoffFreqGeneric(pProp, eAct, axisLetterY_); }
+    // signal DAC properties
+    int OnDACModeGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnDACGateGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnCutoffFreqGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnDACModeX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnDACModeGeneric(pProp, eAct, axisLetterX_); }
+    int OnDACModeY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnDACModeGeneric(pProp, eAct, axisLetterY_); }
+    int OnDACGateX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnDACGateGeneric(pProp, eAct, axisLetterX_); }
+    int OnDACGateY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnDACGateGeneric(pProp, eAct, axisLetterY_); }
+    int OnCutoffFreqX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnCutoffFreqGeneric(pProp, eAct, axisLetterX_); }
+    int OnCutoffFreqY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnCutoffFreqGeneric(pProp, eAct, axisLetterY_); }
 
-	// single axis properties
-	int OnSAAdvancedX(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnSAAdvancedY(MM::PropertyBase* pProp, MM::ActionType eAct);
+    // single axis properties
+    int OnSAAdvancedX(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnSAAdvancedY(MM::PropertyBase* pProp, MM::ActionType eAct);
 
-	int OnSAAmplitudeGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnSAOffsetGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnSAPeriodGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnSAModeGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnSAPatternGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnSAClkSrcGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnSAClkPolGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnSAPatternByteGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnSATTLOutGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
-	int OnSATTLPolGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSAAmplitudeGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSAOffsetGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSAPeriodGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSAModeGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSAPatternGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSAClkSrcGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSAClkPolGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSAPatternByteGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSATTLOutGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
+    int OnSATTLPolGeneric(MM::PropertyBase* pProp, MM::ActionType eAct, const std::string& axisLetter);
 
-	int OnSAAmplitudeX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAAmplitudeGeneric(pProp, eAct, axisLetterX_); }
-	int OnSAAmplitudeY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAAmplitudeGeneric(pProp, eAct, axisLetterY_); }
-	int OnSAOffsetX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAOffsetGeneric(pProp, eAct, axisLetterX_); }
-	int OnSAOffsetY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAOffsetGeneric(pProp, eAct, axisLetterY_); }
-	int OnSAPeriodX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPeriodGeneric(pProp, eAct, axisLetterX_); }
-	int OnSAPeriodY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPeriodGeneric(pProp, eAct, axisLetterY_); }
-	int OnSAModeX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAModeGeneric(pProp, eAct, axisLetterX_); }
-	int OnSAModeY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAModeGeneric(pProp, eAct, axisLetterY_); }
-	int OnSAPatternX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPatternGeneric(pProp, eAct, axisLetterX_); }
-	int OnSAPatternY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPatternGeneric(pProp, eAct, axisLetterY_); }
-	int OnSAClkSrcX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAClkSrcGeneric(pProp, eAct, axisLetterX_); }
-	int OnSAClkSrcY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAClkSrcGeneric(pProp, eAct, axisLetterY_); }
-	int OnSAClkPolX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAClkPolGeneric(pProp, eAct, axisLetterX_); }
-	int OnSAClkPolY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAClkPolGeneric(pProp, eAct, axisLetterY_); }
-	int OnSAPatternByteX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPatternByteGeneric(pProp, eAct, axisLetterX_); }
-	int OnSAPatternByteY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPatternByteGeneric(pProp, eAct, axisLetterY_); }
-	int OnSATTLOutX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSATTLOutGeneric(pProp, eAct, axisLetterX_); }
-	int OnSATTLOutY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSATTLOutGeneric(pProp, eAct, axisLetterY_); }
-	int OnSATTLPolX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSATTLPolGeneric(pProp, eAct, axisLetterX_); }
-	int OnSATTLPolY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSATTLPolGeneric(pProp, eAct, axisLetterY_); }
+    int OnSAAmplitudeX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAAmplitudeGeneric(pProp, eAct, axisLetterX_); }
+    int OnSAAmplitudeY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAAmplitudeGeneric(pProp, eAct, axisLetterY_); }
+    int OnSAOffsetX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAOffsetGeneric(pProp, eAct, axisLetterX_); }
+    int OnSAOffsetY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAOffsetGeneric(pProp, eAct, axisLetterY_); }
+    int OnSAPeriodX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPeriodGeneric(pProp, eAct, axisLetterX_); }
+    int OnSAPeriodY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPeriodGeneric(pProp, eAct, axisLetterY_); }
+    int OnSAModeX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAModeGeneric(pProp, eAct, axisLetterX_); }
+    int OnSAModeY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAModeGeneric(pProp, eAct, axisLetterY_); }
+    int OnSAPatternX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPatternGeneric(pProp, eAct, axisLetterX_); }
+    int OnSAPatternY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPatternGeneric(pProp, eAct, axisLetterY_); }
+    int OnSAClkSrcX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAClkSrcGeneric(pProp, eAct, axisLetterX_); }
+    int OnSAClkSrcY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAClkSrcGeneric(pProp, eAct, axisLetterY_); }
+    int OnSAClkPolX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAClkPolGeneric(pProp, eAct, axisLetterX_); }
+    int OnSAClkPolY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAClkPolGeneric(pProp, eAct, axisLetterY_); }
+    int OnSAPatternByteX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPatternByteGeneric(pProp, eAct, axisLetterX_); }
+    int OnSAPatternByteY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSAPatternByteGeneric(pProp, eAct, axisLetterY_); }
+    int OnSATTLOutX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSATTLOutGeneric(pProp, eAct, axisLetterX_); }
+    int OnSATTLOutY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSATTLOutGeneric(pProp, eAct, axisLetterY_); }
+    int OnSATTLPolX(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSATTLPolGeneric(pProp, eAct, axisLetterX_); }
+    int OnSATTLPolY(MM::PropertyBase* pProp, MM::ActionType eAct) { return OnSATTLPolGeneric(pProp, eAct, axisLetterY_); }
 
-	// ttl
-	int OnTTLin(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnTTLout(MM::PropertyBase* pProp, MM::ActionType eAct);
+    // ttl
+    int OnTTLin(MM::PropertyBase* pProp, MM::ActionType eAct);
+    int OnTTLout(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
-	// private helper functions
-	int OnSaveJoystickSettings();
+    // private helper functions
+    int OnSaveJoystickSettings();
 
-	// DAC helpers
-	int GetMaxVolts(double& volts, const std::string& axisLetter);
-	int GetMinVolts(double& volts, const std::string& axisLetter);
+    // DAC helpers
+    int GetMaxVolts(double& volts, const std::string& axisLetter);
+    int GetMinVolts(double& volts, const std::string& axisLetter);
 
-	// Properties
-	void CreateSingleAxisRiseTimeProperty(const char axisChar, std::string axisLetter);
+    // Properties
+    void CreateSingleAxisRiseTimeProperty(const char axisChar, std::string axisLetter);
 
-	std::string axisLetterX_ = g_EmptyAxisLetterStr; // value determined by extended name
-	std::string axisLetterY_ = g_EmptyAxisLetterStr; // value determined by extended name
-	double maxvoltsX_ = 0.0; // X axis limits
-	double minvoltsX_ = 0.0;
-	double maxvoltsY_ = 0.0; // Y axis limits
-	double minvoltsY_ = 0.0;
-	long ring_buffer_capacity_ = 0;
-	bool ring_buffer_supported_ = false;
-	bool ttl_trigger_supported_ = false;
-	bool ttl_trigger_enabled_ = false;
-	long umToMvX_ = 1; // microns to millivolts conversion factors
-	long umToMvY_ = 1;
-	std::vector<double> sequenceX_{};
-	std::vector<double> sequenceY_{};
+    std::string axisLetterX_ = g_EmptyAxisLetterStr; // value determined by extended name
+    std::string axisLetterY_ = g_EmptyAxisLetterStr; // value determined by extended name
+    double maxvoltsX_ = 0.0; // X axis limits
+    double minvoltsX_ = 0.0;
+    double maxvoltsY_ = 0.0; // Y axis limits
+    double minvoltsY_ = 0.0;
+    long ring_buffer_capacity_ = 0;
+    bool ring_buffer_supported_ = false;
+    bool ttl_trigger_supported_ = false;
+    bool ttl_trigger_enabled_ = false;
+    long umToMvX_ = 1; // microns to millivolts conversion factors
+    long umToMvY_ = 1;
+    std::vector<double> sequenceX_{};
+    std::vector<double> sequenceY_{};
 };

--- a/DeviceAdapters/ASITiger/ASIHub.cpp
+++ b/DeviceAdapters/ASITiger/ASIHub.cpp
@@ -89,7 +89,7 @@ int ASIHub::QueryCommandUnterminatedResponse(const char *command, const long tim
 
    while (ret == DEVICE_OK && total_read < replyLength && !timerOut.expired(GetCurrentMMTime())) {
       ret = ReadFromComPort(port_.c_str(), (unsigned char*)rcvBuf, MM::MaxStrLength, read);
-	  total_read += read;
+      total_read += read;
    }
    if (total_read > 0)
    {

--- a/DeviceAdapters/ASITiger/ASIHub.h
+++ b/DeviceAdapters/ASITiger/ASIHub.h
@@ -49,12 +49,14 @@ public:
    // also doesn't necessarily wait for a complete response
    int QueryCommandUnterminatedResponse(const char *command, const long timeoutMs, unsigned long replyLength);
    int QueryCommandUnterminatedResponse(const char *command, const long timeoutMs) {
-       return  QueryCommandUnterminatedResponse(command, timeoutMs,1);
+       return QueryCommandUnterminatedResponse(command, timeoutMs, 1);
    }
-   int QueryCommandUnterminatedResponse(const std::string &command, const long timeoutMs)
-      { return QueryCommandUnterminatedResponse(command.c_str(), timeoutMs,1); }
-   int QueryCommandUnterminatedResponse(const std::string &command, const long timeoutMs, unsigned long replyLength)
-   {   return QueryCommandUnterminatedResponse(command.c_str(), timeoutMs, replyLength);   }
+   int QueryCommandUnterminatedResponse(const std::string &command, const long timeoutMs) {
+       return QueryCommandUnterminatedResponse(command.c_str(), timeoutMs, 1);
+   }
+   int QueryCommandUnterminatedResponse(const std::string &command, const long timeoutMs, unsigned long replyLength) {
+       return QueryCommandUnterminatedResponse(command.c_str(), timeoutMs, replyLength);
+   }
 
    int QueryCommandLongReply(const char *command, const char *replyTerminator);  // all variants call this
    int QueryCommandLongReply(const char *command) { return QueryCommandLongReply(command, g_SerialTerminatorMultiLine); }

--- a/DeviceAdapters/ASITiger/ASIHub.h
+++ b/DeviceAdapters/ASITiger/ASIHub.h
@@ -48,8 +48,9 @@ public:
    // gets the response to a command but waits a certain time for the response to come instead of looking for a terminator
    // also doesn't necessarily wait for a complete response
    int QueryCommandUnterminatedResponse(const char *command, const long timeoutMs, unsigned long replyLength);
-   int QueryCommandUnterminatedResponse(const char *command, const long timeoutMs) 
-   {	   return  QueryCommandUnterminatedResponse(command, timeoutMs,1);   }
+   int QueryCommandUnterminatedResponse(const char *command, const long timeoutMs) {
+       return  QueryCommandUnterminatedResponse(command, timeoutMs,1);
+   }
    int QueryCommandUnterminatedResponse(const std::string &command, const long timeoutMs)
       { return QueryCommandUnterminatedResponse(command.c_str(), timeoutMs,1); }
    int QueryCommandUnterminatedResponse(const std::string &command, const long timeoutMs, unsigned long replyLength)
@@ -98,12 +99,12 @@ public:
    int ParseAnswerAfterUnderscore(unsigned int &val);  // finds next number after underscore and returns as long int
    int ParseAnswerAfterColon(double &val);  // finds next number after colon and returns as float
    int ParseAnswerAfterColon(long &val);  // finds next number after colon and returns as long int
-	int ParseAnswerAfterPosition(unsigned int pos, double &val);  // finds next number after character position specified and returns as float
-	int ParseAnswerAfterPosition(unsigned int pos, long &val);    // finds next number after character position specified and returns as long int
+    int ParseAnswerAfterPosition(unsigned int pos, double &val);  // finds next number after character position specified and returns as float
+    int ParseAnswerAfterPosition(unsigned int pos, long &val);    // finds next number after character position specified and returns as long int
    int ParseAnswerAfterPosition(unsigned int pos, unsigned int &val);    // finds next number after character position specified and returns as unsigned int
    int ParseAnswerAfterPosition2(double &val);  // finds next number after character position 2 and returns as float
-	int ParseAnswerAfterPosition2(long &val);    // finds next number after character position 2 and returns as long int
-	int ParseAnswerAfterPosition2(unsigned int &val);    // finds next number after character position 2 and returns as unsigned int
+    int ParseAnswerAfterPosition2(long &val);    // finds next number after character position 2 and returns as long int
+    int ParseAnswerAfterPosition2(unsigned int &val);    // finds next number after character position 2 and returns as unsigned int
    int ParseAnswerAfterPosition3(double &val);  // finds next number after character position 3 and returns as float
    int ParseAnswerAfterPosition3(long &val);    // finds next number after character position 3 and returns as long int
    int ParseAnswerAfterPosition3(unsigned int &val);    // finds next number after character position 3 and returns as unsigned int
@@ -148,11 +149,11 @@ protected:
     std::string port_ = "Undefined"; // serial port to use for communication
 
 private:
-	int ParseErrorReply() const;
-	static std::string EscapeControlCharacters(const std::string &v);
-	static std::string UnescapeControlCharacters(const std::string &v0);
-	static std::vector<char> ConvertStringVector2CharVector(const std::vector<std::string> &v);
-	static std::vector<int> ConvertStringVector2IntVector(const std::vector<std::string> &v);
+    int ParseErrorReply() const;
+    static std::string EscapeControlCharacters(const std::string &v);
+    static std::string UnescapeControlCharacters(const std::string &v0);
+    static std::vector<char> ConvertStringVector2CharVector(const std::vector<std::string> &v);
+    static std::vector<int> ConvertStringVector2IntVector(const std::vector<std::string> &v);
 
     MMThreadLock threadLock_; // used to lock thread during serial transaction
 

--- a/DeviceAdapters/ASITiger/ASILens.cpp
+++ b/DeviceAdapters/ASITiger/ASILens.cpp
@@ -18,7 +18,7 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
 // AUTHOR:        Jon Daniels (jon@asiimaging.com) 09/2013
-//                Modified for Tunable lens by Vik (vik@asiimaging.com)	05/2017
+//                Modified for Tunable lens by Vik (vik@asiimaging.com) 05/2017
 //
 
 #include "ASILens.h"
@@ -310,16 +310,16 @@ int CLens::Initialize() {
    {
       ttl_trigger_supported_ = true;
 
-	  	  //TTL IN mode
-	  pAct = new CPropertyAction (this, &CLens::OnTTLin);
+      // TTL IN mode
+      pAct = new CPropertyAction (this, &CLens::OnTTLin);
       CreateProperty(g_TTLinName, "0", MM::Integer, false, pAct);
       SetPropertyLimits(g_TTLinName, 0,30);
-	  UpdateProperty(g_TTLinName);
-	  //TTL Out Mode
-	  pAct = new CPropertyAction (this, &CLens::OnTTLout);
+      UpdateProperty(g_TTLinName);
+      // TTL Out Mode
+      pAct = new CPropertyAction (this, &CLens::OnTTLout);
       CreateProperty(g_TTLoutName, "0", MM::Integer, false, pAct);
       SetPropertyLimits(g_TTLoutName,0,30);
-	  UpdateProperty(g_TTLoutName);
+      UpdateProperty(g_TTLoutName);
    }
 
       //VectorMove
@@ -1170,7 +1170,7 @@ int CLens::OnSAPattern(MM::PropertyBase* pProp, MM::ActionType eAct)
          case 0: success = pProp->Set(g_SAPattern_0); break;
          case 1: success = pProp->Set(g_SAPattern_1); break;
          case 2: success = pProp->Set(g_SAPattern_2); break;
-		 case 3: success = pProp->Set(g_SAPattern_3); break;
+         case 3: success = pProp->Set(g_SAPattern_3); break;
          case 4: success = pProp->Set(g_SAPattern_4); break;
          default:success = 0;                      break;
       }
@@ -1191,7 +1191,7 @@ int CLens::OnSAPattern(MM::PropertyBase* pProp, MM::ActionType eAct)
          tmp = 3;
       else if (tmpstr == g_SAPattern_4)
          tmp = 4;
-	  else
+      else
          return DEVICE_INVALID_PROPERTY_VALUE;
       // have to get current settings and then modify bits 0-2 from there
       command << "SAP " << axisLetter_ << "?";

--- a/DeviceAdapters/ASITiger/ASILens.h
+++ b/DeviceAdapters/ASITiger/ASILens.h
@@ -18,7 +18,7 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
 // AUTHOR:        Jon Daniels (jon@asiimaging.com) 09/2013
-//                Modified for Tunable lens by Vik (vik@asiimaging.com)	05/2017
+//                Modified for Tunable lens by Vik (vik@asiimaging.com) 05/2017
 //
 
 #pragma once
@@ -98,9 +98,9 @@ public:
    int OnRBRunning            (MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnUseSequence          (MM::PropertyBase* pProp, MM::ActionType eAct);
    // others
-   int OnVector				  (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnTTLin				  (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnTTLout			      (MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnVector(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnTTLin(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnTTLout(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
     int OnSaveJoystickSettings();

--- a/DeviceAdapters/ASITiger/ASIPLogic.cpp
+++ b/DeviceAdapters/ASITiger/ASIPLogic.cpp
@@ -643,7 +643,7 @@ int CPLogic::OnSaveCardSettings(MM::PropertyBase* pProp, MM::ActionType eAct)
       if (tmpstr == g_SaveSettingsX)
          command << 'X';
       else if (tmpstr == g_SaveSettingsY)
-         command << 'X';
+         command << 'Y';
       else if (tmpstr == g_SaveSettingsZ)
          command << 'Z';
       RETURN_ON_MM_ERROR (hub_->QueryCommandVerify(command.str(), ":A", (long)200));  // note 200ms delay added

--- a/DeviceAdapters/ASITiger/ASIPiezo.cpp
+++ b/DeviceAdapters/ASITiger/ASIPiezo.cpp
@@ -1371,7 +1371,7 @@ int CPiezo::OnSAPattern(MM::PropertyBase* pProp, MM::ActionType eAct)
          case 0: success = pProp->Set(g_SAPattern_0); break;
          case 1: success = pProp->Set(g_SAPattern_1); break;
          case 2: success = pProp->Set(g_SAPattern_2); break;
-		 case 3: success = pProp->Set(g_SAPattern_3); break;
+         case 3: success = pProp->Set(g_SAPattern_3); break;
          case 4: success = pProp->Set(g_SAPattern_4); break;
          default:success = 0;                      break;
       }
@@ -1392,7 +1392,7 @@ int CPiezo::OnSAPattern(MM::PropertyBase* pProp, MM::ActionType eAct)
          tmp = 3;
       else if (tmpstr == g_SAPattern_4)
          tmp = 4;
-	  else
+      else
          return DEVICE_INVALID_PROPERTY_VALUE;
       // have to get current settings and then modify bits 0-2 from there
       command << "SAP " << axisLetter_ << "?";

--- a/DeviceAdapters/ASITiger/ASIPiezo.h
+++ b/DeviceAdapters/ASITiger/ASIPiezo.h
@@ -107,7 +107,7 @@ public:
    int OnUseSequence          (MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnFastSequence         (MM::PropertyBase* pProp, MM::ActionType eAct);
    //Others
-   int OnVector				  (MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnVector(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
     int OnSaveJoystickSettings();

--- a/DeviceAdapters/ASITiger/ASIPmt.cpp
+++ b/DeviceAdapters/ASITiger/ASIPmt.cpp
@@ -241,7 +241,7 @@ int CPMT::OnOverloadReset(MM::PropertyBase* pProp, MM::ActionType eAct)
          return DEVICE_OK;
       else if (tmpstr == g_PMTOverloadDone)
          return DEVICE_OK;
-	  else if (tmpstr == g_OnState)
+      else if (tmpstr == g_OnState)
          command << addressChar_ << "LK " << channelAxisChar_ ;
       RETURN_ON_MM_ERROR( hub_->QueryCommandVerify(command.str(), ":A", (long)200) );  // note 200ms delay added
       pProp->Set(g_PMTOverloadDone);
@@ -330,16 +330,15 @@ int CPMT::OnPMTOverload(MM::PropertyBase* pProp, MM::ActionType eAct)
       command << addressChar_ << "LK " << channelAxisChar_ << "?" ;
       RETURN_ON_MM_ERROR ( hub_->QueryCommandVerify(command.str(), ":A") );
       RETURN_ON_MM_ERROR ( hub_->ParseAnswerAfterPosition2(val) );
-      if(val)
-	  {
-	  if (!pProp->Set(g_NoState))
-         return DEVICE_INVALID_PROPERTY_VALUE;
-	  }
-	  else
-	  {
-	  	  if (!pProp->Set(g_YesState))
-         return DEVICE_INVALID_PROPERTY_VALUE;
-	  }
+      if(val) {
+          if (!pProp->Set(g_NoState)) {
+              return DEVICE_INVALID_PROPERTY_VALUE;
+          }
+      } else {
+          if (!pProp->Set(g_YesState)) {
+              return DEVICE_INVALID_PROPERTY_VALUE;
+          }
+      }
    }
    return DEVICE_OK;
 }

--- a/DeviceAdapters/ASITiger/ASIPmt.h
+++ b/DeviceAdapters/ASITiger/ASIPmt.h
@@ -48,13 +48,13 @@ public:
    int IsDASequenceable(bool& isSequenceable) const {isSequenceable = false; return DEVICE_OK;}
 
    // action interface
-   int OnSaveCardSettings     (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnRefreshProperties    (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnGain                 (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnAverage              (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnPMTSignal			  (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnPMTOverload    	  (MM::PropertyBase* pProp, MM::ActionType eAct);
-   int OnOverloadReset        (MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnSaveCardSettings(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnRefreshProperties(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnGain(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnAverage(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnPMTSignal(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnPMTOverload(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnOverloadReset(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 private:
     int UpdateGain();

--- a/DeviceAdapters/ASITiger/ASIScanner.cpp
+++ b/DeviceAdapters/ASITiger/ASIScanner.cpp
@@ -1267,7 +1267,7 @@ int CScanner::OnOutputMode(MM::PropertyBase* pProp, MM::ActionType eAct)
       }
       else
       {
-	  command << "PM " << axisLetterX_ << "?";
+      command << "PM " << axisLetterX_ << "?";
       }
       response << axisLetterX_ << "=";
       RETURN_ON_MM_ERROR ( hub_->QueryCommandVerify(command.str(), response.str()));
@@ -1312,7 +1312,7 @@ int CScanner::OnOutputMode(MM::PropertyBase* pProp, MM::ActionType eAct)
       }
       else
       {
-	  command << "PM " << axisLetterX_ << "=" << tmp << " " << axisLetterY_ << "=" << tmp;
+      command << "PM " << axisLetterX_ << "=" << tmp << " " << axisLetterY_ << "=" << tmp;
       }
       RETURN_ON_MM_ERROR ( hub_->QueryCommandVerify(command.str(), ":A") );
    }
@@ -1754,7 +1754,7 @@ int CScanner::OnSAPatternX(MM::PropertyBase* pProp, MM::ActionType eAct)
          case 0: success = pProp->Set(g_SAPattern_0); break;
          case 1: success = pProp->Set(g_SAPattern_1); break;
          case 2: success = pProp->Set(g_SAPattern_2); break;
-		 case 3: success = pProp->Set(g_SAPattern_3); break;
+         case 3: success = pProp->Set(g_SAPattern_3); break;
          case 4: success = pProp->Set(g_SAPattern_4); break;
          default:success = 0;                      break;
       }
@@ -1929,7 +1929,7 @@ int CScanner::OnSAPatternY(MM::PropertyBase* pProp, MM::ActionType eAct)
          case 2: success = pProp->Set(g_SAPattern_2); break;
          case 3: success = pProp->Set(g_SAPattern_3); break;
          case 4: success = pProp->Set(g_SAPattern_4); break;
-		 default:success = 0;                      break;
+         default:success = 0;                      break;
       }
       if (!success)
          return DEVICE_INVALID_PROPERTY_VALUE;

--- a/DeviceAdapters/ASITiger/ASIScanner.cpp
+++ b/DeviceAdapters/ASITiger/ASIScanner.cpp
@@ -331,33 +331,33 @@ int CScanner::Initialize() {
       dac4ch_ = true;
       if (hub_->IsDefinePresent(build, "SIGNAL_DAC"))
       {
-	signalDAC_ = true;
-	// add output mode property, for SIGNAL_DAC a restart is required and use PR instead of PM
-	// but the list of modules is exactly the same as with the generic DAC_4CH.      
-	pAct = new CPropertyAction (this, &CScanner::OnOutputMode);
-	CreateProperty(g_DACModePropertyName, "0", MM::String, false, pAct);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_0);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_1);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_2);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_4);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_5);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_6);
-	AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_7);
-	UpdateProperty(g_DACModePropertyName);
+    signalDAC_ = true;
+    // add output mode property, for SIGNAL_DAC a restart is required and use PR instead of PM
+    // but the list of modules is exactly the same as with the generic DAC_4CH.      
+    pAct = new CPropertyAction (this, &CScanner::OnOutputMode);
+    CreateProperty(g_DACModePropertyName, "0", MM::String, false, pAct);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_0);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_1);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_2);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_4);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_5);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_6);
+    AddAllowedValue(g_DACModePropertyName, g_DACOutputMode_7);
+    UpdateProperty(g_DACModePropertyName);
       }
       else
       {
-	// add output mode property
+    // add output mode property
         pAct = new CPropertyAction (this, &CScanner::OnOutputMode);
-	CreateProperty(g_ScannerOutputModePropertyName, "0", MM::String, false, pAct);
-	AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_0);
-	AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_1);
-	AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_2);
-	AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_4);
-	AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_5);
-	AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_6);
-	AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_7);
-	UpdateProperty(g_ScannerOutputModePropertyName);
+    CreateProperty(g_ScannerOutputModePropertyName, "0", MM::String, false, pAct);
+    AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_0);
+    AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_1);
+    AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_2);
+    AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_4);
+    AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_5);
+    AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_6);
+    AddAllowedValue(g_ScannerOutputModePropertyName, g_DACOutputMode_7);
+    UpdateProperty(g_ScannerOutputModePropertyName);
       }
    }
    else  // original MEMS scanner firmware
@@ -514,9 +514,9 @@ int CScanner::Initialize() {
       }
 
       if (FirmwareVersionAtLeast(3.14)) {
-	// in 3.50 added bit 7 of SPIM mode for smooth slice (e.g. constant galvo scan for scope)
+    // in 3.50 added bit 7 of SPIM mode for smooth slice (e.g. constant galvo scan for scope)
         pAct = new CPropertyAction (this, &CScanner::OnSPIMSmoothSliceEnable);
-	CreateProperty(g_SPIMSmoothSliceEnable, g_NoState, MM::String, false, pAct);
+    CreateProperty(g_SPIMSmoothSliceEnable, g_NoState, MM::String, false, pAct);
         AddAllowedValue(g_SPIMSmoothSliceEnable, g_YesState);
         AddAllowedValue(g_SPIMSmoothSliceEnable, g_NoState);
         UpdateProperty(g_SPIMSmoothSliceEnable);

--- a/DeviceAdapters/ASITiger/ASITigerComm.cpp
+++ b/DeviceAdapters/ASITiger/ASITigerComm.cpp
@@ -322,9 +322,9 @@ int CTigerCommHub::DetectInstalledDevices()
             command << "Found slave axis letter " <<  build.vAxesLetter[i] << "; skipping it";
             LogMessage(command.str());
             continue; // go on to next axis (skips below code and goes to next for loop iteration)
-		 case 'd':  // Signal DAC
-			 name = g_DacDeviceName;
-			 break;
+        case 'd':  // Signal DAC
+            name = g_DacDeviceName;
+            break;
          default:
             command.str("");
             command << "Device type " <<  build.vAxesType[i] << " not supported by Tiger device adapter, skipping it";

--- a/DeviceAdapters/ASITiger/ASIXYStage.cpp
+++ b/DeviceAdapters/ASITiger/ASIXYStage.cpp
@@ -485,28 +485,25 @@ int CXYStage::GetPositionSteps(long& x, long& y)
 }
 
 //rewritten to get 2 position from one serial command query, require half the time
-//But may cause problem for cases where xy axis are on different cards , reply may not be in correct order
-//int CXYStage::GetPositionSteps(long& x, long& y)
-//{
-//	 ostringstream command;	 command.str("");
-//	 command << "W " << axisLetterX_<<" "<<axisLetterY_;
-//	 RETURN_ON_MM_ERROR ( hub_->QueryCommandVerify(command.str(),":A") );
-//	 vector<string> elems=hub_->SplitAnswerOnDelim(" ");
-//	 //check if reply is in correct format
-//	 //has exactly 3 strings after split, and first string is ":A"
-//	 //W X Y
-//	 //:A 123 123
-//	 if(elems.size()<3 || elems[0].find(":A")== string::npos)
-//	 {
-//		RETURN_ON_MM_ERROR(DEVICE_SERIAL_INVALID_RESPONSE);
-//	 }
-//	 double xtmp,ytmp;
-//	 xtmp=atoi(elems[1].c_str());
-//	 ytmp=atoi(elems[2].c_str());
-//	 x = (long)(xtmp/unitMultX_/stepSizeXUm_);
-//	 y = (long)(ytmp/unitMultY_/stepSizeYUm_);
-//
-//	  return DEVICE_OK;
+//But may cause problem for cases where xy axis are on different cards, reply may not be in correct order
+//int CXYStage::GetPositionSteps(long& x, long& y) {
+// ostringstream command;
+// command << "W " << axisLetterX_<<" "<<axisLetterY_;
+// RETURN_ON_MM_ERROR ( hub_->QueryCommandVerify(command.str(),":A") );
+// vector<string> elems=hub_->SplitAnswerOnDelim(" ");
+// //check if reply is in correct format
+// //has exactly 3 strings after split, and first string is ":A"
+// //W X Y
+// //:A 123 123
+// if (elems.size()<3 || elems[0].find(":A")== string::npos) {
+//     RETURN_ON_MM_ERROR(DEVICE_SERIAL_INVALID_RESPONSE);
+// }
+// double xtmp,ytmp;
+// xtmp=atoi(elems[1].c_str());
+// ytmp=atoi(elems[2].c_str());
+// x = (long)(xtmp/unitMultX_/stepSizeXUm_);
+// y = (long)(ytmp/unitMultY_/stepSizeYUm_);
+//  return DEVICE_OK;
 //}
 
 int CXYStage::SetPositionSteps(long x, long y)

--- a/DeviceAdapters/ASITiger/ASIXYStage.cpp
+++ b/DeviceAdapters/ASITiger/ASIXYStage.cpp
@@ -783,7 +783,7 @@ int CXYStage::OnSaveCardSettings(MM::PropertyBase* pProp, MM::ActionType eAct)
       if (tmpstr == g_SaveSettingsX)
          command << 'X';
       else if (tmpstr == g_SaveSettingsY)
-         command << 'X';
+         command << 'Y';
       else if (tmpstr == g_SaveSettingsZ)
          command << 'Z';
       else if (tmpstr == g_SaveSettingsZJoystick)

--- a/DeviceAdapters/ASITiger/ASIZStage.cpp
+++ b/DeviceAdapters/ASITiger/ASIZStage.cpp
@@ -1730,7 +1730,7 @@ int CZStage::OnSAPattern(MM::PropertyBase* pProp, MM::ActionType eAct)
          case 2: success = pProp->Set(g_SAPattern_2); break;
          case 3: success = pProp->Set(g_SAPattern_3); break;
          case 4: success = pProp->Set(g_SAPattern_4); break;
-		 default:success = 0;                      break;
+         default:success = 0;                      break;
       }
       if (!success)
          return DEVICE_INVALID_PROPERTY_VALUE;
@@ -1749,7 +1749,7 @@ int CZStage::OnSAPattern(MM::PropertyBase* pProp, MM::ActionType eAct)
          tmp = 3;
       else if (tmpstr == g_SAPattern_4)
          tmp = 4;
-	  else
+      else
          return DEVICE_INVALID_PROPERTY_VALUE;
       // have to get current settings and then modify bits 0-2 from there
       command << "SAP " << axisLetter_ << "?";


### PR DESCRIPTION
This fixes an error present on the PLogic, XYStage, and DacXYStage devices.

Those devices were sending `SS X` when they should have sent `SS Y` in the `OnSaveCardSettings()` action handler.

It appears that this was a copy and paste error that propagated through the code.

I implemented DacXYStage partially from XYStage and I must have copied it from there.

See the [SAVESET](https://www.asiimaging.com/docs/commands/saveset) command documentation.

```java

      if (tmpstr == g_SaveSettingsX)
         command << 'X';
      else if (tmpstr == g_SaveSettingsY) // g_SaveSettingsY == "Y - restore last saved settings from card";
         command << 'Y';  <--------------------  This was 'X'
      else if (tmpstr == g_SaveSettingsZ)
         command << 'Z';
         
```

Note: this commit also contains cosmetic changes that do not change the behavior of the code. Use spaces throughout the project.