### PR TITLE
Use standard C++ for DeviceThreadBase and MMThreadLock implementation

### DIFF
--- a/DeviceAdapters/89NorthLDI/LDI.cpp
+++ b/DeviceAdapters/89NorthLDI/LDI.cpp
@@ -2,6 +2,9 @@
 
 #include <ctime>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 const char* g_LDI_name = "89 North Laser Diode Illuminator";
 const char* g_LDI_description = "Multi-line, Solid-State Laser Illuminator";
 #define LDI_ERROR 108901

--- a/DeviceAdapters/ABS/AbsImgBuffer.h
+++ b/DeviceAdapters/ABS/AbsImgBuffer.h
@@ -2,6 +2,9 @@
 #include "ImgBuffer.h"              //!< base  class
 #include "DeviceThreads.h"          //!< MMThreadLock class
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 // ---------------------------Camera - API ------------------------------------
 #include "common_structs_exp.h"     //!< ABS Camera API structs
 

--- a/DeviceAdapters/AndorShamrock/AndorShamrock.cpp
+++ b/DeviceAdapters/AndorShamrock/AndorShamrock.cpp
@@ -1,7 +1,10 @@
 #include "AndorShamrock.h"
 #include "ModuleAPIFunctions.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 #include "ShamrockCIF.h"
-//#include "ShamrockConstants.h"
 #include <sstream>
 
 using namespace std;

--- a/DeviceAdapters/BaumerOptronic/BaumerOptronic.h
+++ b/DeviceAdapters/BaumerOptronic/BaumerOptronic.h
@@ -27,6 +27,9 @@
 #include "ImgBuffer.h"
 #include "DeviceThreads.h"
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 #pragma warning(push)
 #pragma warning(disable: 4245)
 #include "FxApi.h"

--- a/DeviceAdapters/DemoCamera/DemoCamera.cpp
+++ b/DeviceAdapters/DemoCamera/DemoCamera.cpp
@@ -37,6 +37,8 @@
 #include <future>
 
 #ifdef _WIN32
+   #define WIN32_LEAN_AND_MEAN
+   #include <Windows.h>
    #include <timeapi.h>
 #endif
 

--- a/DeviceAdapters/Dragonfly/TIRFIntensity.cpp
+++ b/DeviceAdapters/Dragonfly/TIRFIntensity.cpp
@@ -4,6 +4,9 @@
 #include "ConfocalMode.h"
 #include "Dragonfly.h"
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 const char* const g_TIRFIntensityPropertyName = "TIRF | Optical Feedback";
 const char* const g_TIRFIntensityLimitsReadError = "Failed to retrieve TIRF intensity limits";
 const char* const g_TIRFIntensityValueReadError = "Failed to retrieve the current TIRF intensity";

--- a/DeviceAdapters/Elveflow/mux_distrib.cpp
+++ b/DeviceAdapters/Elveflow/mux_distrib.cpp
@@ -1,9 +1,11 @@
 #include "ModuleInterface.h"
 #include "mux_distrib.h"
-#include "iostream"
+#include <iostream>
 #include <vector>
 #include <string>
-#include <windows.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 
 using namespace std;
 

--- a/DeviceAdapters/Elveflow/mux_wire_v3.cpp
+++ b/DeviceAdapters/Elveflow/mux_wire_v3.cpp
@@ -1,9 +1,8 @@
 #include "ModuleInterface.h"
 #include "mux_wire_v3.h"
-#include "iostream"
+#include <iostream>
 #include <vector>
 #include <string>
-#include <windows.h>
 
 using namespace std;
 

--- a/DeviceAdapters/Elveflow/mux_wire_v3.h
+++ b/DeviceAdapters/Elveflow/mux_wire_v3.h
@@ -2,6 +2,9 @@
 #include "DeviceUtils.h"
 #include <vector>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 using namespace std;
 
 class MuxWireV3 : public CGenericBase<MuxWireV3> {

--- a/DeviceAdapters/Elveflow/ob1_mk4.cpp
+++ b/DeviceAdapters/Elveflow/ob1_mk4.cpp
@@ -1,9 +1,8 @@
 #include "ModuleInterface.h"
 #include "ob1_mk4.h"
-#include "iostream"
+#include <iostream>
 #include <vector>
 #include <string>
-#include <windows.h>
 
 using namespace std;
 

--- a/DeviceAdapters/Elveflow/ob1_mk4.h
+++ b/DeviceAdapters/Elveflow/ob1_mk4.h
@@ -2,6 +2,9 @@
 #include "DeviceUtils.h"
 #include <vector>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 using namespace std;
 
 class Ob1Mk4 : public CGenericBase<Ob1Mk4> {

--- a/DeviceAdapters/Hikrobot/HikrobotCamera.h
+++ b/DeviceAdapters/Hikrobot/HikrobotCamera.h
@@ -43,6 +43,9 @@
 #include <iostream>
 #include "MvCamera.h"
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 
 //////////////////////////////////////////////////////////////////////////////
 // Error codes

--- a/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ALC_REVOject3Wrapper.cpp
+++ b/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ALC_REVOject3Wrapper.cpp
@@ -4,8 +4,9 @@
 // SUBSYSTEM:     DeviceAdapters
 //-----------------------------------------------------------------------------
 
-#ifdef WIN32
-#include <windows.h>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 #include "ALC_REVOject3Wrapper.h"

--- a/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ALC_REV_ILE2Wrapper.cpp
+++ b/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ALC_REV_ILE2Wrapper.cpp
@@ -3,8 +3,9 @@
 // PROJECT:       Micro-Manager
 // SUBSYSTEM:     DeviceAdapters
 //-----------------------------------------------------------------------------
-#ifdef WIN32
-#include <windows.h>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 #include "ALC_REV_ILE2Wrapper.h"
 #include "ILESDKLock.h"

--- a/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ALC_REV_ILE4Wrapper.cpp
+++ b/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ALC_REV_ILE4Wrapper.cpp
@@ -3,8 +3,9 @@
 // PROJECT:       Micro-Manager
 // SUBSYSTEM:     DeviceAdapters
 //-----------------------------------------------------------------------------
-#ifdef WIN32
-#include <windows.h>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 #include "ALC_REV_ILE4Wrapper.h"
 #include "ILESDKLock.h"

--- a/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ILEWrapper.cpp
+++ b/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ILEWrapper.cpp
@@ -8,8 +8,9 @@
 // Based off the AndorLaserCombiner adapter from Karl Hoover, UCSF
 //
 
-#ifdef WIN32
-#include <windows.h>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 #include "ALC_REV.h"
@@ -22,7 +23,7 @@
 #include "ALC_REV_ILE4Wrapper.h"
 #include "ILESDKLock.h"
 #include "../IntegratedLaserEngine.h"
-#include "../../../MMDevice/DeviceThreads.h"
+#include "DeviceThreads.h"
 #include <sstream>
 #include <exception>
 

--- a/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ILEWrapper.h
+++ b/DeviceAdapters/IntegratedLaserEngine/ILEWrapper/ILEWrapper.h
@@ -15,6 +15,9 @@
 #include "..\ILEWrapperInterface.h"
 #include <map>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 class CALC_REV_ILEActiveBlankingManagementWrapper;
 class CALC_REV_ILEPowerManagementWrapper;
 class CALC_REV_ILEPowerManagement2Wrapper;

--- a/DeviceAdapters/IntegratedLaserEngine/IntegratedLaserEngine.cpp
+++ b/DeviceAdapters/IntegratedLaserEngine/IntegratedLaserEngine.cpp
@@ -15,6 +15,7 @@
 #include "ILEWrapper/ILEWrapper.h"
 #include "Lasers.h"
 #include "VeryLowPower.h"
+#include "MMDevice.h"
 
 
 // Properties
@@ -619,7 +620,7 @@ void CIntegratedLaserEngine::LogMMMessage( std::string Message, bool DebugOnly )
   LogMessage( Message, DebugOnly );
 }
 
-MM::MMTime CIntegratedLaserEngine::GetCurrentTime()
+MM::MMTime CIntegratedLaserEngine::GetCurrentTimeMM()
 {
   return GetCurrentMMTime();
 }

--- a/DeviceAdapters/IntegratedLaserEngine/IntegratedLaserEngine.h
+++ b/DeviceAdapters/IntegratedLaserEngine/IntegratedLaserEngine.h
@@ -12,7 +12,7 @@
 #ifndef _INTEGRATEDLASERENGINE_H_
 #define _INTEGRATEDLASERENGINE_H_
 
-#include "../../MMDevice/DeviceBase.h"
+#include "DeviceBase.h"
 #include <string>
 #include <vector>
 #include "ILEWrapperInterface.h"
@@ -85,7 +85,7 @@ public:
 
   // Helper functions
   void LogMMMessage( std::string Message, bool DebugOnly = false );
-  MM::MMTime GetCurrentTime();
+  MM::MMTime GetCurrentTimeMM();
 
   void CheckAndUpdateLasers();
   virtual void CheckAndUpdateLowPowerMode() = 0;

--- a/DeviceAdapters/IntegratedLaserEngine/Lasers.cpp
+++ b/DeviceAdapters/IntegratedLaserEngine/Lasers.cpp
@@ -80,7 +80,7 @@ void CLasers::WaitOnLaserWarmingUp()
   std::vector<TLaserState> vState( NumberOfLasers_ + 1, ALC_NOT_AVAILABLE );
 
   // Lasers can take up to 90 seconds to initialize
-  MM::TimeoutMs vTimerOut( MMILE_->GetCurrentTime(), 91000 );
+  MM::TimeoutMs vTimerOut( MMILE_->GetCurrentTimeMM(), 91000 );
 
   while ( true )
   {
@@ -119,7 +119,7 @@ void CLasers::WaitOnLaserWarmingUp()
       break;
     }
 
-    if ( vTimerOut.expired( MMILE_->GetCurrentTime() ) )
+    if ( vTimerOut.expired( MMILE_->GetCurrentTimeMM() ) )
     {
       MMILE_->LogMMMessage( " some lasers did not respond", false );
       break;

--- a/DeviceAdapters/IntegratedLaserEngine/Lasers.h
+++ b/DeviceAdapters/IntegratedLaserEngine/Lasers.h
@@ -13,7 +13,10 @@
 #define _LASERS_H_
 
 #include "Property.h"
-#include "../../MMDevice/DeviceThreads.h"
+#include "DeviceThreads.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 
 class IALC_REV_Laser2;
 class IALC_REV_ILEPowerManagement;

--- a/DeviceAdapters/IntegratedLaserEngine/PortsConfiguration.cpp
+++ b/DeviceAdapters/IntegratedLaserEngine/PortsConfiguration.cpp
@@ -6,7 +6,8 @@
 
 #include "PortsConfiguration.h"
 #include "IntegratedLaserEngine.h"
-#include <windows.h>
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #include <Shlobj.h>
 #include <fstream>
 #include "boost\filesystem.hpp"

--- a/DeviceAdapters/JAI/JAI.h
+++ b/DeviceAdapters/JAI/JAI.h
@@ -26,17 +26,8 @@
 #include <DeviceThreads.h>
 #include <cstdint>
 
-#ifdef WIN32
-//...
-#endif
-
-#ifdef __APPLE__
-//...
-#endif
-
-#ifdef __linux__
-//...
-#endif
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 
 #include <string>
 #include <vector>

--- a/DeviceAdapters/LaserQuantumLaser/LaserQuantumLaser.cpp
+++ b/DeviceAdapters/LaserQuantumLaser/LaserQuantumLaser.cpp
@@ -13,8 +13,9 @@
 #include <iostream>
 #include <fstream>
 
-#ifdef WIN32
-#include "winuser.h"
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 const char* g_DeviceName = "Laser";

--- a/DeviceAdapters/MCCDAQ/MCCDAQ.cpp
+++ b/DeviceAdapters/MCCDAQ/MCCDAQ.cpp
@@ -21,7 +21,10 @@
 
 #include "MCCDAQ.h"
 #include "ModuleInterface.h"
+
+#define WIN32_LEAN_AND_MEAN
 #include "cbw.h"
+
 #include <sstream>
 
 

--- a/DeviceAdapters/MCL_MicroDrive/MicroDriveXYStage.h
+++ b/DeviceAdapters/MCL_MicroDrive/MicroDriveXYStage.h
@@ -20,6 +20,9 @@ License:	Distributed under the BSD license.
 #include "handle_list_if.h"
 #include "HandleListType.h"
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 #define ERR_UNKNOWN_MODE         102
 #define ERR_UNKNOWN_POSITION     103
 #define ERR_NOT_VALID_INPUT      104

--- a/DeviceAdapters/MCL_MicroDrive/MicroDriveZStage.h
+++ b/DeviceAdapters/MCL_MicroDrive/MicroDriveZStage.h
@@ -19,6 +19,9 @@ License:	Distributed under the BSD license.
 #include "handle_list_if.h"
 #include "HandleListType.h"
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 #define ERR_UNKNOWN_MODE         102
 #define ERR_UNKNOWN_POSITION     103
 #define ERR_NOT_VALID_INPUT      104

--- a/DeviceAdapters/MCL_NanoDrive/MCL_NanoDrive_XYStage.cpp
+++ b/DeviceAdapters/MCL_NanoDrive/MCL_NanoDrive_XYStage.cpp
@@ -9,6 +9,9 @@ License:	Distributed under the BSD license.
 #include <vector>
 #include <string>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 MCL_NanoDrive_XYStage::MCL_NanoDrive_XYStage():
 	calibrationX_(0),
 	calibrationY_(0),

--- a/DeviceAdapters/MCL_NanoDrive/MCL_NanoDrive_ZStage.cpp
+++ b/DeviceAdapters/MCL_NanoDrive/MCL_NanoDrive_ZStage.cpp
@@ -9,6 +9,9 @@ License:	Distributed under the BSD license.
 #include <vector>
 #include <string>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 MCL_NanoDrive_ZStage::MCL_NanoDrive_ZStage() :	
 	axis_(0),
 	calibration_(0.0),

--- a/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.h
+++ b/DeviceAdapters/Mightex_C_Cam/Mightex_USBCamera.h
@@ -35,6 +35,9 @@
 #include <map>
 #include <algorithm>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 //////////////////////////////////////////////////////////////////////////////
 // Error codes
 //

--- a/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.h
+++ b/DeviceAdapters/Mightex_SB_Cam/Mightex_SB_Camera.h
@@ -35,6 +35,9 @@
 #include <map>
 #include <algorithm>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 //////////////////////////////////////////////////////////////////////////////
 // Error codes
 //

--- a/DeviceAdapters/Motic/MoticCamera.h
+++ b/DeviceAdapters/Motic/MoticCamera.h
@@ -35,6 +35,10 @@
 #include "ImgBuffer.h"
 #include "DeviceThreads.h"
 #include "ImgBuffer.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 using namespace std;
 //////////////////////////////////////////////////////////////////////////////
 // Error codes

--- a/DeviceAdapters/MoticMicroscope/MoticMicroscope.h
+++ b/DeviceAdapters/MoticMicroscope/MoticMicroscope.h
@@ -32,8 +32,12 @@
 
 #include <map>
 #include <set>
-using namespace std;
 #include "DeviceBase.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+using namespace std;
 
 // Error codes
 #define ERR_HUB_PATH (900)

--- a/DeviceAdapters/Okolab/OkolabDevice.cpp
+++ b/DeviceAdapters/Okolab/OkolabDevice.cpp
@@ -3,6 +3,9 @@
 #include <ModuleInterface.h>
 #include <cmath>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 /* String constants */
 std::vector<std::string> OkolabDevice::_ports;
 bool OkolabDevice::_initialized = false;

--- a/DeviceAdapters/Omicron/Omicron.cpp
+++ b/DeviceAdapters/Omicron/Omicron.cpp
@@ -11,8 +11,9 @@
 
 #include "Omicron.h"
 
-#ifdef _WINDOWS
-#include "winuser.h"
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 const char* g_DeviceoldOmicronName = "Omicron";

--- a/DeviceAdapters/Omicron/OmicronxX.cpp
+++ b/DeviceAdapters/Omicron/OmicronxX.cpp
@@ -13,10 +13,12 @@
 #include "Omicron.h"
 #include "CoherentOBISDirect.h"
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include "OmicronDeviceDriver.h"
 #include "OmicronxXDevices.h"
 #define OMICRON_XDEVICES
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 #include <algorithm>

--- a/DeviceAdapters/OxxiusCombiner/OxxiusCombinerHub.h
+++ b/DeviceAdapters/OxxiusCombiner/OxxiusCombinerHub.h
@@ -13,8 +13,9 @@
 using namespace std;
 
 //For Obis
-#ifdef WIN32
-	#include <windows.h>
+#ifdef _WIN32
+   #define WIN32_LEAN_AND_MEAN
+   #include <Windows.h>
 #endif
 #include "DeviceUtils.h"
 #include <algorithm>

--- a/DeviceAdapters/PCO_Generic/MicroManager.cpp
+++ b/DeviceAdapters/PCO_Generic/MicroManager.cpp
@@ -19,12 +19,14 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
 
-#include "..\..\MMDevice/ModuleInterface.h"
+#include "MicroManager.h"
+
+#include "ModuleInterface.h"
+
 #define PCO_ERRT_H_CREATE_OBJECT
 #include "PCO_err.h"
 #include "PCO_errt.h"
 
-#include "MicroManager.h"
 #include "VersionNo.h"
 
 #if defined _WIN64

--- a/DeviceAdapters/PCO_Generic/MicroManager.h
+++ b/DeviceAdapters/PCO_Generic/MicroManager.h
@@ -24,10 +24,14 @@
 #ifndef _PCO_GENERIC_H_
 #define _PCO_GENERIC_H_
 
-#include "../../MMDevice/DeviceBase.h"
-#include "../../MMDevice/ImgBuffer.h"
-#include "../../MMDevice/DeviceThreads.h"
-#include "../../MMDevice/DeviceUtils.h"
+#include "DeviceBase.h"
+#include "ImgBuffer.h"
+#include "DeviceThreads.h"
+#include "DeviceUtils.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 #include "Camera.h"
 #include <string>
 #include <map>

--- a/DeviceAdapters/PICAM/PICAMAdapter.h
+++ b/DeviceAdapters/PICAM/PICAMAdapter.h
@@ -32,11 +32,13 @@
 #include "DeviceUtils.h"
 #include "DeviceThreads.h"
 
-#ifdef WIN64
+#ifdef _WIN32
 #pragma warning(push)
 #include "picam.h"
 #include "picam_advanced.h"
 #pragma warning(pop)
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 #include <functional> // for mem_fn

--- a/DeviceAdapters/PI_GCS_2/PIController.cpp
+++ b/DeviceAdapters/PI_GCS_2/PIController.cpp
@@ -27,6 +27,11 @@
 #include "PIGCSCommands.h"
 #include "PI_GCS_2.h"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
 std::map<std::string, PIController*> PIController::allControllersByLabel_;
 
 PIController::PIController (const std::string& label, MM::Core* logsink, MM::Device* logdevice)

--- a/DeviceAdapters/PI_GCS_2/PIGCSCommands.cpp
+++ b/DeviceAdapters/PI_GCS_2/PIGCSCommands.cpp
@@ -26,6 +26,11 @@
 #include "PI_GCS_2.h"
 #include "PIController.h" // error codes
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
 
 PIGCSCommands::PIGCSCommands ()
    : controllerError_ (PI_CNTR_NO_ERROR)

--- a/DeviceAdapters/PI_GCS_2/PIGCSCommandsDLL.h
+++ b/DeviceAdapters/PI_GCS_2/PIGCSCommandsDLL.h
@@ -30,6 +30,11 @@
 #include <string>
 #include <stdint.h>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
 class PIController;
 
 class PIGCSCommandsDLL : public PIGCSCommands
@@ -83,7 +88,7 @@ private:
    std::string dllPrefix_;
    int ID_;
 
-#ifdef WIN32
+#ifdef _WIN32
    HMODULE module_;
 #else
    void* module_;

--- a/DeviceAdapters/PI_GCS_2/PIXYStage.cpp
+++ b/DeviceAdapters/PI_GCS_2/PIXYStage.cpp
@@ -25,6 +25,11 @@
 #include "PIXYStage.h"
 #include "PIController.h"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
 const char* PIXYStage::DeviceName_ = "PIXYStage";
 
 const char* g_PI_XYStageAxisXName = "Axis X: Name";

--- a/DeviceAdapters/PI_GCS_2/PIZStage.cpp
+++ b/DeviceAdapters/PI_GCS_2/PIZStage.cpp
@@ -27,6 +27,11 @@
 #include "PI_GCS_2.h"
 #include "PIController.h"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
 const char* PIZStage::DeviceName_ = "PIZStage";
 const char* g_PI_ZStageAxisName = "Axis";
 const char* g_PI_ZStageAxisLimitUm = "Limit_um";

--- a/DeviceAdapters/PicardStage/PicardStage.cpp
+++ b/DeviceAdapters/PicardStage/PicardStage.cpp
@@ -21,12 +21,16 @@
 //                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 
-#include <iostream>
+#include "PicardStage.h"
 
 #include "ModuleInterface.h"
+
+#include <iostream>
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #include "PiUsb.h"
 
-#include "PicardStage.h"
 
 using namespace std;
 

--- a/DeviceAdapters/RaptorEPIX/RaptorEPIX.h
+++ b/DeviceAdapters/RaptorEPIX/RaptorEPIX.h
@@ -28,6 +28,9 @@
 #include "ImgBuffer.h"
 #include "DeviceThreads.h"
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 //#define PLEORA
 
 #ifdef PLEORA

--- a/DeviceAdapters/SigmaKoki/Camera.h
+++ b/DeviceAdapters/SigmaKoki/Camera.h
@@ -16,6 +16,10 @@
 #include <map>
 #include <algorithm>
 #include <stdint.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 using namespace std;
 extern const char* g_CameraDeviceName;
 #pragma endregion Prehead_Inclus

--- a/DeviceAdapters/TSI/TSI3Cam.h
+++ b/DeviceAdapters/TSI/TSI3Cam.h
@@ -29,16 +29,9 @@
 #include "tl_camera_sdk.h"
 #include "tl_camera_sdk_load.h"
 
-#ifdef WIN32
-//...
-#endif
-
-#ifdef __APPLE__
-//...
-#endif
-
-#ifdef __linux__
-//...
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 #include <string>

--- a/DeviceAdapters/TSI/TSICam.h
+++ b/DeviceAdapters/TSI/TSICam.h
@@ -31,16 +31,9 @@
 #include <TsiColorCamera.h>
 #include "TsiLibrary.h"
 
-#ifdef WIN32
-//...
-#endif
-
-#ifdef __APPLE__
-//...
-#endif
-
-#ifdef linux
-//...
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 #include <string>

--- a/DeviceAdapters/ThorlabsCHROLIS/ThorlabsChrolis.cpp
+++ b/DeviceAdapters/ThorlabsCHROLIS/ThorlabsChrolis.cpp
@@ -25,6 +25,9 @@
 
 #include <string>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 MODULE_API void InitializeModuleData() {
     RegisterDevice(CHROLIS_HUB_NAME,
         MM::HubDevice, 

--- a/DeviceAdapters/Toptica_iBeamSmartCW/Toptica_iBeamSmartCW.cpp
+++ b/DeviceAdapters/Toptica_iBeamSmartCW/Toptica_iBeamSmartCW.cpp
@@ -12,8 +12,9 @@
 
 #include "Toptica_iBeamSmartCW.h"
 
-#ifdef WIN32
-#include "winuser.h"
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 const char* g_DeviceiBeamSmartName = "iBeamSmartCW";

--- a/DeviceAdapters/TriggerScope/TriggerScope.cpp
+++ b/DeviceAdapters/TriggerScope/TriggerScope.cpp
@@ -26,7 +26,10 @@
 
 #include "ModuleInterface.h"
 
-#ifndef _WIN32
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#else
 #include <unistd.h>
 #endif
 
@@ -65,26 +68,6 @@ const char* g_Off = "Off";
 // static lock
 MMThreadLock CTriggerScopeHub::lock_;
 
-// TODO: linux entry code
-
-// windows DLL entry code
-#ifdef WIN32
-BOOL APIENTRY DllMain( HANDLE /*hModule*/, 
-                      DWORD  ul_reason_for_call, 
-                      LPVOID /*lpReserved*/
-                      )
-{
-   switch (ul_reason_for_call)
-   {
-   case DLL_PROCESS_ATTACH:
-   case DLL_THREAD_ATTACH:
-   case DLL_THREAD_DETACH:
-   case DLL_PROCESS_DETACH:
-      break;
-   }
-   return TRUE;
-}
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // Exported MMDevice API

--- a/DeviceAdapters/TriggerScope/TriggerScope.h
+++ b/DeviceAdapters/TriggerScope/TriggerScope.h
@@ -27,7 +27,6 @@
 #define _TriggerScope_H_
 
 #include "DeviceBase.h"
-#include "../Utilities/Utilities.h"
 #include <string>
 #include <map>
 #include <algorithm>

--- a/DeviceAdapters/TriggerScopeMM/TriggerScopeMM.cpp
+++ b/DeviceAdapters/TriggerScopeMM/TriggerScopeMM.cpp
@@ -29,7 +29,6 @@
 #include <string>
 #include <math.h>
 #include "ModuleInterface.h"
-#include "../../MMCore/Error.h"
 #include <sstream>
 #include <algorithm>
 #include <iostream>
@@ -59,26 +58,6 @@ const char * g_TriggerScope_Version = "v1.0-MM, 8/24/2020";
 // static lock
 MMThreadLock CTriggerScopeMMHub::lock_;
 
-// TODO: linux entry code
-
-// windows DLL entry code
-#ifdef WIN32
-BOOL APIENTRY DllMain( HANDLE /*hModule*/, 
-                      DWORD  ul_reason_for_call, 
-                      LPVOID /*lpReserved*/
-                      )
-{
-   switch (ul_reason_for_call)
-   {
-   case DLL_PROCESS_ATTACH:
-   case DLL_THREAD_ATTACH:
-   case DLL_THREAD_DETACH:
-   case DLL_PROCESS_DETACH:
-      break;
-   }
-   return TRUE;
-}
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // Exported MMDevice API

--- a/DeviceAdapters/USB_Viper_QPL/XCiteViper.cpp
+++ b/DeviceAdapters/USB_Viper_QPL/XCiteViper.cpp
@@ -14,9 +14,10 @@
 
 #include "XCiteViper.h"
 #include "ModuleInterface.h"
-#include "cbw.h"
 #include <sstream>
 
+#define WIN32_LEAN_AND_MEAN
+#include "cbw.h"
 
 const int BOARDREADY = 100;
 

--- a/DeviceAdapters/UniversalMMHubSerial/ummhSerial.cpp
+++ b/DeviceAdapters/UniversalMMHubSerial/ummhSerial.cpp
@@ -24,6 +24,9 @@
 #include "ummhSerial.h"
 #include "ummhreserved.h"
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 using namespace std;
 
 // External names used by the rest of the system

--- a/DeviceAdapters/UniversalMMHubUsb/ummhUsb.cpp
+++ b/DeviceAdapters/UniversalMMHubUsb/ummhUsb.cpp
@@ -28,9 +28,12 @@
 
 #include "ummhUsb.h"
 #include "../UniversalMMHubSerial/ummhreserved.h"
-#include "libusb.h"
 
 #include "CameraImageMetadata.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "libusb.h"
 
 using namespace MM;
 

--- a/DeviceAdapters/VisiTech_iSIM/VTiSIM.h
+++ b/DeviceAdapters/VisiTech_iSIM/VTiSIM.h
@@ -35,6 +35,9 @@
 
 #include "DeviceBase.h"
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 
 class VTiSIMHub : public HubBase<VTiSIMHub>
 {

--- a/DeviceAdapters/Vortran/VersaLase.cpp
+++ b/DeviceAdapters/Vortran/VersaLase.cpp
@@ -48,8 +48,9 @@
 */
 
 #include "VersaLase.h"
-#ifdef WIN32
-   #include <windows.h>
+#ifdef _WIN32
+   #define WIN32_LEAN_AND_MEAN
+   #include <Windows.h>
 #endif
 
 #include "MMDevice.h"

--- a/DeviceAdapters/ZWO/MyASICam2.cpp
+++ b/DeviceAdapters/ZWO/MyASICam2.cpp
@@ -1,7 +1,3 @@
-#include "MyASICam2.h"
-
-#include "CameraImageMetadata.h"
-
 ///////////////////////////////////////////////////////////////////////////////
 // FILE:          CMyASICam.cpp
 // PROJECT:       Micro-Manager
@@ -26,6 +22,12 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
 
+#include "MyASICam2.h"
+
+#include "CameraImageMetadata.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 
 
 using namespace std;

--- a/MMDevice/DeviceThreads.h
+++ b/MMDevice/DeviceThreads.h
@@ -23,14 +23,6 @@
 #include <mutex>
 #include <thread>
 
-// TODO: These includes are no longer used, but adapter code depends on them.
-#ifdef _WIN32
-   #define WIN32_LEAN_AND_MEAN
-   #include <windows.h>
-#else
-   #include <pthread.h>
-#endif
-
 /**
  * @brief Base class for threads in MM devices.
  *

--- a/MMDevice/DeviceThreads.h
+++ b/MMDevice/DeviceThreads.h
@@ -20,8 +20,7 @@
 
 #pragma once
 
-#include <cassert>
-#include <exception>
+#include <thread>
 
 #ifdef _WIN32
    #define WIN32_LEAN_AND_MEAN
@@ -43,15 +42,9 @@ public:
    virtual ~MMDeviceThreadBase()
    {
       // Detaching on destruction may not be the ideal design, but the only one
-      // possible given previous behavior (which leaked the handle).
-      if (joinable_)
-      {
-#ifdef _WIN32
-         CloseHandle(thread_);
-#else
-         pthread_detach(thread_);
-#endif
-      }
+      // possible given previous behavior (which leaked the native handle).
+      if (thread_.joinable())
+         thread_.detach();
    }
 
    // Cannot copy a thread
@@ -69,77 +62,28 @@ public:
     * The return value is ignored.
     */
    virtual int svc() = 0;
-   // Note: On Windows the return value theoretically can be retrieved using
-   // GetExitCodeThread(), but only if you have the thread handle or ID, which
-   // we don't expose (hence "ignored").
 
    void activate()
    {
-      // We do not disallow reusing the thread object.
-      if (joinable_)
-      {
-#ifdef _WIN32
-         CloseHandle(thread_);
-#else
-         pthread_detach(thread_);
-#endif
-      }
-
-      bool ok{};
-#ifdef _WIN32
-      DWORD id;
-      thread_ = CreateThread(NULL, 0, ThreadProc, this, 0, &id);
-      ok = thread_ != NULL;
-#else
-      ok = pthread_create(&thread_, NULL, ThreadProc, this) == 0;
-#endif
-      joinable_ = ok;
-      // TODO We have no way to report creation error. Probably should terminate.
+      if (thread_.joinable())
+         thread_.detach();
+      thread_ = std::thread([this]() { (void)svc(); });
+      // Note: failure to create the thread will throw std::system_error, but
+      // that only happens upon resource exhaustion (normally rare; akin to
+      // std::bad_alloc). Most callers do not handle this, but terminating with
+      // an uncaught exception is preferable to silently continuing (as we
+      // previously did).
    }
 
    void wait()
    {
-      assert(joinable_);
-      if (!joinable_)
-         std::terminate();
-
-#ifdef _WIN32
-      WaitForSingleObject(thread_, INFINITE);
-      CloseHandle(thread_);
-#else
-      pthread_join(thread_, NULL);
-#endif
-      joinable_ = false;
+      // Note: joining a non-joinable thread (a programming error) will throw
+      // std::system_error.
+      thread_.join();
    }
 
 private:
-#ifdef _WIN32
-   HANDLE
-#else
-   pthread_t
-#endif
-   thread_{};
-
-   // pthread_t has no "empty" value, so we must keep a separate flag.
-   bool joinable_ = false;
-
-
-   static
-#ifdef _WIN32
-   DWORD WINAPI
-#else
-   void*
-#endif
-   ThreadProc(void* param)
-   {
-      MMDeviceThreadBase* pThrObj = (MMDeviceThreadBase*) param;
-#ifdef _WIN32
-      return pThrObj->svc();
-#else
-      pThrObj->svc();
-      return (void*) 0;
-#endif
-   }
+   std::thread thread_;
 };
 
 /**

--- a/MMDevice/DeviceThreads.h
+++ b/MMDevice/DeviceThreads.h
@@ -88,6 +88,9 @@ private:
 
 /**
  * @brief Critical section lock.
+ *
+ * @attention New code should use std::mutex or std::recursive_mutex instead
+ * (note that MMThreadLock is recursive).
  */
 class MMThreadLock
 {
@@ -114,6 +117,11 @@ public:
 #endif
    }
 
+   MMThreadLock(const MMThreadLock&) = delete;
+   MMThreadLock& operator=(const MMThreadLock&) = delete;
+   MMThreadLock(MMThreadLock&&) = delete;
+   MMThreadLock& operator=(MMThreadLock&&) = delete;
+
    void Lock()
    {
 #ifdef _WIN32
@@ -133,10 +141,6 @@ public:
    }
 
 private:
-   // Forbid copying
-   MMThreadLock(const MMThreadLock&);
-   MMThreadLock& operator=(const MMThreadLock&);
-
 #ifdef _WIN32
    CRITICAL_SECTION
 #else
@@ -145,6 +149,12 @@ private:
    lock_;
 };
 
+
+/**
+ * @brief RAII object to acquire and auto-release MMThreadLock.
+ *
+ * @attention New code should use std::lock_guard instead.
+ */
 class MMThreadGuard
 {
 public:
@@ -155,22 +165,23 @@ public:
 
    MMThreadGuard(MMThreadLock* lock) : lock_(lock)
    {
-      if (lock != 0)
+      if (lock != nullptr)
          lock_->Lock();
    }
 
-   bool isLocked() {return lock_ == 0 ? false : true;}
-
    ~MMThreadGuard()
    {
-      if (lock_ != 0)
+      if (lock_ != nullptr)
          lock_->Unlock();
    }
 
-private:
-   // Forbid copying
-   MMThreadGuard(const MMThreadGuard&);
-   MMThreadGuard& operator=(const MMThreadGuard&);
+   MMThreadGuard(const MMThreadGuard&) = delete;
+   MMThreadGuard& operator=(const MMThreadGuard&) = delete;
+   MMThreadGuard(MMThreadGuard&&) = delete;
+   MMThreadGuard& operator=(MMThreadGuard&&) = delete;
 
+   bool isLocked() { return lock_ != nullptr; }
+
+private:
    MMThreadLock* lock_;
 };

--- a/MMDevice/DeviceThreads.h
+++ b/MMDevice/DeviceThreads.h
@@ -180,8 +180,6 @@ public:
    MMThreadGuard(MMThreadGuard&&) = delete;
    MMThreadGuard& operator=(MMThreadGuard&&) = delete;
 
-   bool isLocked() { return lock_ != nullptr; }
-
 private:
    MMThreadLock* lock_;
 };

--- a/MMDevice/DeviceThreads.h
+++ b/MMDevice/DeviceThreads.h
@@ -20,8 +20,10 @@
 
 #pragma once
 
+#include <mutex>
 #include <thread>
 
+// TODO: These includes are no longer used, but adapter code depends on them.
 #ifdef _WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
@@ -95,28 +97,10 @@ private:
 class MMThreadLock
 {
 public:
-   MMThreadLock()
-   {
-#ifdef _WIN32
-      InitializeCriticalSection(&lock_);
-#else
-      pthread_mutexattr_t a;
-      pthread_mutexattr_init(&a);
-      pthread_mutexattr_settype(&a, PTHREAD_MUTEX_RECURSIVE);
-      pthread_mutex_init(&lock_, &a);
-      pthread_mutexattr_destroy(&a);
-#endif
-   }
+   MMThreadLock() = default;
 
-   ~MMThreadLock()
-   {
-#ifdef _WIN32
-      DeleteCriticalSection(&lock_);
-#else
-      pthread_mutex_destroy(&lock_);
-#endif
-   }
-
+   // Disallow moving because we always did and no reason to newly allow.
+   ~MMThreadLock() = default;
    MMThreadLock(const MMThreadLock&) = delete;
    MMThreadLock& operator=(const MMThreadLock&) = delete;
    MMThreadLock(MMThreadLock&&) = delete;
@@ -124,29 +108,16 @@ public:
 
    void Lock()
    {
-#ifdef _WIN32
-      EnterCriticalSection(&lock_);
-#else
-      pthread_mutex_lock(&lock_);
-#endif
+      mutex_.lock();
    }
 
    void Unlock()
    {
-#ifdef _WIN32
-      LeaveCriticalSection(&lock_);
-#else
-      pthread_mutex_unlock(&lock_);
-#endif
+      mutex_.unlock();
    }
 
 private:
-#ifdef _WIN32
-   CRITICAL_SECTION
-#else
-   pthread_mutex_t
-#endif
-   lock_;
+   std::recursive_mutex mutex_;
 };
 
 

--- a/MMDevice/DeviceThreads.h
+++ b/MMDevice/DeviceThreads.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include <cassert>
+#include <exception>
+
 #ifdef _WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
@@ -29,46 +32,97 @@
 
 /**
  * @brief Base class for threads in MM devices.
+ *
+ * @attention New code should use std::thread instead.
  */
 class MMDeviceThreadBase
 {
 public:
-   MMDeviceThreadBase() : thread_(0) {}
-   virtual ~MMDeviceThreadBase() {}
+   MMDeviceThreadBase() {}
 
-   virtual int svc() = 0;
-
-   virtual int activate()
+   virtual ~MMDeviceThreadBase()
    {
+      // Detaching on destruction may not be the ideal design, but the only one
+      // possible given previous behavior (which leaked the handle).
+      if (joinable_)
+      {
+#ifdef _WIN32
+         CloseHandle(thread_);
+#else
+         pthread_detach(thread_);
+#endif
+      }
+   }
+
+   // Cannot copy a thread
+   MMDeviceThreadBase(const MMDeviceThreadBase&) = delete;
+   MMDeviceThreadBase& operator=(const MMDeviceThreadBase&) = delete;
+
+   // We also cannot safely support move because the thread calls svc() by
+   // reference.
+   MMDeviceThreadBase(MMDeviceThreadBase&&) = delete;
+   MMDeviceThreadBase& operator=(MMDeviceThreadBase&&) = delete;
+
+   /**
+    * @brief This function is called on the new thread.
+    *
+    * The return value is ignored.
+    */
+   virtual int svc() = 0;
+   // Note: On Windows the return value theoretically can be retrieved using
+   // GetExitCodeThread(), but only if you have the thread handle or ID, which
+   // we don't expose (hence "ignored").
+
+   void activate()
+   {
+      // We do not disallow reusing the thread object.
+      if (joinable_)
+      {
+#ifdef _WIN32
+         CloseHandle(thread_);
+#else
+         pthread_detach(thread_);
+#endif
+      }
+
+      bool ok{};
 #ifdef _WIN32
       DWORD id;
       thread_ = CreateThread(NULL, 0, ThreadProc, this, 0, &id);
+      ok = thread_ != NULL;
 #else
-      pthread_create(&thread_, NULL, ThreadProc, this);
+      ok = pthread_create(&thread_, NULL, ThreadProc, this) == 0;
 #endif
-      return 0; // TODO: return thread id
+      joinable_ = ok;
+      // TODO We have no way to report creation error. Probably should terminate.
    }
 
    void wait()
    {
+      assert(joinable_);
+      if (!joinable_)
+         std::terminate();
+
 #ifdef _WIN32
       WaitForSingleObject(thread_, INFINITE);
+      CloseHandle(thread_);
 #else
       pthread_join(thread_, NULL);
 #endif
+      joinable_ = false;
    }
 
 private:
-   // Forbid copying
-   MMDeviceThreadBase(const MMDeviceThreadBase&);
-   MMDeviceThreadBase& operator=(const MMDeviceThreadBase&);
-
 #ifdef _WIN32
    HANDLE
 #else
    pthread_t
 #endif
-   thread_;
+   thread_{};
+
+   // pthread_t has no "empty" value, so we must keep a separate flag.
+   bool joinable_ = false;
+
 
    static
 #ifdef _WIN32


### PR DESCRIPTION
Closes #971.

Retire the Win32 and pthreads types/calls and replace with `std::thread` and `std::recursive_mutex`.

No longer leak a thread handle (Windows) or joinable thread (POSIX).

Patch device adapters that broke because MMDevice no longer includes Windows.h or defines `WIN32_LEAN_AND_MEAN`.

No device ABI changes. Source-incompatible changes (no in-tree adapters affected):
- `DeviceThreadBase::activate()` is no longer `virtual` and now returns `void` rather than `int` (no adapter overrides this function or reads its return value)
- `MMThreadGuard::isLocked()` has been deleted (no adapter calls it)

TODO:
- [x] Patch device adapters (if any) that break because pthread.h is no longer included by MMDevice