### PR TITLE
Fix/aravis

### DIFF
--- a/DeviceAdapters/Aravis/AravisCamera.cpp
+++ b/DeviceAdapters/Aravis/AravisCamera.cpp
@@ -59,7 +59,7 @@ MODULE_API void InitializeModuleData()
   uint64_t nDevices=0;
 
   // Debugging.
-  //arv_debug_enable("all:1,device");
+  // arv_debug_enable("all:1,device");
 
   // Update and get number of aravis compatible cameras.
   arv_update_device_list();
@@ -191,7 +191,6 @@ void AravisCamera::AcquisitionCallback(ArvStreamCallbackType type, ArvBuffer *cb
   }
 }
 
-
 void AravisCamera::ArvBufferUpdate(ArvBuffer *aBuffer)
 {
   int status;
@@ -201,8 +200,49 @@ void AravisCamera::ArvBufferUpdate(ArvBuffer *aBuffer)
   
   status = arv_buffer_get_status(aBuffer);
   if (status != 0){
-    printf("Error, Aravis buffer status is %d\n", status);
-    return;
+    std::stringstream msg;
+    switch (status) {
+    case ARV_BUFFER_STATUS_UNKNOWN:
+      msg << "Aravis Error, Aravis buffer status is 'UNKNOWN'";
+      LogMessage(msg.str(), false);
+      return;
+    case ARV_BUFFER_STATUS_CLEARED:
+      msg << "Aravis Error, Aravis buffer status is 'CLEARED'";
+      LogMessage(msg.str(), false);
+      return;
+    case ARV_BUFFER_STATUS_TIMEOUT:
+      msg << "Aravis Error, Aravis buffer status is 'TIMEOUT'";
+      LogMessage(msg.str(), false);
+      return;
+    case ARV_BUFFER_STATUS_MISSING_PACKETS:
+      msg << "Aravis Error, Aravis buffer status is 'MISSING PACKETS'";
+      LogMessage(msg.str(), false);
+      return;
+    case ARV_BUFFER_STATUS_WRONG_PACKET_ID:
+      msg << "Aravis Error, Aravis buffer status is 'WRONG_PACKET_ID'";
+      LogMessage(msg.str(), false);
+      return;
+    case ARV_BUFFER_STATUS_SIZE_MISMATCH:
+      msg << "Aravis Error, Aravis buffer status is 'SIZE_MISMATCH'";
+      LogMessage(msg.str(), false);
+      return;
+    case ARV_BUFFER_STATUS_FILLING:
+      msg << "Aravis Error, Aravis buffer status is 'FILLING'";
+      LogMessage(msg.str(), false);
+      return;
+    case ARV_BUFFER_STATUS_ABORTED:
+      msg << "Aravis Error, Aravis buffer status is 'ABORTED'";
+      LogMessage(msg.str(), false);
+      return;
+    case ARV_BUFFER_STATUS_PAYLOAD_NOT_SUPPORTED:
+      msg << "Aravis Error, Aravis buffer status is 'PAYLOAD_NOT_SUPPORTED'";
+      LogMessage(msg.str(), false);
+      return;
+    default:
+      msg << "Aravis Error, Aravis buffer status is 'UNKNOWN_STATUS'";
+      LogMessage(msg.str(), false);
+      return;
+    }
   }
 
   // Pixel format updates.
@@ -530,9 +570,12 @@ int AravisCamera::Initialize()
   ArvCheckError(gerror);
   ArvPixelFormatUpdate(arvPixelFormat);
 
-  // Turn off auto exposure.
-  arv_camera_set_exposure_time_auto(arv_cam, ARV_AUTO_OFF, &gerror);
-  ArvCheckError(gerror);
+  // Turn off auto exposure (if available).
+  if(arv_camera_is_exposure_auto_available(arv_cam, &gerror)){
+    ArvCheckError(gerror);
+    arv_camera_set_exposure_time_auto(arv_cam, ARV_AUTO_OFF, &gerror);
+    ArvCheckError(gerror);  
+  }
 
   // Get current exposure time.
   ArvGetExposure();

--- a/DeviceAdapters/Aravis/AravisCamera.h
+++ b/DeviceAdapters/Aravis/AravisCamera.h
@@ -1,9 +1,9 @@
 /*
   Copyright 2024 Hazen Babcock
-  
+
   Redistribution and use in source and binary forms, with or without modification, 
   are permitted provided that the following conditions are met:
-  
+
   1. Redistributions of source code must retain the above copyright notice, this 
      list of conditions and the following disclaimer.
 
@@ -53,10 +53,11 @@ public:
   ~AravisCamera();
 
   // MMDevice API.
-  void GetName(char* name) const;  
+  bool Busy() { return false; }
+  void GetName(char* name) const;
   int Initialize();
   int Shutdown();
-  
+
   // MMCamera API.
   int ClearROI();
   int GetBinning() const;
@@ -69,7 +70,7 @@ public:
   unsigned GetImageHeight() const;
   unsigned GetNumberOfComponents() const;
   int GetROI(unsigned& x, unsigned& y, unsigned& xSize, unsigned& ySize);
-  int IsExposureSequenceable(bool& isSequenceable) const;  
+  int IsExposureSequenceable(bool& isSequenceable) const;
   int SetBinning(int binSize);
   void SetExposure(double exp);
   int SetROI(unsigned x, unsigned y, unsigned xSize, unsigned ySize);
@@ -102,7 +103,7 @@ public:
   void ArvPixelFormatUpdate(guint32 arvPixelFormat);
   int ArvStartSequenceAcquisition();
 
-  
+
 private:
   bool capturing;
   long counter;

--- a/DeviceAdapters/Aravis/README.md
+++ b/DeviceAdapters/Aravis/README.md
@@ -1,6 +1,6 @@
 ## About
 
-These device adapters add support for the [Aravis Project](https://github.com/AravisProject). The adapters have been developed and tested on 64-bit Linux with Aravis-0.10.
+These device adapters add support for the [Aravis Project](https://github.com/AravisProject). The adapters have been developed and tested on 64-bit Linux with Aravis-0.8.
 
 ### Note
 

--- a/m4/mm_libs.m4
+++ b/m4/mm_libs.m4
@@ -74,7 +74,7 @@ AC_DEFUN([MM_LIB_HIDAPI], [
 # ARAVIS_LIBS.
 #
 AC_DEFUN([MM_LIB_ARAVIS], [
-   MM_LIB_WITH_PKG_CONFIG([ARAVIS], [Aravis], [aravis-0.10], [],
+   MM_LIB_WITH_PKG_CONFIG([ARAVIS], [Aravis], [aravis-0.8], [],
       [$1], [-laravis],
       [arv.h], [arv_update_device_list],
       [$2], [$3])


### PR DESCRIPTION
This PR fixes the Aravis driver so that it will compile with the current version of micro-manager.

I also changed the supported Aravis version to 0.8 as this is the stable version and is hopefully easier to install. It is for example available in most linux package managers. 