### PR TITLE
ILE: Restore per-laser Power Enable property

### DIFF
--- a/DeviceAdapters/IntegratedLaserEngine/IntegratedLaserEngine.vcxproj
+++ b/DeviceAdapters/IntegratedLaserEngine/IntegratedLaserEngine.vcxproj
@@ -66,7 +66,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)/boost-versions/boost_1_77_0;$(MM_3RDPARTYPRIVATE)/Andor/ALC/SDK2.5/Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;SHOW_LASER_ENABLE_PROPERTY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>
@@ -85,7 +85,7 @@
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)/boost-versions/boost_1_77_0;$(MM_3RDPARTYPRIVATE)/Andor/ALC/SDK2.5/Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;SHOW_LASER_ENABLE_PROPERTY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>
       </PrecompiledHeader>


### PR DESCRIPTION
Re-enables the per-laser-line `<wavelength>-Power Enable` property for the Andor ILE, which was compiled out in e0e33fc9d by gating its creation behind the never-defined `SHOW_LASER_ENABLE_PROPERTY` macro.

This defines that macro in both Debug and Release configs of `IntegratedLaserEngine.vcxproj`. All supporting code (`OnEnable`, `LasersState_.Enable_`, `g_LaserEnable*` constants) was left intact by the original commit, so no other changes are needed. Verified the property is exposed in a local Release x64 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)